### PR TITLE
feat: OIDC admin-approval flow

### DIFF
--- a/cmd/embookshelf/main.go
+++ b/cmd/embookshelf/main.go
@@ -110,7 +110,7 @@ func main() {
 	libSvc := service.NewLibraryService(libRepo)
 	shelfSvc := service.NewShelfService(shelfRepo)
 	searchSvc := service.NewSearchService(libRepo, shelfRepo)
-	authSvc := service.NewAuthService(userRepo, sessionRepo)
+	authSvc := service.NewAuthService(userRepo, sessionRepo, hub)
 	bdropSvc := service.NewBookDropService(bdropRepo, libRepo, appSettingsRepo, covers, hub)
 	progressSvc := service.NewProgressService(progressRepo, readingSessionRepo)
 	annotationSvc := service.NewAnnotationService(annotationRepo)

--- a/docs/superpowers/plans/2026-04-27-oidc-admin-approval.md
+++ b/docs/superpowers/plans/2026-04-27-oidc-admin-approval.md
@@ -1,0 +1,1545 @@
+# OIDC Admin Approval Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `RequireAdminApproval` flag to OIDC auto-provisioning that holds new users in a `pending` status until an admin approves them via the existing Users & roles settings panel.
+
+**Architecture:** Adds a `status` enum column to `users` (`active | pending | denied`). Extends `OIDCAutoProvisionDetails` with `RequireAdminApproval`. The OIDC `Exchange` returns a new sentinel `ErrOIDCPendingApproval` that the callback handler turns into a redirect to a new `/login/pending` page. Two new admin endpoints (`/users/:id/approve`, `/users/:id/deny`) flip the status. The Users & roles panel renders a status pill, approve/deny buttons, and a numeric badge fed by an SSE invalidation event. Existing rows backfill to `active`, so upgrades are zero-impact.
+
+**Tech Stack:** Go 1.25 (Gin, pgx, golang-migrate), React 19 (TanStack Router/Query, shadcn/ui), Vitest, Playwright.
+
+**Spec:** [docs/superpowers/specs/2026-04-27-oidc-admin-approval-design.md](../specs/2026-04-27-oidc-admin-approval-design.md)
+
+---
+
+## File Structure
+
+**Backend (Go):**
+- Create: `internal/migrator/migrations/000023_user_approval_status.up.sql`
+- Create: `internal/migrator/migrations/000023_user_approval_status.down.sql`
+- Modify: `internal/model/user.go` — add `UserStatus` type and fields on `User`.
+- Modify: `internal/repo/user.go` — extend column list, add `CreateOIDCPending`, `UpdateStatus`, status filter helpers; update `scanUser`.
+- Modify: `internal/repo/app_settings.go` — add `RequireAdminApproval` field + default + validation.
+- Modify: `internal/service/oidc.go` — new sentinel `ErrOIDCPendingApproval`; status-aware branch logic in `findOrProvisionUser`; pending users skip session creation in `Exchange`.
+- Modify: `internal/service/auth.go` — add `ApproveUser` and `DenyUser` with last-admin / self-target guards. Inject `*sse.Hub` so they can broadcast.
+- Create: `internal/service/auth_test.go` — in-memory fake `userStatusRepo` covering approve/deny guards.
+- Modify: `cmd/embookshelf/main.go` — pass `hub` to `NewAuthService`.
+- Modify: `internal/handler/auth.go` — extend `userDTO` with `status` and `statusChangedAt`; map in `toUserDTO`.
+- Modify: `internal/handler/oidc.go` — redirect to `/login/pending` on `ErrOIDCPendingApproval`; extend `oidcErrorCode` mapping.
+- Create: `internal/handler/oidc_test.go` — pure-function test for `oidcErrorCode`.
+- Modify: `internal/handler/users.go` — add `SettingsUsersApprove` and `SettingsUsersDeny` handlers.
+- Modify: `internal/handler/router.go` — wire the two new admin routes.
+
+**Frontend (TS/React):**
+- Create: `ui/src/routes/login.pending.tsx` — static "pending approval" page.
+- Modify: `ui/src/api/auth.ts` — extend `AuthUser` with `status` and `statusChangedAt`.
+- Modify: `ui/src/api/oidc.ts` — extend `OidcAutoProvision` with `requireAdminApproval`.
+- Modify: `ui/src/api/settings.ts` — add `approveSettingsUser`, `denySettingsUser`.
+- Modify: `ui/src/api/realtime.ts` — wire `users.updated` event to invalidate the users query.
+- Modify: `ui/src/routes/_app.settings.tsx` — third checkbox in OIDC auto-provisioning panel; pending/denied pills, Approve/Deny buttons, sort, and pending-count badge in the Users panel.
+- Create: `ui/src/components/__tests__/UserStatusBadge.test.tsx` — Vitest for the new pill component (if extracted) or for the Users panel.
+
+**E2E:**
+- Create: `e2e/fixtures/sql/pending-user.sql` — inserts a deterministic pending user.
+- Create: `e2e/tests/admin-approval.spec.ts` — admin sees badge, approves, denies; user list reflects state.
+
+---
+
+## Task 1: Migration — `users.status` and `users.status_changed_at`
+
+**Files:**
+- Create: `internal/migrator/migrations/000023_user_approval_status.up.sql`
+- Create: `internal/migrator/migrations/000023_user_approval_status.down.sql`
+
+- [ ] **Step 1: Write the up migration**
+
+`internal/migrator/migrations/000023_user_approval_status.up.sql`:
+```sql
+ALTER TABLE users
+    ADD COLUMN status TEXT NOT NULL DEFAULT 'active'
+    CHECK (status IN ('active', 'pending', 'denied'));
+
+ALTER TABLE users
+    ADD COLUMN status_changed_at TIMESTAMPTZ;
+
+CREATE INDEX users_status_idx ON users (status) WHERE status <> 'active';
+```
+
+- [ ] **Step 2: Write the down migration**
+
+`internal/migrator/migrations/000023_user_approval_status.down.sql`:
+```sql
+DROP INDEX IF EXISTS users_status_idx;
+ALTER TABLE users DROP COLUMN IF EXISTS status_changed_at;
+ALTER TABLE users DROP COLUMN IF EXISTS status;
+```
+
+- [ ] **Step 3: Apply and verify round-trip**
+
+Run:
+```
+make migrate
+make migrate-version
+make migrate-down
+make migrate
+```
+
+Expected output: `make migrate-version` prints `23` after the up; `make migrate-down` rolls back to `22`; the second `make migrate` reapplies cleanly.
+
+- [ ] **Step 4: Sanity-check column with psql**
+
+Run:
+```
+docker exec -i $(docker compose -f compose.dev.yml ps -q postgres-embookshelf) psql -U embookshelf -d embookshelf -c "\d users"
+```
+
+Expected: `status` column with default `'active'`, NOT NULL; `status_changed_at` column TIMESTAMPTZ nullable; `users_status_idx` partial index listed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/migrator/migrations/000023_user_approval_status.up.sql internal/migrator/migrations/000023_user_approval_status.down.sql
+git commit -m "feat(db): add users.status for OIDC admin approval"
+```
+
+---
+
+## Task 2: Model — `UserStatus` enum + struct fields
+
+**Files:**
+- Modify: `internal/model/user.go`
+
+- [ ] **Step 1: Add UserStatus type and constants**
+
+Open `internal/model/user.go`. Above the `User` struct (after the `Role` block ending at line 10), insert:
+
+```go
+type UserStatus string
+
+const (
+	UserStatusActive  UserStatus = "active"
+	UserStatusPending UserStatus = "pending"
+	UserStatusDenied  UserStatus = "denied"
+)
+```
+
+- [ ] **Step 2: Extend the User struct**
+
+In the `User` struct (lines 12–24), add two fields just before `CreatedAt`:
+
+```go
+	Status          UserStatus
+	StatusChangedAt *time.Time
+```
+
+- [ ] **Step 3: Build to confirm compilation**
+
+Run: `go build ./...`
+Expected: build fails inside `internal/repo/user.go` because `scanUser` no longer matches the struct shape — that failure is fixed in Task 3.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/model/user.go
+git commit -m "feat(model): add UserStatus enum and User.Status fields"
+```
+
+---
+
+## Task 3: Repo — extend `users` queries for status
+
+**Files:**
+- Modify: `internal/repo/user.go`
+
+- [ ] **Step 1: Extend the column list and scanner**
+
+In `internal/repo/user.go`, update line 23:
+
+```go
+const userCols = `id, email, password_hash, name, role, oidc_subject, oidc_issuer, avatar_url, status, status_changed_at, created_at, updated_at, last_seen_at`
+```
+
+Update `scanUser` (lines 184–198) to read the two new columns. Replace the function body with:
+
+```go
+func scanUser(s scanner) (model.User, error) {
+	var (
+		u      model.User
+		role   string
+		status string
+	)
+	err := s.Scan(
+		&u.ID, &u.Email, &u.PasswordHash, &u.Name, &role,
+		&u.OIDCSubject, &u.OIDCIssuer, &u.AvatarURL,
+		&status, &u.StatusChangedAt,
+		&u.CreatedAt, &u.UpdatedAt, &u.LastSeenAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return u, ErrNotFound
+		}
+		return u, err
+	}
+	u.Role = model.Role(role)
+	u.Status = model.UserStatus(status)
+	return u, nil
+}
+```
+
+- [ ] **Step 2: Add `CreateOIDCPending`**
+
+Append below the existing `CreateOIDC` (after line 158):
+
+```go
+// CreateOIDCPending mirrors CreateOIDC but inserts the user with
+// status='pending' so they cannot log in until an admin approves them.
+func (r *UserRepo) CreateOIDCPending(ctx context.Context, email, name string, role model.Role, issuer, subject string) (model.User, error) {
+	row := r.pool.QueryRow(ctx, `
+		INSERT INTO users (email, name, password_hash, role, oidc_issuer, oidc_subject, status, status_changed_at)
+		VALUES (lower($1), $2, '', $3, $4, $5, 'pending', now())
+		RETURNING `+userCols+`
+	`, strings.TrimSpace(email), strings.TrimSpace(name), string(role), issuer, subject)
+	return scanUser(row)
+}
+```
+
+- [ ] **Step 3: Add `UpdateStatus`**
+
+Append below `CreateOIDCPending`:
+
+```go
+// UpdateStatus flips the approval status. The caller (service) enforces
+// guards (last admin, self-target) before calling this.
+func (r *UserRepo) UpdateStatus(ctx context.Context, id string, status model.UserStatus) error {
+	tag, err := r.pool.Exec(ctx, `
+		UPDATE users
+		SET status = $2, status_changed_at = now(), updated_at = now()
+		WHERE id = $1
+	`, id, string(status))
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Build**
+
+Run: `go build ./...`
+Expected: PASS. (Other modules now compile; service layer still uses old `CreateOIDC` everywhere — that's fine.)
+
+- [ ] **Step 5: Run unit tests touching repo signatures**
+
+Run: `go test ./...`
+Expected: PASS for the existing pure-logic packages; the project has no Go tests that hit the DB so nothing breaks.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/repo/user.go
+git commit -m "feat(repo): scan user status; add CreateOIDCPending and UpdateStatus"
+```
+
+---
+
+## Task 4: Settings — add `RequireAdminApproval`
+
+**Files:**
+- Modify: `internal/repo/app_settings.go`
+
+- [ ] **Step 1: Extend the struct + default**
+
+In `internal/repo/app_settings.go`, replace the `OIDCAutoProvisionDetails` struct (lines 89–93) with:
+
+```go
+type OIDCAutoProvisionDetails struct {
+	EnableAutoProvisioning   bool   `json:"enableAutoProvisioning"`
+	AllowLocalAccountLinking bool   `json:"allowLocalAccountLinking"`
+	DefaultRole              string `json:"defaultRole"` // "admin" | "user"
+	RequireAdminApproval     bool   `json:"requireAdminApproval"`
+}
+```
+
+Update `DefaultOIDCAutoProvisionDetails` (lines 111–116) to include the new field:
+
+```go
+func DefaultOIDCAutoProvisionDetails() OIDCAutoProvisionDetails {
+	return OIDCAutoProvisionDetails{
+		EnableAutoProvisioning:   false,
+		AllowLocalAccountLinking: true,
+		DefaultRole:              "user",
+		RequireAdminApproval:     false,
+	}
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `go build ./...`
+Expected: PASS — no other code references the new field yet.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/repo/app_settings.go
+git commit -m "feat(settings): add RequireAdminApproval to OIDCAutoProvisionDetails"
+```
+
+---
+
+## Task 5: Service — `ErrOIDCPendingApproval` + status-aware OIDC flow
+
+**Files:**
+- Modify: `internal/service/oidc.go`
+
+- [ ] **Step 1: Add the new sentinel error**
+
+In `internal/service/oidc.go` (line 26 var block), append `ErrOIDCPendingApproval`:
+
+```go
+var (
+	ErrOIDCNotConfigured    = errors.New("OIDC is not configured")
+	ErrOIDCDisabled         = errors.New("OIDC is disabled")
+	ErrOIDCStateMismatch    = errors.New("OIDC state mismatch")
+	ErrOIDCLoginNotAllowed  = errors.New("this OIDC identity is not allowed to log in")
+	ErrOIDCForceOnlyBlocked = errors.New("OIDC-only mode cannot be enabled without at least one configured provider")
+	ErrOIDCUnknownProvider  = errors.New("unknown OIDC provider")
+	ErrOIDCPendingApproval  = errors.New("this OIDC account is awaiting administrator approval")
+)
+```
+
+- [ ] **Step 2: Add status checks to path 1 (existing OIDC link)**
+
+In `findOrProvisionUser` (lines 605–655), replace the `// 1) Match by OIDC identity.` block (lines 606–613) with:
+
+```go
+	// 1) Match by OIDC identity. Existing users still need to clear
+	//    the status gate — pending users have not been approved yet,
+	//    denied users have been explicitly refused.
+	u, err := s.users.GetByOIDC(ctx, issuer, claims.Subject)
+	if err != nil && !errors.Is(err, repo.ErrNotFound) {
+		return model.User{}, err
+	}
+	if err == nil {
+		switch u.Status {
+		case model.UserStatusActive:
+			return u, nil
+		case model.UserStatusPending:
+			return u, ErrOIDCPendingApproval
+		case model.UserStatusDenied:
+			return model.User{}, ErrOIDCLoginNotAllowed
+		default:
+			return u, nil
+		}
+	}
+```
+
+- [ ] **Step 3: Branch path 3 on `RequireAdminApproval`**
+
+In the same function, replace the `// 3) Auto-provision.` block all the way through the final `return s.users.CreateOIDC(...)` (lines 633–654) with:
+
+```go
+	// 3) Auto-provision.
+	if !provision.EnableAutoProvisioning {
+		n, err := s.users.Count(ctx)
+		if err != nil {
+			return model.User{}, err
+		}
+		if n > 0 {
+			return model.User{}, ErrOIDCLoginNotAllowed
+		}
+	}
+
+	role := model.RoleUser
+	if provision.DefaultRole == "admin" {
+		role = model.RoleAdmin
+	}
+	// First-user-becomes-admin shortcut bypasses approval — otherwise
+	// an admin-less instance with approval-required is unrecoverable.
+	firstUser := false
+	if n, err := s.users.Count(ctx); err == nil && n == 0 {
+		role = model.RoleAdmin
+		firstUser = true
+	}
+
+	if claims.Email == "" {
+		return model.User{}, errors.New("OIDC provider did not return an email claim and email is required")
+	}
+
+	if provision.RequireAdminApproval && !firstUser {
+		created, err := s.users.CreateOIDCPending(ctx, claims.Email, claims.Name, role, issuer, claims.Subject)
+		if err != nil {
+			return model.User{}, err
+		}
+		return created, ErrOIDCPendingApproval
+	}
+	return s.users.CreateOIDC(ctx, claims.Email, claims.Name, role, issuer, claims.Subject)
+```
+
+- [ ] **Step 4: Skip session creation for pending users in `Exchange`**
+
+In `Exchange` (lines 228–302), wrap the post-`findOrProvisionUser` block (lines 290–301) so the pending-approval error short-circuits:
+
+```go
+	u, err := s.findOrProvisionUser(ctx, issuer, claims, provision)
+	if err != nil {
+		if errors.Is(err, ErrOIDCPendingApproval) {
+			// Return the user so callers (handlers, tests) can see who is
+			// pending, but no session is issued.
+			return model.Session{}, u, ErrOIDCPendingApproval
+		}
+		return model.Session{}, model.User{}, err
+	}
+	_ = s.users.SyncOIDCProfile(ctx, u.ID, claims.Name, claims.Picture)
+
+	sess, err := s.sessions.Create(ctx, u.ID, userAgent, SessionTTL)
+	if err != nil {
+		return model.Session{}, model.User{}, err
+	}
+	_ = s.users.TouchLastSeen(ctx, u.ID, time.Now())
+	return sess, u, nil
+```
+
+- [ ] **Step 5: Build**
+
+Run: `go build ./...`
+Expected: PASS.
+
+- [ ] **Step 6: Run existing tests**
+
+Run: `go test ./...`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/service/oidc.go
+git commit -m "feat(oidc): pending-approval flow in findOrProvisionUser and Exchange"
+```
+
+---
+
+## Task 6: Service — `ApproveUser` / `DenyUser` with TDD via fake repo
+
+**Files:**
+- Modify: `internal/service/auth.go`
+- Create: `internal/service/auth_test.go`
+- Modify: `cmd/embookshelf/main.go`
+
+- [ ] **Step 1: Introduce a tiny status-repo seam in `auth.go`**
+
+In `internal/service/auth.go`, just above the existing `AuthService` struct (line 26), add an interface that captures only the methods the new approve/deny logic needs. This keeps the existing struct mostly intact and lets the test substitute a fake.
+
+```go
+// userStatusRepo is the slice of UserRepo that ApproveUser and DenyUser
+// touch. Defining it as a tiny interface lets the service test substitute
+// an in-memory fake without spinning up a database — the rest of
+// AuthService keeps using the concrete *repo.UserRepo via embedding.
+type userStatusRepo interface {
+	GetByID(ctx context.Context, id string) (model.User, error)
+	UpdateStatus(ctx context.Context, id string, status model.UserStatus) error
+	CountByRole(ctx context.Context, role model.Role) (int, error)
+}
+```
+
+- [ ] **Step 2: Add hub field + extended constructor**
+
+Replace the `AuthService` struct + `NewAuthService` (lines 26–33) with:
+
+```go
+type AuthService struct {
+	users    *repo.UserRepo
+	sessions *repo.SessionRepo
+	hub      *sse.Hub
+}
+
+func NewAuthService(users *repo.UserRepo, sessions *repo.SessionRepo, hub *sse.Hub) *AuthService {
+	return &AuthService{users: users, sessions: sessions, hub: hub}
+}
+```
+
+Add the import at the top of the file:
+
+```go
+	"github.com/blackforge/embookshelf/internal/sse"
+```
+
+- [ ] **Step 3: Add `ErrCannotTargetSelf` sentinel**
+
+In the `var (...)` block at the top of `auth.go` (line 20), append:
+
+```go
+	ErrCannotTargetSelf = errors.New("cannot change your own approval status")
+```
+
+- [ ] **Step 4: Write the failing test for ApproveUser/DenyUser guards**
+
+`internal/service/auth_test.go`:
+
+```go
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/blackforge/embookshelf/internal/model"
+	"github.com/blackforge/embookshelf/internal/repo"
+)
+
+// fakeUserStatusRepo is the in-memory test seam. It implements only the
+// methods userStatusRepo names; nothing else from UserRepo is needed.
+type fakeUserStatusRepo struct {
+	users map[string]model.User
+}
+
+func (f *fakeUserStatusRepo) GetByID(_ context.Context, id string) (model.User, error) {
+	u, ok := f.users[id]
+	if !ok {
+		return model.User{}, repo.ErrNotFound
+	}
+	return u, nil
+}
+
+func (f *fakeUserStatusRepo) UpdateStatus(_ context.Context, id string, status model.UserStatus) error {
+	u, ok := f.users[id]
+	if !ok {
+		return repo.ErrNotFound
+	}
+	now := time.Now()
+	u.Status = status
+	u.StatusChangedAt = &now
+	f.users[id] = u
+	return nil
+}
+
+func (f *fakeUserStatusRepo) CountByRole(_ context.Context, role model.Role) (int, error) {
+	n := 0
+	for _, u := range f.users {
+		if u.Role == role && u.Status == model.UserStatusActive {
+			n++
+		}
+	}
+	return n, nil
+}
+
+func newApproveTestSetup() (*fakeUserStatusRepo, model.User, model.User) {
+	admin := model.User{ID: "admin-1", Email: "a@x", Role: model.RoleAdmin, Status: model.UserStatusActive}
+	pending := model.User{ID: "u-2", Email: "p@x", Role: model.RoleUser, Status: model.UserStatusPending}
+	return &fakeUserStatusRepo{users: map[string]model.User{
+		admin.ID:   admin,
+		pending.ID: pending,
+	}}, admin, pending
+}
+
+func TestApproveUserFlipsPendingToActive(t *testing.T) {
+	repo, admin, pending := newApproveTestSetup()
+
+	if err := approveUser(context.Background(), repo, admin.ID, pending.ID); err != nil {
+		t.Fatalf("approveUser: %v", err)
+	}
+	got := repo.users[pending.ID]
+	if got.Status != model.UserStatusActive {
+		t.Fatalf("status = %q, want active", got.Status)
+	}
+	if got.StatusChangedAt == nil {
+		t.Fatalf("status_changed_at not set")
+	}
+}
+
+func TestApproveUserIsIdempotentOnActive(t *testing.T) {
+	repo, admin, pending := newApproveTestSetup()
+	pending.Status = model.UserStatusActive
+	repo.users[pending.ID] = pending
+
+	if err := approveUser(context.Background(), repo, admin.ID, pending.ID); err != nil {
+		t.Fatalf("approveUser idempotent: %v", err)
+	}
+}
+
+func TestDenyUserFlipsPendingToDenied(t *testing.T) {
+	repo, admin, pending := newApproveTestSetup()
+	if err := denyUser(context.Background(), repo, admin.ID, pending.ID); err != nil {
+		t.Fatalf("denyUser: %v", err)
+	}
+	if repo.users[pending.ID].Status != model.UserStatusDenied {
+		t.Fatalf("status = %q, want denied", repo.users[pending.ID].Status)
+	}
+}
+
+func TestDenyUserRefusesSelf(t *testing.T) {
+	repo, admin, _ := newApproveTestSetup()
+	err := denyUser(context.Background(), repo, admin.ID, admin.ID)
+	if !errors.Is(err, ErrCannotTargetSelf) {
+		t.Fatalf("err = %v, want ErrCannotTargetSelf", err)
+	}
+}
+
+func TestDenyUserRefusesLastAdmin(t *testing.T) {
+	repo, admin, _ := newApproveTestSetup()
+	other := model.User{ID: "admin-2", Email: "b@x", Role: model.RoleAdmin, Status: model.UserStatusActive}
+	repo.users[other.ID] = other
+
+	// Deny the second admin — should fail because the caller themselves is
+	// also an admin and cannot leave the instance with no admins. Wait —
+	// our rule is "cannot deny last remaining admin": with two admins,
+	// denying one is allowed.
+	if err := denyUser(context.Background(), repo, admin.ID, other.ID); err != nil {
+		t.Fatalf("denying second admin should succeed: %v", err)
+	}
+	// Now only `admin` remains active. Try to deny them via an arbitrary
+	// other-admin path — the guard should block.
+	repo.users[admin.ID] = admin
+	if err := denyUser(context.Background(), repo, "ghost", admin.ID); !errors.Is(err, ErrLastAdmin) {
+		t.Fatalf("err = %v, want ErrLastAdmin", err)
+	}
+}
+```
+
+- [ ] **Step 5: Run test to confirm failure**
+
+Run: `go test ./internal/service/ -run TestApproveUser -v`
+Expected: FAIL — `approveUser` and `denyUser` are not yet defined.
+
+- [ ] **Step 6: Implement `approveUser`/`denyUser` (helpers) plus `ApproveUser`/`DenyUser` (methods)**
+
+In `internal/service/auth.go`, append below `DeleteUser`:
+
+```go
+// approveUser/denyUser are pure helpers operating against any repo that
+// satisfies userStatusRepo. They contain the guard logic and are unit
+// tested in auth_test.go without a database. The exported method wrappers
+// add SSE broadcast on success.
+
+func approveUser(ctx context.Context, r userStatusRepo, callerID, targetID string) error {
+	u, err := r.GetByID(ctx, targetID)
+	if err != nil {
+		return err
+	}
+	if u.Status == model.UserStatusActive {
+		return nil // idempotent
+	}
+	return r.UpdateStatus(ctx, targetID, model.UserStatusActive)
+}
+
+func denyUser(ctx context.Context, r userStatusRepo, callerID, targetID string) error {
+	if callerID == targetID {
+		return ErrCannotTargetSelf
+	}
+	u, err := r.GetByID(ctx, targetID)
+	if err != nil {
+		return err
+	}
+	if u.Status == model.UserStatusDenied {
+		return nil // idempotent
+	}
+	if u.Role == model.RoleAdmin && u.Status == model.UserStatusActive {
+		n, err := r.CountByRole(ctx, model.RoleAdmin)
+		if err != nil {
+			return err
+		}
+		if n <= 1 {
+			return ErrLastAdmin
+		}
+	}
+	return r.UpdateStatus(ctx, targetID, model.UserStatusDenied)
+}
+
+// ApproveUser flips a pending or denied user back to active. Idempotent
+// for already-active users. Broadcasts a settings.users.updated SSE event
+// so open admin tabs refresh.
+func (s *AuthService) ApproveUser(ctx context.Context, callerID, targetID string) (model.User, error) {
+	if err := approveUser(ctx, s.users, callerID, targetID); err != nil {
+		return model.User{}, err
+	}
+	u, err := s.users.GetByID(ctx, targetID)
+	if err != nil {
+		return model.User{}, err
+	}
+	s.broadcastUsersUpdate()
+	return u, nil
+}
+
+// DenyUser flips a pending user to denied. Idempotent. Refuses to deny
+// the caller's own row or the last remaining admin.
+func (s *AuthService) DenyUser(ctx context.Context, callerID, targetID string) (model.User, error) {
+	if err := denyUser(ctx, s.users, callerID, targetID); err != nil {
+		return model.User{}, err
+	}
+	u, err := s.users.GetByID(ctx, targetID)
+	if err != nil {
+		return model.User{}, err
+	}
+	s.broadcastUsersUpdate()
+	return u, nil
+}
+
+func (s *AuthService) broadcastUsersUpdate() {
+	if s.hub == nil {
+		return
+	}
+	s.hub.Broadcast(sse.Event{Name: "users.updated", Data: "{}"})
+}
+```
+
+- [ ] **Step 7: Run tests to confirm pass**
+
+Run: `go test ./internal/service/ -run TestApproveUser -v && go test ./internal/service/ -run TestDenyUser -v`
+Expected: PASS for all five test functions.
+
+- [ ] **Step 8: Wire the hub into main.go**
+
+In `cmd/embookshelf/main.go`, find the `service.NewAuthService` call (line 113):
+
+```go
+	authSvc := service.NewAuthService(userRepo, sessionRepo)
+```
+
+Replace with:
+
+```go
+	authSvc := service.NewAuthService(userRepo, sessionRepo, hub)
+```
+
+- [ ] **Step 9: Build the whole binary**
+
+Run: `make build`
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add internal/service/auth.go internal/service/auth_test.go cmd/embookshelf/main.go
+git commit -m "feat(auth): ApproveUser and DenyUser with last-admin and self guards"
+```
+
+---
+
+## Task 7: Handlers — DTO, callback redirect, approve/deny endpoints
+
+**Files:**
+- Modify: `internal/handler/auth.go`
+- Modify: `internal/handler/oidc.go`
+- Create: `internal/handler/oidc_test.go`
+- Modify: `internal/handler/users.go`
+- Modify: `internal/handler/router.go`
+
+- [ ] **Step 1: Extend `userDTO`**
+
+In `internal/handler/auth.go`, replace the `userDTO` struct (lines 17–26) with:
+
+```go
+type userDTO struct {
+	ID              string `json:"id"`
+	Email           string `json:"email"`
+	Name            string `json:"name"`
+	Role            string `json:"role"`
+	Status          string `json:"status"`
+	StatusChangedAt string `json:"statusChangedAt,omitempty"`
+	Display         string `json:"display"`
+	Initials        string `json:"initials"`
+	CreatedAt       string `json:"createdAt"`
+	LastSeenAt      string `json:"lastSeenAt,omitempty"`
+}
+```
+
+Update `toUserDTO` (lines 28–42) to map the new fields:
+
+```go
+func toUserDTO(u model.User) userDTO {
+	d := userDTO{
+		ID:        u.ID,
+		Email:     u.Email,
+		Name:      u.Name,
+		Role:      string(u.Role),
+		Status:    string(u.Status),
+		Display:   u.Display(),
+		Initials:  u.Initials(),
+		CreatedAt: u.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"),
+	}
+	if d.Status == "" {
+		// Defensive default — older rows or test fakes may leave Status zero.
+		d.Status = string(model.UserStatusActive)
+	}
+	if u.StatusChangedAt != nil {
+		d.StatusChangedAt = u.StatusChangedAt.UTC().Format("2006-01-02T15:04:05Z")
+	}
+	if u.LastSeenAt != nil {
+		d.LastSeenAt = u.LastSeenAt.UTC().Format("2006-01-02T15:04:05Z")
+	}
+	return d
+}
+```
+
+- [ ] **Step 2: Write failing test for `oidcErrorCode`**
+
+`internal/handler/oidc_test.go`:
+
+```go
+package handler
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/blackforge/embookshelf/internal/service"
+)
+
+func TestOIDCErrorCodeMaps(t *testing.T) {
+	cases := []struct {
+		err  error
+		want string
+	}{
+		{service.ErrOIDCStateMismatch, "stateMismatch"},
+		{service.ErrOIDCLoginNotAllowed, "userNotProvisioned"},
+		{service.ErrOIDCDisabled, "disabled"},
+		{service.ErrOIDCNotConfigured, "notConfigured"},
+		{service.ErrOIDCUnknownProvider, "notConfigured"},
+		{service.ErrOIDCPendingApproval, "pendingApproval"},
+		{errors.New("anything else"), "unknown"},
+	}
+	for _, tc := range cases {
+		if got := oidcErrorCode(tc.err); got != tc.want {
+			t.Errorf("oidcErrorCode(%v) = %q, want %q", tc.err, got, tc.want)
+		}
+	}
+}
+```
+
+- [ ] **Step 3: Run test to confirm it fails**
+
+Run: `go test ./internal/handler/ -run TestOIDCErrorCodeMaps -v`
+Expected: FAIL — `oidcErrorCode` does not yet emit `pendingApproval`.
+
+- [ ] **Step 4: Update `oidcErrorCode` and the callback redirect**
+
+In `internal/handler/oidc.go`, update `oidcErrorCode` (lines 112–127) to include the new sentinel:
+
+```go
+func oidcErrorCode(err error) string {
+	switch {
+	case errors.Is(err, service.ErrOIDCStateMismatch):
+		return "stateMismatch"
+	case errors.Is(err, service.ErrOIDCLoginNotAllowed):
+		return "userNotProvisioned"
+	case errors.Is(err, service.ErrOIDCDisabled):
+		return "disabled"
+	case errors.Is(err, service.ErrOIDCNotConfigured):
+		return "notConfigured"
+	case errors.Is(err, service.ErrOIDCUnknownProvider):
+		return "notConfigured"
+	case errors.Is(err, service.ErrOIDCPendingApproval):
+		return "pendingApproval"
+	default:
+		return "unknown"
+	}
+}
+```
+
+Update `OIDCCallback` (lines 54–81). Replace the `sess, _, err := h.oidc.Exchange(...)` block (lines 74–80) with:
+
+```go
+	sess, _, err := h.oidc.Exchange(c.Request.Context(), code, state, c.Request.UserAgent())
+	if err != nil {
+		if errors.Is(err, service.ErrOIDCPendingApproval) {
+			c.Redirect(http.StatusFound, "/login/pending")
+			return
+		}
+		c.Redirect(http.StatusFound, "/login?oidcError="+oidcErrorCode(err))
+		return
+	}
+	auth.SetSessionCookie(c, sess.ID, service.SessionTTL, h.Secure())
+	c.Redirect(http.StatusFound, "/")
+```
+
+- [ ] **Step 5: Run handler tests**
+
+Run: `go test ./internal/handler/ -run TestOIDCErrorCodeMaps -v`
+Expected: PASS.
+
+- [ ] **Step 6: Add approve/deny handlers**
+
+In `internal/handler/users.go`, append below `SettingsUsersDelete`:
+
+```go
+// callerID returns the authenticated user's ID, or "" when no session is
+// attached. The admin guard upstream guarantees a session exists, but
+// returning "" instead of panicking keeps this defensive.
+func callerID(c *gin.Context) string {
+	u, ok := auth.UserFromContext(c)
+	if !ok || u == nil {
+		return ""
+	}
+	return u.ID
+}
+
+// SettingsUsersApprove flips a pending or denied user to active.
+func (h *Handler) SettingsUsersApprove(c *gin.Context) {
+	u, err := h.auth.ApproveUser(c.Request.Context(), callerID(c), c.Param("id"))
+	switch {
+	case err == nil:
+		c.JSON(http.StatusOK, gin.H{"user": toUserDTO(u)})
+	case errors.Is(err, repo.ErrNotFound):
+		writeError(c, http.StatusNotFound, "user not found")
+	default:
+		writeServerError(c, "settings users approve", err)
+	}
+}
+
+// SettingsUsersDeny flips a pending user to denied. Refuses to deny the
+// caller themselves or the last remaining admin.
+func (h *Handler) SettingsUsersDeny(c *gin.Context) {
+	u, err := h.auth.DenyUser(c.Request.Context(), callerID(c), c.Param("id"))
+	switch {
+	case err == nil:
+		c.JSON(http.StatusOK, gin.H{"user": toUserDTO(u)})
+	case errors.Is(err, repo.ErrNotFound):
+		writeError(c, http.StatusNotFound, "user not found")
+	case errors.Is(err, service.ErrCannotTargetSelf):
+		writeError(c, http.StatusBadRequest, service.ErrCannotTargetSelf.Error())
+	case errors.Is(err, service.ErrLastAdmin):
+		writeError(c, http.StatusConflict, service.ErrLastAdmin.Error())
+	default:
+		writeServerError(c, "settings users deny", err)
+	}
+}
+```
+
+Add the import at the top of the file:
+
+```go
+	"github.com/blackforge/embookshelf/internal/auth"
+```
+
+- [ ] **Step 7: Wire the new routes**
+
+In `internal/handler/router.go`, find the existing user routes (lines 149–152) and insert two new lines below `admin.PATCH("/users/:id/role", h.SettingsUsersUpdateRole)`:
+
+```go
+				admin.POST("/users/:id/approve", h.SettingsUsersApprove)
+				admin.POST("/users/:id/deny", h.SettingsUsersDeny)
+```
+
+- [ ] **Step 8: Build and run all tests**
+
+Run: `go build ./... && go test ./...`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/handler/auth.go internal/handler/oidc.go internal/handler/oidc_test.go internal/handler/users.go internal/handler/router.go
+git commit -m "feat(handler): /login/pending redirect and approve/deny endpoints"
+```
+
+---
+
+## Task 8: Frontend API + types
+
+**Files:**
+- Modify: `ui/src/api/auth.ts`
+- Modify: `ui/src/api/oidc.ts`
+- Modify: `ui/src/api/settings.ts`
+- Modify: `ui/src/api/realtime.ts`
+
+- [ ] **Step 1: Extend `AuthUser` with status fields**
+
+In `ui/src/api/auth.ts`, replace the `AuthUser` type (lines 5–14) with:
+
+```ts
+export type UserStatus = "active" | "pending" | "denied"
+
+// Mirrors internal/handler/auth.go userDTO.
+export type AuthUser = {
+  id: string
+  email: string
+  name: string
+  role: "admin" | "user"
+  status: UserStatus
+  statusChangedAt?: string
+  display: string
+  initials: string
+  createdAt: string
+  lastSeenAt?: string
+}
+```
+
+- [ ] **Step 2: Extend `OidcAutoProvision`**
+
+In `ui/src/api/oidc.ts`, replace the `OidcAutoProvision` type (lines 30–34) with:
+
+```ts
+export type OidcAutoProvision = {
+  enableAutoProvisioning: boolean
+  allowLocalAccountLinking: boolean
+  defaultRole: "admin" | "user"
+  requireAdminApproval: boolean
+}
+```
+
+- [ ] **Step 3: Add approve/deny API helpers**
+
+In `ui/src/api/settings.ts`, append below `deleteSettingsUser` (after line 303):
+
+```ts
+export async function approveSettingsUser(id: string): Promise<AuthUser> {
+  const { user } = await api<{ user: AuthUser }>(
+    `/api/v1/settings/users/${id}/approve`,
+    { method: "POST" }
+  )
+  return user
+}
+
+export async function denySettingsUser(id: string): Promise<AuthUser> {
+  const { user } = await api<{ user: AuthUser }>(
+    `/api/v1/settings/users/${id}/deny`,
+    { method: "POST" }
+  )
+  return user
+}
+```
+
+- [ ] **Step 4: Wire the SSE event**
+
+In `ui/src/api/realtime.ts`, update line 9 to include the new event name:
+
+```ts
+type RealtimeEvent = "bookdrop.updated" | "bookdrop.cleared" | "users.updated"
+```
+
+Add the import at the top of the file:
+
+```ts
+import { settingsUsersQueryKey } from "./settings"
+```
+
+Extend the `handlers` map (lines 24–35) with:
+
+```ts
+      "users.updated": () => {
+        queryClient.invalidateQueries({ queryKey: settingsUsersQueryKey })
+      },
+```
+
+- [ ] **Step 5: Typecheck**
+
+Run: `make ui-typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ui/src/api/auth.ts ui/src/api/oidc.ts ui/src/api/settings.ts ui/src/api/realtime.ts
+git commit -m "feat(ui-api): user status types and approve/deny endpoints"
+```
+
+---
+
+## Task 9: `/login/pending` route
+
+**Files:**
+- Create: `ui/src/routes/login.pending.tsx`
+
+- [ ] **Step 1: Look at the existing login route for styling cues**
+
+Run: `head -80 ui/src/routes/login.tsx`
+Expected: short component using project tokens (`t-h2`, `Card`, etc.). Keep the new route visually consistent.
+
+- [ ] **Step 2: Create the route file**
+
+`ui/src/routes/login.pending.tsx`:
+
+```tsx
+import { createFileRoute, Link } from "@tanstack/react-router"
+
+import { Card } from "@/components/ui/Card"
+
+export const Route = createFileRoute("/login/pending")({
+  component: PendingApproval,
+})
+
+function PendingApproval() {
+  return (
+    <main
+      style={{
+        minHeight: "100vh",
+        display: "grid",
+        placeItems: "center",
+        padding: 24,
+      }}
+    >
+      <Card style={{ maxWidth: 460, width: "100%" }}>
+        <h1 className="t-h2" style={{ marginBottom: 12 }}>
+          Pending approval
+        </h1>
+        <p className="t-body" style={{ marginBottom: 12 }}>
+          Your account has been created and is awaiting approval from an
+          administrator. You will be able to sign in once it’s reviewed.
+        </p>
+        <p className="t-small" style={{ marginBottom: 18, fontStyle: "italic" }}>
+          You can close this tab — there’s nothing else to do here.
+        </p>
+        <Link to="/login" className="t-link">
+          Back to login
+        </Link>
+      </Card>
+    </main>
+  )
+}
+```
+
+(If `Card` lives elsewhere, mirror the import path used in `login.tsx`. Verify by inspecting `ui/src/routes/login.tsx`.)
+
+- [ ] **Step 3: Typecheck**
+
+Run: `make ui-typecheck`
+Expected: PASS.
+
+- [ ] **Step 4: Manual smoke**
+
+Run `make up` in one terminal. Visit `http://localhost:5173/login/pending`.
+Expected: card with the heading "Pending approval" renders; "Back to login" link returns to `/login`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/routes/login.pending.tsx
+git commit -m "feat(ui): /login/pending landing page for OIDC users awaiting approval"
+```
+
+---
+
+## Task 10: OIDC settings UI — `RequireAdminApproval` checkbox
+
+**Files:**
+- Modify: `ui/src/routes/_app.settings.tsx`
+
+- [ ] **Step 1: Locate the auto-provisioning panel**
+
+Open `ui/src/routes/_app.settings.tsx` around line 1495 (`<h3>Auto provisioning</h3>` block).
+
+- [ ] **Step 2: Insert the new switch row**
+
+Inside the `<Card>`'s flex column (right after the "Link by email" row that ends at line 1543, i.e. just before the `<Field label="Default role for new users">`), insert:
+
+```tsx
+          <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+            <div className="grow">
+              <div className="t-item-title">Require admin approval</div>
+              <div className="t-item-sub">
+                New SSO users are created in a pending state and cannot sign in
+                until an admin approves them in Users &amp; roles. Disabling
+                this later does not auto-promote already-pending users.
+              </div>
+            </div>
+            <Switch
+              checked={draft.autoProvision.requireAdminApproval}
+              disabled={!draft.autoProvision.enableAutoProvisioning}
+              onCheckedChange={(v) =>
+                setDraft({
+                  ...draft,
+                  autoProvision: {
+                    ...draft.autoProvision,
+                    requireAdminApproval: v,
+                  },
+                })
+              }
+            />
+          </div>
+```
+
+- [ ] **Step 3: Typecheck + lint**
+
+Run: `make ui-typecheck && make ui-lint`
+Expected: PASS.
+
+- [ ] **Step 4: Manual smoke**
+
+With `make up` running and signed in as admin, navigate to `/settings → OIDC / SSO`. Toggle "Auto-create users on first login" off; the new "Require admin approval" switch is disabled. Toggle it on; the new switch becomes enabled. Save and reload — the value persists.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/routes/_app.settings.tsx
+git commit -m "feat(ui): RequireAdminApproval toggle in OIDC auto-provisioning panel"
+```
+
+---
+
+## Task 11: Users panel — pending pill, approve/deny actions, badge, sort
+
+**Files:**
+- Modify: `ui/src/routes/_app.settings.tsx`
+
+- [ ] **Step 1: Import the new mutations + types**
+
+In `ui/src/routes/_app.settings.tsx`, find the existing import for `fetchSettingsUsers` (line 31) and extend it:
+
+```tsx
+import {
+  // existing imports...
+  approveSettingsUser,
+  denySettingsUser,
+  fetchSettingsUsers,
+  // ...
+  settingsUsersQueryKey,
+} from "@/api/settings"
+```
+
+(Insert `approveSettingsUser` and `denySettingsUser` next to `fetchSettingsUsers` in the existing import block.)
+
+- [ ] **Step 2: Sort and partition the users list**
+
+Inside `UsersPanel` (around line 1148), just after the `users` query is declared, add a memoised sorter:
+
+```tsx
+  const sortedUsers = useMemo(() => {
+    const all = users.data ?? []
+    const rank = (s: AuthUser["status"]) =>
+      s === "pending" ? 0 : s === "active" ? 1 : 2
+    return [...all].sort((a, b) => {
+      const r = rank(a.status) - rank(b.status)
+      if (r !== 0) return r
+      if (a.status === "pending") {
+        // Oldest pending first.
+        return (
+          new Date(a.statusChangedAt ?? a.createdAt).getTime() -
+          new Date(b.statusChangedAt ?? b.createdAt).getTime()
+        )
+      }
+      return a.email.localeCompare(b.email)
+    })
+  }, [users.data])
+
+  const pendingCount = (users.data ?? []).filter(
+    (u) => u.status === "pending"
+  ).length
+```
+
+(Verify `useMemo` is in the React import at the top of the file; add it if missing.)
+
+- [ ] **Step 3: Add approve/deny mutations**
+
+Below the existing `deleteMut` (around line 1197), add:
+
+```tsx
+  const approveMut = useMutation({
+    mutationFn: (id: string) => approveSettingsUser(id),
+    onSuccess: () => {
+      invalidate()
+      toast.success("User approved.")
+    },
+    onError: (e) => toast.error((e as unknown as ApiError).message),
+  })
+
+  const denyMut = useMutation({
+    mutationFn: (id: string) => denySettingsUser(id),
+    onSuccess: () => {
+      invalidate()
+      toast.success("User denied.")
+    },
+    onError: (e) => toast.error((e as unknown as ApiError).message),
+  })
+```
+
+- [ ] **Step 4: Render the status pill + action buttons inside the user row**
+
+Replace the iteration on `(users.data ?? []).map((u) => { ... })` (around line 1298) so it iterates over `sortedUsers` and renders the pill + new buttons. Inside each row, just before the existing `<Avatar>` block, add:
+
+```tsx
+              {u.status !== "active" && (
+                <span
+                  className="t-pill"
+                  data-status={u.status}
+                  style={{
+                    padding: "2px 8px",
+                    borderRadius: 999,
+                    background:
+                      u.status === "pending"
+                        ? "var(--color-amber-bg, #fff5cc)"
+                        : "var(--color-paper-2)",
+                    color:
+                      u.status === "pending"
+                        ? "var(--color-amber-ink, #8a5b00)"
+                        : "var(--color-ink-soft)",
+                    fontSize: 11,
+                    fontWeight: 500,
+                  }}
+                >
+                  {u.status === "pending" ? "Pending" : "Denied"}
+                </span>
+              )}
+```
+
+After the `<Select>` for role and before the existing delete button, render the two new buttons conditionally:
+
+```tsx
+              {u.status === "pending" && (
+                <>
+                  <Button
+                    type="button"
+                    size="sm"
+                    onClick={() => approveMut.mutate(u.id)}
+                    disabled={approveMut.isPending}
+                  >
+                    Approve
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => denyMut.mutate(u.id)}
+                    disabled={denyMut.isPending || isMe}
+                  >
+                    Deny
+                  </Button>
+                </>
+              )}
+              {u.status === "denied" && (
+                <Button
+                  type="button"
+                  size="sm"
+                  onClick={() => approveMut.mutate(u.id)}
+                  disabled={approveMut.isPending}
+                >
+                  Approve
+                </Button>
+              )}
+```
+
+For pending and denied users, hide the role `<Select>` and existing delete button by wrapping them with `{u.status === "active" && (...)}`. The simplest approach: check the existing JSX block lines 1327–1358 and wrap from `<Select>` through `</Button>` (delete) in `{u.status === "active" && (<>...</>)}`.
+
+- [ ] **Step 5: Add the pending count badge to the settings nav**
+
+Find the `tabs` array around line 96 — the entry `{ key: "users", label: "Users & roles", adminOnly: true }`. The nav rendering presumably loops over `tabs`. Locate the loop (search for `tabs.map`). In the rendered label cell, append a small numeric badge when the tab is `users` and the count is > 0.
+
+The cleanest way: read `pendingCount` at the top of the parent component (`SettingsRoute` around line 100) by using the existing `users.data` query, or by calling `useQuery({ queryKey: settingsUsersQueryKey, queryFn: fetchSettingsUsers, enabled: isAdmin })` once at the parent level. (The `UsersPanel` already issues this query so the cache is warm.)
+
+In the parent component, add:
+
+```tsx
+  const pendingUsers = useQuery({
+    queryKey: settingsUsersQueryKey,
+    queryFn: fetchSettingsUsers,
+    enabled: isAdmin,
+  })
+  const pendingCount = (pendingUsers.data ?? []).filter(
+    (u) => u.status === "pending"
+  ).length
+```
+
+In the tab-rendering loop, when `tab.key === "users"` and `pendingCount > 0`, render a span next to the label:
+
+```tsx
+{tab.key === "users" && pendingCount > 0 && (
+  <span
+    className="t-badge"
+    style={{
+      marginLeft: 8,
+      padding: "1px 6px",
+      borderRadius: 999,
+      background: "var(--color-amber-bg, #fff5cc)",
+      color: "var(--color-amber-ink, #8a5b00)",
+      fontSize: 10,
+      fontWeight: 600,
+    }}
+  >
+    {pendingCount}
+  </span>
+)}
+```
+
+- [ ] **Step 6: Typecheck + lint**
+
+Run: `make ui-typecheck && make ui-lint`
+Expected: PASS.
+
+- [ ] **Step 7: Manual smoke (admin half)**
+
+Backend running. Insert a fake pending user manually to verify the UI:
+```
+docker exec -i $(docker compose -f compose.dev.yml ps -q postgres-embookshelf) psql -U embookshelf -d embookshelf -c "INSERT INTO users (email, password_hash, name, role, oidc_issuer, oidc_subject, status, status_changed_at) VALUES ('pending@example.com', '', 'Pending Person', 'user', 'https://example.com', 'sub-1', 'pending', now());"
+```
+Visit `/settings → Users & roles` as admin. Expected: amber "1" badge on the Users tab; the row shows a "Pending" pill and Approve/Deny buttons. Approve → toast + the pill disappears + role/delete UI returns. Insert another pending user, then click Deny → pill flips to "Denied" + only Approve remains.
+
+Cleanup: `docker exec ... psql ... -c "DELETE FROM users WHERE email LIKE 'pending%@example.com';"`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add ui/src/routes/_app.settings.tsx
+git commit -m "feat(ui): pending/denied status pills, approve/deny actions, badge"
+```
+
+---
+
+## Task 12: E2E test — admin approves and denies pending users
+
+**Files:**
+- Create: `e2e/fixtures/sql/pending-user.sql`
+- Create: `e2e/tests/admin-approval.spec.ts`
+
+- [ ] **Step 1: Write the SQL fixture**
+
+`e2e/fixtures/sql/pending-user.sql`:
+
+```sql
+-- Two deterministic pending users used by admin-approval.spec.ts. The
+-- e2e harness loads this via psql before the spec runs.
+INSERT INTO users (email, password_hash, name, role, oidc_issuer, oidc_subject, status, status_changed_at)
+VALUES
+  ('pending-approve@e2e.local', '', 'Pending Approve', 'user', 'https://e2e.local', 'e2e-approve', 'pending', now()),
+  ('pending-deny@e2e.local',    '', 'Pending Deny',    'user', 'https://e2e.local', 'e2e-deny',    'pending', now())
+ON CONFLICT (email) DO NOTHING;
+```
+
+- [ ] **Step 2: Write the spec**
+
+`e2e/tests/admin-approval.spec.ts`:
+
+```ts
+import { execFileSync } from 'node:child_process'
+import { resolve } from 'node:path'
+
+import { test, expect } from '@playwright/test'
+
+import { ADMIN_STATE_PATH } from '../fixtures/constants'
+
+// Admin-only flow — reuse the cached admin session.
+test.use({ storageState: ADMIN_STATE_PATH })
+
+const FIXTURE = resolve(__dirname, '../fixtures/sql/pending-user.sql')
+const SQL_DELETE_PENDING = `DELETE FROM users WHERE email LIKE '%@e2e.local';`
+
+function psql(sql: string) {
+  // The fixture container is named in compose.dev.yml as postgres-embookshelf.
+  execFileSync('docker', [
+    'exec', '-i',
+    '$(docker compose -f compose.dev.yml ps -q postgres-embookshelf)',
+    'psql', '-U', 'embookshelf', '-d', 'embookshelf',
+    '-c', sql,
+  ], { stdio: 'inherit', shell: true } as never)
+}
+
+function loadFixture(path: string) {
+  const sql = require('node:fs').readFileSync(path, 'utf8')
+  psql(sql)
+}
+
+test.beforeEach(() => {
+  psql(SQL_DELETE_PENDING)
+  loadFixture(FIXTURE)
+})
+
+test.afterEach(() => {
+  psql(SQL_DELETE_PENDING)
+})
+
+test.describe('OIDC admin approval', () => {
+  test('badge surfaces pending users and approve flips them to active', async ({ page }) => {
+    await page.goto('/settings')
+    await page.getByRole('button', { name: /Users & roles/ }).click()
+
+    // Two pending users → badge reads "2".
+    await expect(page.locator('[data-testid="users-tab-badge"], .t-badge').first()).toContainText('2')
+
+    const row = page.locator('[data-row]').filter({ hasText: 'pending-approve@e2e.local' }).first()
+    await expect(row.locator('.t-pill')).toHaveText('Pending')
+    await row.getByRole('button', { name: 'Approve' }).click()
+
+    await expect(row.locator('.t-pill')).toHaveCount(0)
+    // Badge now reads "1" (one pending user remains).
+    await expect(page.locator('.t-badge').first()).toContainText('1')
+  })
+
+  test('deny flips status to denied and keeps row durable', async ({ page }) => {
+    await page.goto('/settings')
+    await page.getByRole('button', { name: /Users & roles/ }).click()
+
+    const row = page.locator('[data-row]').filter({ hasText: 'pending-deny@e2e.local' }).first()
+    await row.getByRole('button', { name: 'Deny' }).click()
+
+    await expect(row.locator('.t-pill')).toHaveText('Denied')
+    await expect(row.getByRole('button', { name: 'Approve' })).toBeVisible()
+    await expect(row.getByRole('button', { name: 'Deny' })).toHaveCount(0)
+  })
+})
+```
+
+(Adjust selectors if the Users panel rows use different `data-*` attributes — search for one match in `_app.settings.tsx` and use the most specific selector available. Add `data-row` to the row container in Task 11 if needed.)
+
+- [ ] **Step 3: Add `data-row` and `data-testid` for stable selectors**
+
+If selectors in step 2 don't match what the panel produces, go back into `ui/src/routes/_app.settings.tsx` and add to the row container created in Task 11:
+
+```tsx
+<div data-row="user" data-user-id={u.id} ...>
+```
+
+And to the badge in the tab navigation:
+
+```tsx
+<span data-testid="users-tab-badge" ...>
+```
+
+- [ ] **Step 4: Run the spec**
+
+In one terminal: `make build && ./tmp/embookshelf` (with DB up + seeded). In another:
+```
+make e2e -- --grep "OIDC admin approval"
+```
+Expected: both tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e/fixtures/sql/pending-user.sql e2e/tests/admin-approval.spec.ts ui/src/routes/_app.settings.tsx
+git commit -m "test(e2e): admin approval and denial flow"
+```
+
+---
+
+## Task 13: Final integration check + lint pass
+
+**Files:** none new; verification only.
+
+- [ ] **Step 1: Run the full local CI**
+
+Run: `make ci-local`
+Expected: lint, typecheck, Go test, UI test all PASS in parallel.
+
+- [ ] **Step 2: Manual full-stack smoke**
+
+With `make up` running:
+
+1. Sign in as admin. `/settings → OIDC / SSO`. Configure a real provider (or skip if not available); turn on "Auto-create users on first login" and "Require admin approval". Save.
+2. Insert a fake pending OIDC user via psql (Task 11 step 7 snippet) — simulates an unknown user completing OIDC.
+3. Verify `/settings → Users & roles` shows the badge and Approve/Deny actions.
+4. Approve. The user's `status` flips to active.
+5. Insert another pending user. Visit `/login/pending` directly to confirm the page renders.
+
+- [ ] **Step 3: Commit nothing if no changes; otherwise commit fixes**
+
+```bash
+git status
+```
+
+If clean, the feature is done. If lint or typecheck flagged issues, fix them and commit:
+```bash
+git add -p
+git commit -m "chore: address lint findings from full-stack smoke"
+```
+
+---
+
+## Self-Review Checklist (post-write)
+
+- **Spec coverage** — every section of the design doc maps to a task: configuration (Task 4, 8, 10), data model (Tasks 1–3), service flow (Task 5), approve/deny service (Task 6), API (Task 7), frontend client (Task 8), pending route (Task 9), settings UI (Task 10), Users panel UI (Task 11), edge cases (covered inline across Tasks 5–7 and the e2e spec in Task 12), testing (Task 6 unit; Task 7 unit; Task 12 e2e).
+- **Placeholder scan** — no TBDs, no "implement later", no "similar to Task N". Each step has the literal code or command to run.
+- **Type consistency** — `UserStatus`, `model.UserStatusActive/Pending/Denied`, `RequireAdminApproval`, `ErrOIDCPendingApproval`, `ErrCannotTargetSelf`, `ApproveUser`/`DenyUser`, `approveSettingsUser`/`denySettingsUser`, `users.updated` event name, `/login/pending` route, and `/api/v1/settings/users/:id/{approve,deny}` paths are used consistently across all tasks.
+- **Spec re-read** — first-user-becomes-admin shortcut is preserved (Task 5 step 3); toggle-flipped-off behavior leaves pending rows untouched (covered by helper text in Task 10 step 2 and by service logic that only writes `pending` on path 3); denial is durable (Task 5 step 2 — denied users are rejected by path 1 immediately).

--- a/docs/superpowers/specs/2026-04-27-oidc-admin-approval-design.md
+++ b/docs/superpowers/specs/2026-04-27-oidc-admin-approval-design.md
@@ -1,0 +1,210 @@
+# OIDC Admin Approval — Design
+
+**Date:** 2026-04-27
+**Status:** Draft
+
+## Problem
+
+When OIDC auto-provisioning is enabled, any identity from a configured provider that successfully completes the OIDC flow gets a usable embookshelf account immediately. For self-hosted instances exposed to a wide identity provider (e.g. a corporate Google Workspace, a public OIDC issuer, or a personal SSO that has more accounts than the admin wants in their library), this is too permissive.
+
+Admins want a third state: **auto-create the user, but hold the account in a "pending" state until an admin approves it.** The user cannot log in until approval.
+
+## Goals
+
+- Admins can require manual approval for newly auto-provisioned OIDC users.
+- New users land on a clear "pending approval" page; they get no session.
+- Admins approve or deny pending users from the existing Users & roles settings panel.
+- Denied users cannot keep retrying — denial is durable.
+- Existing installs upgrade with no behavior change (default off).
+
+## Non-goals
+
+- Email notifications to admins.
+- Full audit log of approval decisions (only `status_changed_at` is recorded).
+- TTL / auto-cleanup of stale pending users.
+- A general "disable user" flow.
+- Per-provider approval policy — this is a single global flag.
+
+## Configuration
+
+Extend `OIDCAutoProvisionDetails` in `internal/repo/app_settings.go` with one new field:
+
+```go
+type OIDCAutoProvisionDetails struct {
+    EnableAutoProvisioning   bool   `json:"enableAutoProvisioning"`
+    AllowLocalAccountLinking bool   `json:"allowLocalAccountLinking"`
+    DefaultRole              string `json:"defaultRole"`
+    RequireAdminApproval     bool   `json:"requireAdminApproval"` // NEW
+}
+```
+
+- Default: `false`. Existing installs see no behavior change.
+- `RequireAdminApproval` is only meaningful when `EnableAutoProvisioning` is `true`. When auto-provisioning is off, unknown OIDC users are still rejected outright (current behavior).
+- Settings UI: a third checkbox under the existing two in the OIDC Auto-Provisioning settings panel, conditionally enabled when auto-provisioning is on. Helper text explains that flipping the flag off does not auto-promote already-pending users.
+
+## Data model
+
+New migration `000023_user_approval_status`:
+
+```sql
+-- up
+ALTER TABLE users
+    ADD COLUMN status TEXT NOT NULL DEFAULT 'active'
+    CHECK (status IN ('active', 'pending', 'denied'));
+ALTER TABLE users
+    ADD COLUMN status_changed_at TIMESTAMPTZ;
+
+-- down
+ALTER TABLE users DROP COLUMN status_changed_at;
+ALTER TABLE users DROP COLUMN status;
+```
+
+- All existing rows backfill to `'active'`.
+- `status_changed_at` lets the admin UI sort the pending queue oldest-first.
+
+Extend `model.User` in `internal/model/user.go`:
+
+```go
+type UserStatus string
+
+const (
+    UserStatusActive  UserStatus = "active"
+    UserStatusPending UserStatus = "pending"
+    UserStatusDenied  UserStatus = "denied"
+)
+
+type User struct {
+    // existing fields...
+    Status          UserStatus
+    StatusChangedAt *time.Time
+}
+```
+
+Pending and denied states are produced **only** by OIDC auto-provisioning. Local-bootstrap signup, admin user-creation, and the email-link path always result in `active` users.
+
+## Service & flow
+
+### `OIDCService.findOrProvisionUser` (`internal/service/oidc.go`)
+
+- **Path 1 — match by OIDC identity:** check `user.Status`.
+  - `active` → return user (current behavior).
+  - `pending` → return new sentinel `ErrOIDCPendingApproval` along with the user.
+  - `denied` → return existing sentinel `ErrOIDCLoginNotAllowed`.
+- **Path 2 — match by email, link OIDC:** unchanged. Local users are already `active`.
+- **Path 3 — auto-provision:** if `RequireAdminApproval = true`, call new repo method `CreateOIDCPending(...)` that inserts with `status='pending'`, `status_changed_at=now()`, and return `ErrOIDCPendingApproval`. Otherwise current `CreateOIDC` path.
+- The first-user-becomes-admin shortcut at `internal/service/oidc.go:647` bypasses approval. First user is always `active` admin — otherwise an admin-less instance with approval-required would be unrecoverable.
+
+### `OIDCService.Exchange`
+
+- Wrap the `findOrProvisionUser` call. If `ErrOIDCPendingApproval` bubbles up:
+  - Do **not** call `SyncOIDCProfile`, `sessions.Create`, or `TouchLastSeen`.
+  - Return the sentinel to the handler. No `model.Session` is produced.
+
+### Handler `OIDCCallback` (`internal/handler/oidc.go:54`)
+
+- On `ErrOIDCPendingApproval`, redirect to `/login/pending` (HTTP 302).
+- All other errors keep the existing `/login?oidcError=...` redirect.
+
+### New user-management service methods
+
+Mirror existing admin user CRUD:
+
+- `ApproveUser(ctx, adminID, userID) error` — flips `pending → active` or `denied → active`, sets `status_changed_at`, emits SSE invalidation event for the users query. Idempotent for already-`active`.
+- `DenyUser(ctx, adminID, userID) error` — flips `pending → denied`, sets `status_changed_at`, emits SSE event. Idempotent for already-`denied`.
+- Both are admin-only.
+- Both refuse to act on the calling admin's own row (cannot self-deny).
+- Deny refuses to act on the last remaining admin user (cannot lock the instance).
+
+## API
+
+New admin endpoints under `/api/v1/settings/users`:
+
+- `POST /api/v1/settings/users/:id/approve` → 200 with updated user DTO. Idempotent for already-`active`. 404 if no such user. 403 if caller is not admin.
+- `POST /api/v1/settings/users/:id/deny` → 200 with updated user DTO. Idempotent for already-`denied`. 400 if denying self or last admin. 404 if no such user. 403 if caller is not admin.
+
+Existing `GET /api/v1/settings/users` response: extend each user DTO with:
+
+```json
+{
+  "status": "pending|active|denied",
+  "statusChangedAt": "2026-04-27T12:34:56Z"
+}
+```
+
+No separate "list pending" endpoint — pending users are a subset of the existing list, filtered/grouped client-side.
+
+Realtime: emit an SSE event on `/events` when a user's status changes (re-use the existing settings-users invalidation event if present, or add one), so any open admin tab updates the badge and list without polling.
+
+## Frontend
+
+### New route — `ui/src/routes/login.pending.tsx`
+
+Reachable at `/login/pending`. No auth required. Renders a calm message:
+
+> **Pending approval**
+> Your account has been created and is awaiting approval from an administrator. You will be able to sign in once it's reviewed. You can close this tab.
+
+Single "Back to login" link. No automatic polling, no retry — the user comes back later via the normal login flow.
+
+### Login route
+
+No changes. The OIDC callback redirects directly to `/login/pending` server-side.
+
+### Users panel — `ui/src/routes/_app.settings.tsx` (`UsersPanel`)
+
+- Each user row shows a status pill:
+  - `active` → no pill (avoid clutter).
+  - `pending` → amber "Pending" pill.
+  - `denied` → gray "Denied" pill.
+- **Pending rows** show Approve (primary) and Deny (ghost) buttons inline. Edit/delete are hidden until approved.
+- **Denied rows** show a single Approve button (re-enabling). Delete remains available.
+- **Active rows:** existing edit/delete UI, unchanged.
+- **Sort order:** pending first (oldest first by `statusChangedAt`), then active, then denied.
+
+### Settings nav badge
+
+The "Users & roles" tab in the settings sidebar gets a small numeric badge when pending count > 0. The count is derived client-side from the existing users query — no extra endpoint. The badge updates reactively via SSE invalidation.
+
+### API client
+
+Add to the appropriate module (`ui/src/api/settings-users.ts` or wherever `fetchSettingsUsers` lives):
+
+- `approveUser(id: string): Promise<UserDTO>`
+- `denyUser(id: string): Promise<UserDTO>`
+
+Wire as TanStack Query mutations that invalidate `settingsUsersQueryKey` on success.
+
+## Edge cases
+
+| Scenario | Behavior |
+| --- | --- |
+| First user ever, approval required + force-only + auto-provision on | First-user shortcut wins: `active` admin, no approval needed. |
+| Toggle flipped on retroactively | Existing users untouched. Only **new** auto-provisioned users land in `pending`. |
+| Toggle flipped off while pending users exist | Pending rows stay pending. Admin still needs to approve or deny — they don't auto-promote. Helper text in the UI explains this. |
+| Denied user retries via OIDC | Path 1 matches the existing OIDC link, sees `status='denied'`, returns `ErrOIDCLoginNotAllowed`. No new pending row. No retry storm. |
+| Approve a denied user | Status flips to `active`. Next OIDC login succeeds normally. |
+| Admin tries to deny themself | Service rejects with a clear error. UI hides the Deny button on the admin's own row. |
+| Admin tries to deny last remaining admin | Service rejects with a clear error. |
+| Email-match path (path 2) for an already-pending user | Cannot happen — pending users are created by OIDC and already have `oidc_subject` set; path 2 only fires when the local user has no OIDC link. |
+
+## Testing
+
+- **Go unit tests** in `internal/service/oidc_test.go`: each path × each status × `RequireAdminApproval` on/off.
+- **Go unit tests** for `ApproveUser` / `DenyUser` in the user service: success, idempotency, last-admin guard, self-deny guard.
+- **Handler tests** for `/api/v1/auth/oidc/callback`: redirects to `/login/pending` on the pending sentinel.
+- **Repo test** for migration round-trip; existing rows backfill to `active`.
+- **E2E (Playwright)**: admin enables approval requirement → simulated OIDC login → user lands on `/login/pending` → admin sees pending badge in settings → admin approves → user can log in. (If no mock OIDC provider exists in the e2e harness, fall back to a Go-level integration test for the auth half and a Playwright test for the admin half.)
+- **Vitest** for the Users panel: pending row renders Approve/Deny, denied row renders Approve only, active row unchanged.
+
+## Implementation order (rough)
+
+1. Migration + model + repo changes (`status`, `status_changed_at`, `CreateOIDCPending`, status-aware getters).
+2. Service: `ErrOIDCPendingApproval`, `findOrProvisionUser` branches, `Exchange` wiring.
+3. Handler: callback redirect to `/login/pending`.
+4. Service: `ApproveUser` / `DenyUser` + admin guards.
+5. API endpoints + DTO extension.
+6. SSE invalidation event.
+7. Frontend: `/login/pending` route.
+8. Frontend: Users panel pills, buttons, sort, badge.
+9. Settings UI: third checkbox + helper text.
+10. Tests across the stack.

--- a/e2e/fixtures/sql/pending-user.sql
+++ b/e2e/fixtures/sql/pending-user.sql
@@ -1,0 +1,7 @@
+-- Two deterministic pending users used by admin-approval.spec.ts. The
+-- e2e harness loads this via psql before the spec runs.
+INSERT INTO users (email, password_hash, name, role, oidc_issuer, oidc_subject, status, status_changed_at)
+VALUES
+  ('pending-approve@e2e.local', '', 'Pending Approve', 'user', 'https://e2e.local', 'e2e-approve', 'pending', now()),
+  ('pending-deny@e2e.local',    '', 'Pending Deny',    'user', 'https://e2e.local', 'e2e-deny',    'pending', now())
+ON CONFLICT (email) DO NOTHING;

--- a/e2e/tests/admin-approval.spec.ts
+++ b/e2e/tests/admin-approval.spec.ts
@@ -1,0 +1,88 @@
+import { execSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { test, expect } from '@playwright/test'
+
+import { ADMIN_STATE_PATH } from '../fixtures/constants'
+
+// Use the cached admin storageState.
+test.use({ storageState: ADMIN_STATE_PATH })
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = resolve(__filename, '..')
+const PROJECT_ROOT = resolve(__dirname, '../..')
+const FIXTURE = resolve(__dirname, '../fixtures/sql/pending-user.sql')
+const SQL_DELETE_PENDING = `DELETE FROM users WHERE email LIKE '%@e2e.local';`
+
+// psql shells out into the dev compose stack — same path `make seed` uses.
+// Service name is `postgres` (see compose.dev.yml). Working directory must
+// be the project root so docker compose resolves the file.
+function psql(sql: string) {
+  execSync(
+    'docker compose -f compose.dev.yml exec -T postgres psql -U embookshelf -d embookshelf -v ON_ERROR_STOP=1',
+    {
+      input: sql,
+      stdio: ['pipe', 'pipe', 'inherit'],
+      cwd: PROJECT_ROOT,
+    }
+  )
+}
+
+function loadFixture(path: string) {
+  psql(readFileSync(path, 'utf8'))
+}
+
+test.beforeEach(() => {
+  psql(SQL_DELETE_PENDING)
+  loadFixture(FIXTURE)
+})
+
+test.afterEach(() => {
+  psql(SQL_DELETE_PENDING)
+})
+
+test.describe('OIDC admin approval', () => {
+  test('badge surfaces pending users and approve flips them to active', async ({
+    page,
+  }) => {
+    await page.goto('/settings')
+    await page.getByRole('button', { name: 'Users & roles', exact: true }).click()
+    await expect(
+      page.getByRole('main').getByRole('heading', { name: 'Users & roles' })
+    ).toBeVisible()
+
+    // Two pending users → badge reads "2".
+    const badge = page.getByTestId('users-tab-badge')
+    await expect(badge).toHaveText('2')
+
+    const row = page
+      .locator('[data-row="user"]')
+      .filter({ hasText: 'pending-approve@e2e.local' })
+    await expect(row.locator('[data-row-status="pending"]')).toBeVisible()
+    await row.getByRole('button', { name: 'Approve' }).click()
+
+    // Pill disappears for the approved row.
+    await expect(row.locator('[data-row-status]')).toHaveCount(0)
+    // Badge now reads "1" (one pending user remains).
+    await expect(badge).toHaveText('1')
+  })
+
+  test('deny flips status to denied and keeps row durable', async ({ page }) => {
+    await page.goto('/settings')
+    await page.getByRole('button', { name: 'Users & roles', exact: true }).click()
+    await expect(
+      page.getByRole('main').getByRole('heading', { name: 'Users & roles' })
+    ).toBeVisible()
+
+    const row = page
+      .locator('[data-row="user"]')
+      .filter({ hasText: 'pending-deny@e2e.local' })
+    await row.getByRole('button', { name: 'Deny' }).click()
+
+    await expect(row.locator('[data-row-status="denied"]')).toBeVisible()
+    await expect(row.getByRole('button', { name: 'Approve' })).toBeVisible()
+    await expect(row.getByRole('button', { name: 'Deny' })).toHaveCount(0)
+  })
+})

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -15,14 +15,16 @@ import (
 // userDTO is the canonical user shape the SPA consumes. camelCase on the
 // wire matches the TS types that frontend/src/data/mock.ts already exports.
 type userDTO struct {
-	ID         string `json:"id"`
-	Email      string `json:"email"`
-	Name       string `json:"name"`
-	Role       string `json:"role"`
-	Display    string `json:"display"`
-	Initials   string `json:"initials"`
-	CreatedAt  string `json:"createdAt"`
-	LastSeenAt string `json:"lastSeenAt,omitempty"`
+	ID              string `json:"id"`
+	Email           string `json:"email"`
+	Name            string `json:"name"`
+	Role            string `json:"role"`
+	Status          string `json:"status"`
+	StatusChangedAt string `json:"statusChangedAt,omitempty"`
+	Display         string `json:"display"`
+	Initials        string `json:"initials"`
+	CreatedAt       string `json:"createdAt"`
+	LastSeenAt      string `json:"lastSeenAt,omitempty"`
 }
 
 func toUserDTO(u model.User) userDTO {
@@ -31,9 +33,17 @@ func toUserDTO(u model.User) userDTO {
 		Email:     u.Email,
 		Name:      u.Name,
 		Role:      string(u.Role),
+		Status:    string(u.Status),
 		Display:   u.Display(),
 		Initials:  u.Initials(),
 		CreatedAt: u.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"),
+	}
+	if d.Status == "" {
+		// Defensive default — older rows or test fakes may leave Status zero.
+		d.Status = string(model.UserStatusActive)
+	}
+	if u.StatusChangedAt != nil {
+		d.StatusChangedAt = u.StatusChangedAt.UTC().Format("2006-01-02T15:04:05Z")
 	}
 	if u.LastSeenAt != nil {
 		d.LastSeenAt = u.LastSeenAt.UTC().Format("2006-01-02T15:04:05Z")

--- a/internal/handler/oidc.go
+++ b/internal/handler/oidc.go
@@ -73,6 +73,10 @@ func (h *Handler) OIDCCallback(c *gin.Context) {
 
 	sess, _, err := h.oidc.Exchange(c.Request.Context(), code, state, c.Request.UserAgent())
 	if err != nil {
+		if errors.Is(err, service.ErrOIDCPendingApproval) {
+			c.Redirect(http.StatusFound, "/login/pending")
+			return
+		}
 		c.Redirect(http.StatusFound, "/login?oidcError="+oidcErrorCode(err))
 		return
 	}
@@ -121,6 +125,8 @@ func oidcErrorCode(err error) string {
 		return "notConfigured"
 	case errors.Is(err, service.ErrOIDCUnknownProvider):
 		return "notConfigured"
+	case errors.Is(err, service.ErrOIDCPendingApproval):
+		return "pendingApproval"
 	default:
 		return "unknown"
 	}

--- a/internal/handler/oidc_test.go
+++ b/internal/handler/oidc_test.go
@@ -1,0 +1,28 @@
+package handler
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/blackforge/embookshelf/internal/service"
+)
+
+func TestOIDCErrorCodeMaps(t *testing.T) {
+	cases := []struct {
+		err  error
+		want string
+	}{
+		{service.ErrOIDCStateMismatch, "stateMismatch"},
+		{service.ErrOIDCLoginNotAllowed, "userNotProvisioned"},
+		{service.ErrOIDCDisabled, "disabled"},
+		{service.ErrOIDCNotConfigured, "notConfigured"},
+		{service.ErrOIDCUnknownProvider, "notConfigured"},
+		{service.ErrOIDCPendingApproval, "pendingApproval"},
+		{errors.New("anything else"), "unknown"},
+	}
+	for _, tc := range cases {
+		if got := oidcErrorCode(tc.err); got != tc.want {
+			t.Errorf("oidcErrorCode(%v) = %q, want %q", tc.err, got, tc.want)
+		}
+	}
+}

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -149,6 +149,8 @@ func (h *Handler) Engine() *gin.Engine {
 				admin.GET("/users", h.SettingsUsersList)
 				admin.POST("/users", h.SettingsUsersCreate)
 				admin.PATCH("/users/:id/role", h.SettingsUsersUpdateRole)
+				admin.POST("/users/:id/approve", h.SettingsUsersApprove)
+				admin.POST("/users/:id/deny", h.SettingsUsersDeny)
 				admin.DELETE("/users/:id", h.SettingsUsersDelete)
 			}
 		}

--- a/internal/handler/users.go
+++ b/internal/handler/users.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/blackforge/embookshelf/internal/auth"
 	"github.com/blackforge/embookshelf/internal/model"
 	"github.com/blackforge/embookshelf/internal/repo"
 	"github.com/blackforge/embookshelf/internal/service"
@@ -94,5 +95,47 @@ func (h *Handler) SettingsUsersDelete(c *gin.Context) {
 		writeError(c, http.StatusConflict, service.ErrLastAdmin.Error())
 	default:
 		writeServerError(c, "settings users delete", err)
+	}
+}
+
+// callerID returns the authenticated user's ID, or "" when no session is
+// attached. The admin guard upstream guarantees a session exists, but
+// returning "" instead of panicking keeps this defensive.
+func callerID(c *gin.Context) string {
+	u := auth.UserFromContext(c.Request.Context())
+	if u == nil {
+		return ""
+	}
+	return u.ID
+}
+
+// SettingsUsersApprove flips a pending or denied user to active.
+func (h *Handler) SettingsUsersApprove(c *gin.Context) {
+	u, err := h.auth.ApproveUser(c.Request.Context(), callerID(c), c.Param("id"))
+	switch {
+	case err == nil:
+		c.JSON(http.StatusOK, gin.H{"user": toUserDTO(u)})
+	case errors.Is(err, repo.ErrNotFound):
+		writeError(c, http.StatusNotFound, "user not found")
+	default:
+		writeServerError(c, "settings users approve", err)
+	}
+}
+
+// SettingsUsersDeny flips a pending user to denied. Refuses to deny the
+// caller themselves or the last remaining admin.
+func (h *Handler) SettingsUsersDeny(c *gin.Context) {
+	u, err := h.auth.DenyUser(c.Request.Context(), callerID(c), c.Param("id"))
+	switch {
+	case err == nil:
+		c.JSON(http.StatusOK, gin.H{"user": toUserDTO(u)})
+	case errors.Is(err, repo.ErrNotFound):
+		writeError(c, http.StatusNotFound, "user not found")
+	case errors.Is(err, service.ErrCannotTargetSelf):
+		writeError(c, http.StatusBadRequest, service.ErrCannotTargetSelf.Error())
+	case errors.Is(err, service.ErrLastAdmin):
+		writeError(c, http.StatusConflict, service.ErrLastAdmin.Error())
+	default:
+		writeServerError(c, "settings users deny", err)
 	}
 }

--- a/internal/migrator/migrations/000023_user_approval_status.down.sql
+++ b/internal/migrator/migrations/000023_user_approval_status.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS users_status_idx;
+ALTER TABLE users DROP COLUMN IF EXISTS status_changed_at;
+ALTER TABLE users DROP COLUMN IF EXISTS status;

--- a/internal/migrator/migrations/000023_user_approval_status.up.sql
+++ b/internal/migrator/migrations/000023_user_approval_status.up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE users
+    ADD COLUMN status TEXT NOT NULL DEFAULT 'active'
+    CHECK (status IN ('active', 'pending', 'denied'));
+
+ALTER TABLE users
+    ADD COLUMN status_changed_at TIMESTAMPTZ;
+
+CREATE INDEX users_status_idx ON users (status) WHERE status <> 'active';

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -9,18 +9,28 @@ const (
 	RoleUser  Role = "user"
 )
 
+type UserStatus string
+
+const (
+	UserStatusActive  UserStatus = "active"
+	UserStatusPending UserStatus = "pending"
+	UserStatusDenied  UserStatus = "denied"
+)
+
 type User struct {
-	ID           string
-	Email        string
-	Name         string
-	Role         Role
-	PasswordHash string  // never rendered; repo populates but handlers don't leak it.
-	OIDCSubject  *string // OIDC sub claim — non-nil when linked to an external identity.
-	OIDCIssuer   *string // OIDC issuer URL.
-	AvatarURL    *string // OIDC picture claim, when the provider supplies one.
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
-	LastSeenAt   *time.Time
+	ID              string
+	Email           string
+	Name            string
+	Role            Role
+	PasswordHash    string  // never rendered; repo populates but handlers don't leak it.
+	OIDCSubject     *string // OIDC sub claim — non-nil when linked to an external identity.
+	OIDCIssuer      *string // OIDC issuer URL.
+	AvatarURL       *string // OIDC picture claim, when the provider supplies one.
+	Status          UserStatus
+	StatusChangedAt *time.Time
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+	LastSeenAt      *time.Time
 }
 
 // Display returns a friendly name, falling back to the email.

--- a/internal/repo/app_settings.go
+++ b/internal/repo/app_settings.go
@@ -90,6 +90,7 @@ type OIDCAutoProvisionDetails struct {
 	EnableAutoProvisioning   bool   `json:"enableAutoProvisioning"`
 	AllowLocalAccountLinking bool   `json:"allowLocalAccountLinking"`
 	DefaultRole              string `json:"defaultRole"` // "admin" | "user"
+	RequireAdminApproval     bool   `json:"requireAdminApproval"`
 }
 
 // -------- defaults --------
@@ -113,6 +114,7 @@ func DefaultOIDCAutoProvisionDetails() OIDCAutoProvisionDetails {
 		EnableAutoProvisioning:   false,
 		AllowLocalAccountLinking: true,
 		DefaultRole:              "user",
+		RequireAdminApproval:     false,
 	}
 }
 

--- a/internal/repo/user.go
+++ b/internal/repo/user.go
@@ -20,7 +20,7 @@ func NewUserRepo(pool *pgxpool.Pool) *UserRepo {
 	return &UserRepo{pool: pool}
 }
 
-const userCols = `id, email, password_hash, name, role, oidc_subject, oidc_issuer, avatar_url, created_at, updated_at, last_seen_at`
+const userCols = `id, email, password_hash, name, role, oidc_subject, oidc_issuer, avatar_url, status, status_changed_at, created_at, updated_at, last_seen_at`
 
 func (r *UserRepo) GetByEmail(ctx context.Context, email string) (model.User, error) {
 	row := r.pool.QueryRow(ctx, `
@@ -157,6 +157,34 @@ func (r *UserRepo) CreateOIDC(ctx context.Context, email, name string, role mode
 	return scanUser(row)
 }
 
+// CreateOIDCPending mirrors CreateOIDC but inserts the user with
+// status='pending' so they cannot log in until an admin approves them.
+func (r *UserRepo) CreateOIDCPending(ctx context.Context, email, name string, role model.Role, issuer, subject string) (model.User, error) {
+	row := r.pool.QueryRow(ctx, `
+		INSERT INTO users (email, name, password_hash, role, oidc_issuer, oidc_subject, status, status_changed_at)
+		VALUES (lower($1), $2, '', $3, $4, $5, 'pending', now())
+		RETURNING `+userCols+`
+	`, strings.TrimSpace(email), strings.TrimSpace(name), string(role), issuer, subject)
+	return scanUser(row)
+}
+
+// UpdateStatus flips the approval status. The caller (service) enforces
+// guards (last admin, self-target) before calling this.
+func (r *UserRepo) UpdateStatus(ctx context.Context, id string, status model.UserStatus) error {
+	tag, err := r.pool.Exec(ctx, `
+		UPDATE users
+		SET status = $2, status_changed_at = now(), updated_at = now()
+		WHERE id = $1
+	`, id, string(status))
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 // LinkOIDC sets the OIDC identity on an existing user (e.g. linking a
 // password-based user to their SSO identity on first OIDC login).
 func (r *UserRepo) LinkOIDC(ctx context.Context, userID, issuer, subject string) error {
@@ -183,10 +211,16 @@ func (r *UserRepo) SyncOIDCProfile(ctx context.Context, userID, name, avatarURL 
 
 func scanUser(s scanner) (model.User, error) {
 	var (
-		u    model.User
-		role string
+		u      model.User
+		role   string
+		status string
 	)
-	err := s.Scan(&u.ID, &u.Email, &u.PasswordHash, &u.Name, &role, &u.OIDCSubject, &u.OIDCIssuer, &u.AvatarURL, &u.CreatedAt, &u.UpdatedAt, &u.LastSeenAt)
+	err := s.Scan(
+		&u.ID, &u.Email, &u.PasswordHash, &u.Name, &role,
+		&u.OIDCSubject, &u.OIDCIssuer, &u.AvatarURL,
+		&status, &u.StatusChangedAt,
+		&u.CreatedAt, &u.UpdatedAt, &u.LastSeenAt,
+	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return u, ErrNotFound
@@ -194,5 +228,6 @@ func scanUser(s scanner) (model.User, error) {
 		return u, err
 	}
 	u.Role = model.Role(role)
+	u.Status = model.UserStatus(status)
 	return u, nil
 }

--- a/internal/repo/user.go
+++ b/internal/repo/user.go
@@ -129,11 +129,15 @@ func (r *UserRepo) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
-// CountByRole returns how many users currently hold the given role. Used to
-// refuse the last-admin demotion/delete path.
+// CountByRole returns how many active users hold the given role. Used to
+// refuse the last-admin demotion / delete / deny path. Pending and denied
+// admins do not count — only an active admin can sign in and recover the
+// instance, so the guard tracks active admins specifically.
 func (r *UserRepo) CountByRole(ctx context.Context, role model.Role) (int, error) {
 	var n int
-	err := r.pool.QueryRow(ctx, `SELECT count(*) FROM users WHERE role = $1`, string(role)).Scan(&n)
+	err := r.pool.QueryRow(ctx,
+		`SELECT count(*) FROM users WHERE role = $1 AND status = 'active'`,
+		string(role)).Scan(&n)
 	return n, err
 }
 

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -247,69 +247,77 @@ func (s *AuthService) DeleteUser(ctx context.Context, userID string) error {
 
 // approveUser/denyUser are pure helpers operating against any repo that
 // satisfies userStatusRepo. They contain the guard logic and are unit
-// tested in auth_test.go without a database. The exported method wrappers
-// add SSE broadcast on success.
+// tested in auth_test.go without a database. They report whether the row
+// actually changed so the exported method wrappers can suppress the SSE
+// broadcast on idempotent no-ops.
 
-func approveUser(ctx context.Context, r userStatusRepo, callerID, targetID string) error {
+func approveUser(ctx context.Context, r userStatusRepo, targetID string) (changed bool, err error) {
 	u, err := r.GetByID(ctx, targetID)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if u.Status == model.UserStatusActive {
-		return nil // idempotent
+		return false, nil // idempotent
 	}
-	return r.UpdateStatus(ctx, targetID, model.UserStatusActive)
+	return true, r.UpdateStatus(ctx, targetID, model.UserStatusActive)
 }
 
-func denyUser(ctx context.Context, r userStatusRepo, callerID, targetID string) error {
+func denyUser(ctx context.Context, r userStatusRepo, callerID, targetID string) (changed bool, err error) {
 	if callerID == targetID {
-		return ErrCannotTargetSelf
+		return false, ErrCannotTargetSelf
 	}
 	u, err := r.GetByID(ctx, targetID)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if u.Status == model.UserStatusDenied {
-		return nil // idempotent
+		return false, nil // idempotent
 	}
 	if u.Role == model.RoleAdmin && u.Status == model.UserStatusActive {
 		n, err := r.CountByRole(ctx, model.RoleAdmin)
 		if err != nil {
-			return err
+			return false, err
 		}
 		if n <= 1 {
-			return ErrLastAdmin
+			return false, ErrLastAdmin
 		}
 	}
-	return r.UpdateStatus(ctx, targetID, model.UserStatusDenied)
+	return true, r.UpdateStatus(ctx, targetID, model.UserStatusDenied)
 }
 
 // ApproveUser flips a pending or denied user back to active. Idempotent
-// for already-active users. Broadcasts a users.updated SSE event
-// so open admin tabs refresh.
+// for already-active users. Broadcasts a users.updated SSE event when
+// the status actually changed so open admin tabs refresh.
 func (s *AuthService) ApproveUser(ctx context.Context, callerID, targetID string) (model.User, error) {
-	if err := approveUser(ctx, s.users, callerID, targetID); err != nil {
+	_ = callerID // approve has no caller-vs-target guards today
+	changed, err := approveUser(ctx, s.users, targetID)
+	if err != nil {
 		return model.User{}, err
 	}
 	u, err := s.users.GetByID(ctx, targetID)
 	if err != nil {
 		return model.User{}, err
 	}
-	s.broadcastUsersUpdate()
+	if changed {
+		s.broadcastUsersUpdate()
+	}
 	return u, nil
 }
 
 // DenyUser flips a pending user to denied. Idempotent. Refuses to deny
 // the caller's own row or the last remaining admin.
 func (s *AuthService) DenyUser(ctx context.Context, callerID, targetID string) (model.User, error) {
-	if err := denyUser(ctx, s.users, callerID, targetID); err != nil {
+	changed, err := denyUser(ctx, s.users, callerID, targetID)
+	if err != nil {
 		return model.User{}, err
 	}
 	u, err := s.users.GetByID(ctx, targetID)
 	if err != nil {
 		return model.User{}, err
 	}
-	s.broadcastUsersUpdate()
+	if changed {
+		s.broadcastUsersUpdate()
+	}
 	return u, nil
 }
 

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -9,6 +9,7 @@ import (
 	"github.com/blackforge/embookshelf/internal/auth"
 	"github.com/blackforge/embookshelf/internal/model"
 	"github.com/blackforge/embookshelf/internal/repo"
+	"github.com/blackforge/embookshelf/internal/sse"
 )
 
 // SessionTTL is how long a freshly-issued session remains valid.
@@ -21,15 +22,27 @@ var (
 	ErrInvalidCredentials = errors.New("invalid email or password")
 	ErrSignupClosed       = errors.New("signup is disabled — an administrator must create your account")
 	ErrEmailTaken         = errors.New("that email is already registered")
+	ErrCannotTargetSelf   = errors.New("cannot change your own approval status")
 )
+
+// userStatusRepo is the slice of UserRepo that ApproveUser and DenyUser
+// touch. Defining it as a tiny interface lets the service test substitute
+// an in-memory fake without spinning up a database — the rest of
+// AuthService keeps using the concrete *repo.UserRepo via embedding.
+type userStatusRepo interface {
+	GetByID(ctx context.Context, id string) (model.User, error)
+	UpdateStatus(ctx context.Context, id string, status model.UserStatus) error
+	CountByRole(ctx context.Context, role model.Role) (int, error)
+}
 
 type AuthService struct {
 	users    *repo.UserRepo
 	sessions *repo.SessionRepo
+	hub      *sse.Hub
 }
 
-func NewAuthService(users *repo.UserRepo, sessions *repo.SessionRepo) *AuthService {
-	return &AuthService{users: users, sessions: sessions}
+func NewAuthService(users *repo.UserRepo, sessions *repo.SessionRepo, hub *sse.Hub) *AuthService {
+	return &AuthService{users: users, sessions: sessions, hub: hub}
 }
 
 // Login verifies credentials and issues a new session.
@@ -230,4 +243,79 @@ func (s *AuthService) DeleteUser(ctx context.Context, userID string) error {
 		}
 	}
 	return s.users.Delete(ctx, userID)
+}
+
+// approveUser/denyUser are pure helpers operating against any repo that
+// satisfies userStatusRepo. They contain the guard logic and are unit
+// tested in auth_test.go without a database. The exported method wrappers
+// add SSE broadcast on success.
+
+func approveUser(ctx context.Context, r userStatusRepo, callerID, targetID string) error {
+	u, err := r.GetByID(ctx, targetID)
+	if err != nil {
+		return err
+	}
+	if u.Status == model.UserStatusActive {
+		return nil // idempotent
+	}
+	return r.UpdateStatus(ctx, targetID, model.UserStatusActive)
+}
+
+func denyUser(ctx context.Context, r userStatusRepo, callerID, targetID string) error {
+	if callerID == targetID {
+		return ErrCannotTargetSelf
+	}
+	u, err := r.GetByID(ctx, targetID)
+	if err != nil {
+		return err
+	}
+	if u.Status == model.UserStatusDenied {
+		return nil // idempotent
+	}
+	if u.Role == model.RoleAdmin && u.Status == model.UserStatusActive {
+		n, err := r.CountByRole(ctx, model.RoleAdmin)
+		if err != nil {
+			return err
+		}
+		if n <= 1 {
+			return ErrLastAdmin
+		}
+	}
+	return r.UpdateStatus(ctx, targetID, model.UserStatusDenied)
+}
+
+// ApproveUser flips a pending or denied user back to active. Idempotent
+// for already-active users. Broadcasts a users.updated SSE event
+// so open admin tabs refresh.
+func (s *AuthService) ApproveUser(ctx context.Context, callerID, targetID string) (model.User, error) {
+	if err := approveUser(ctx, s.users, callerID, targetID); err != nil {
+		return model.User{}, err
+	}
+	u, err := s.users.GetByID(ctx, targetID)
+	if err != nil {
+		return model.User{}, err
+	}
+	s.broadcastUsersUpdate()
+	return u, nil
+}
+
+// DenyUser flips a pending user to denied. Idempotent. Refuses to deny
+// the caller's own row or the last remaining admin.
+func (s *AuthService) DenyUser(ctx context.Context, callerID, targetID string) (model.User, error) {
+	if err := denyUser(ctx, s.users, callerID, targetID); err != nil {
+		return model.User{}, err
+	}
+	u, err := s.users.GetByID(ctx, targetID)
+	if err != nil {
+		return model.User{}, err
+	}
+	s.broadcastUsersUpdate()
+	return u, nil
+}
+
+func (s *AuthService) broadcastUsersUpdate() {
+	if s.hub == nil {
+		return
+	}
+	s.hub.Broadcast(sse.Event{Name: "users.updated", Data: "{}"})
 }

--- a/internal/service/auth_test.go
+++ b/internal/service/auth_test.go
@@ -58,8 +58,12 @@ func newApproveTestSetup() (*fakeUserStatusRepo, model.User, model.User) {
 func TestApproveUserFlipsPendingToActive(t *testing.T) {
 	repo, admin, pending := newApproveTestSetup()
 
-	if err := approveUser(context.Background(), repo, admin.ID, pending.ID); err != nil {
+	changed, err := approveUser(context.Background(), repo, pending.ID)
+	if err != nil {
 		t.Fatalf("approveUser: %v", err)
+	}
+	if !changed {
+		t.Fatalf("changed = false, want true on pending → active")
 	}
 	got := repo.users[pending.ID]
 	if got.Status != model.UserStatusActive {
@@ -68,22 +72,31 @@ func TestApproveUserFlipsPendingToActive(t *testing.T) {
 	if got.StatusChangedAt == nil {
 		t.Fatalf("status_changed_at not set")
 	}
+	_ = admin
 }
 
 func TestApproveUserIsIdempotentOnActive(t *testing.T) {
-	repo, admin, pending := newApproveTestSetup()
+	repo, _, pending := newApproveTestSetup()
 	pending.Status = model.UserStatusActive
 	repo.users[pending.ID] = pending
 
-	if err := approveUser(context.Background(), repo, admin.ID, pending.ID); err != nil {
+	changed, err := approveUser(context.Background(), repo, pending.ID)
+	if err != nil {
 		t.Fatalf("approveUser idempotent: %v", err)
+	}
+	if changed {
+		t.Fatalf("changed = true, want false on already-active")
 	}
 }
 
 func TestDenyUserFlipsPendingToDenied(t *testing.T) {
 	repo, admin, pending := newApproveTestSetup()
-	if err := denyUser(context.Background(), repo, admin.ID, pending.ID); err != nil {
+	changed, err := denyUser(context.Background(), repo, admin.ID, pending.ID)
+	if err != nil {
 		t.Fatalf("denyUser: %v", err)
+	}
+	if !changed {
+		t.Fatalf("changed = false, want true on pending → denied")
 	}
 	if repo.users[pending.ID].Status != model.UserStatusDenied {
 		t.Fatalf("status = %q, want denied", repo.users[pending.ID].Status)
@@ -92,7 +105,7 @@ func TestDenyUserFlipsPendingToDenied(t *testing.T) {
 
 func TestDenyUserRefusesSelf(t *testing.T) {
 	repo, admin, _ := newApproveTestSetup()
-	err := denyUser(context.Background(), repo, admin.ID, admin.ID)
+	_, err := denyUser(context.Background(), repo, admin.ID, admin.ID)
 	if !errors.Is(err, ErrCannotTargetSelf) {
 		t.Fatalf("err = %v, want ErrCannotTargetSelf", err)
 	}
@@ -103,14 +116,14 @@ func TestDenyUserRefusesLastAdmin(t *testing.T) {
 	other := model.User{ID: "admin-2", Email: "b@x", Role: model.RoleAdmin, Status: model.UserStatusActive}
 	repo.users[other.ID] = other
 
-	// Two admins exist — denying the second admin should succeed.
-	if err := denyUser(context.Background(), repo, admin.ID, other.ID); err != nil {
+	// Two active admins exist — denying the second admin should succeed.
+	if _, err := denyUser(context.Background(), repo, admin.ID, other.ID); err != nil {
 		t.Fatalf("denying second admin should succeed: %v", err)
 	}
 	// Now only `admin` (admin-1) remains active. Denying them via an
 	// arbitrary other-admin path should be blocked by the last-admin guard.
 	repo.users[admin.ID] = admin
-	if err := denyUser(context.Background(), repo, "ghost", admin.ID); !errors.Is(err, ErrLastAdmin) {
+	if _, err := denyUser(context.Background(), repo, "ghost", admin.ID); !errors.Is(err, ErrLastAdmin) {
 		t.Fatalf("err = %v, want ErrLastAdmin", err)
 	}
 }

--- a/internal/service/auth_test.go
+++ b/internal/service/auth_test.go
@@ -1,0 +1,116 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/blackforge/embookshelf/internal/model"
+	"github.com/blackforge/embookshelf/internal/repo"
+)
+
+// fakeUserStatusRepo is the in-memory test seam. It implements only the
+// methods userStatusRepo names; nothing else from UserRepo is needed.
+type fakeUserStatusRepo struct {
+	users map[string]model.User
+}
+
+func (f *fakeUserStatusRepo) GetByID(_ context.Context, id string) (model.User, error) {
+	u, ok := f.users[id]
+	if !ok {
+		return model.User{}, repo.ErrNotFound
+	}
+	return u, nil
+}
+
+func (f *fakeUserStatusRepo) UpdateStatus(_ context.Context, id string, status model.UserStatus) error {
+	u, ok := f.users[id]
+	if !ok {
+		return repo.ErrNotFound
+	}
+	now := time.Now()
+	u.Status = status
+	u.StatusChangedAt = &now
+	f.users[id] = u
+	return nil
+}
+
+func (f *fakeUserStatusRepo) CountByRole(_ context.Context, role model.Role) (int, error) {
+	n := 0
+	for _, u := range f.users {
+		if u.Role == role && u.Status == model.UserStatusActive {
+			n++
+		}
+	}
+	return n, nil
+}
+
+func newApproveTestSetup() (*fakeUserStatusRepo, model.User, model.User) {
+	admin := model.User{ID: "admin-1", Email: "a@x", Role: model.RoleAdmin, Status: model.UserStatusActive}
+	pending := model.User{ID: "u-2", Email: "p@x", Role: model.RoleUser, Status: model.UserStatusPending}
+	return &fakeUserStatusRepo{users: map[string]model.User{
+		admin.ID:   admin,
+		pending.ID: pending,
+	}}, admin, pending
+}
+
+func TestApproveUserFlipsPendingToActive(t *testing.T) {
+	repo, admin, pending := newApproveTestSetup()
+
+	if err := approveUser(context.Background(), repo, admin.ID, pending.ID); err != nil {
+		t.Fatalf("approveUser: %v", err)
+	}
+	got := repo.users[pending.ID]
+	if got.Status != model.UserStatusActive {
+		t.Fatalf("status = %q, want active", got.Status)
+	}
+	if got.StatusChangedAt == nil {
+		t.Fatalf("status_changed_at not set")
+	}
+}
+
+func TestApproveUserIsIdempotentOnActive(t *testing.T) {
+	repo, admin, pending := newApproveTestSetup()
+	pending.Status = model.UserStatusActive
+	repo.users[pending.ID] = pending
+
+	if err := approveUser(context.Background(), repo, admin.ID, pending.ID); err != nil {
+		t.Fatalf("approveUser idempotent: %v", err)
+	}
+}
+
+func TestDenyUserFlipsPendingToDenied(t *testing.T) {
+	repo, admin, pending := newApproveTestSetup()
+	if err := denyUser(context.Background(), repo, admin.ID, pending.ID); err != nil {
+		t.Fatalf("denyUser: %v", err)
+	}
+	if repo.users[pending.ID].Status != model.UserStatusDenied {
+		t.Fatalf("status = %q, want denied", repo.users[pending.ID].Status)
+	}
+}
+
+func TestDenyUserRefusesSelf(t *testing.T) {
+	repo, admin, _ := newApproveTestSetup()
+	err := denyUser(context.Background(), repo, admin.ID, admin.ID)
+	if !errors.Is(err, ErrCannotTargetSelf) {
+		t.Fatalf("err = %v, want ErrCannotTargetSelf", err)
+	}
+}
+
+func TestDenyUserRefusesLastAdmin(t *testing.T) {
+	repo, admin, _ := newApproveTestSetup()
+	other := model.User{ID: "admin-2", Email: "b@x", Role: model.RoleAdmin, Status: model.UserStatusActive}
+	repo.users[other.ID] = other
+
+	// Two admins exist — denying the second admin should succeed.
+	if err := denyUser(context.Background(), repo, admin.ID, other.ID); err != nil {
+		t.Fatalf("denying second admin should succeed: %v", err)
+	}
+	// Now only `admin` (admin-1) remains active. Denying them via an
+	// arbitrary other-admin path should be blocked by the last-admin guard.
+	repo.users[admin.ID] = admin
+	if err := denyUser(context.Background(), repo, "ghost", admin.ID); !errors.Is(err, ErrLastAdmin) {
+		t.Fatalf("err = %v, want ErrLastAdmin", err)
+	}
+}

--- a/internal/service/oidc.go
+++ b/internal/service/oidc.go
@@ -30,6 +30,7 @@ var (
 	ErrOIDCLoginNotAllowed  = errors.New("this OIDC identity is not allowed to log in")
 	ErrOIDCForceOnlyBlocked = errors.New("OIDC-only mode cannot be enabled without at least one configured provider")
 	ErrOIDCUnknownProvider  = errors.New("unknown OIDC provider")
+	ErrOIDCPendingApproval  = errors.New("this OIDC account is awaiting administrator approval")
 )
 
 const (
@@ -289,6 +290,11 @@ func (s *OIDCService) Exchange(ctx context.Context, code, state, userAgent strin
 
 	u, err := s.findOrProvisionUser(ctx, issuer, claims, provision)
 	if err != nil {
+		if errors.Is(err, ErrOIDCPendingApproval) {
+			// Return the user so callers (handlers, tests) can see who is
+			// pending, but no session is issued.
+			return model.Session{}, u, ErrOIDCPendingApproval
+		}
 		return model.Session{}, model.User{}, err
 	}
 	_ = s.users.SyncOIDCProfile(ctx, u.ID, claims.Name, claims.Picture)
@@ -603,13 +609,24 @@ func extractClaims(ctx context.Context, disc *cachedDiscovery, token *oauth2.Tok
 // -----------------------------------------------------------------------------
 
 func (s *OIDCService) findOrProvisionUser(ctx context.Context, issuer string, claims resolvedClaims, provision repo.OIDCAutoProvisionDetails) (model.User, error) {
-	// 1) Match by OIDC identity.
+	// 1) Match by OIDC identity. Existing users still need to clear
+	//    the status gate — pending users have not been approved yet,
+	//    denied users have been explicitly refused.
 	u, err := s.users.GetByOIDC(ctx, issuer, claims.Subject)
 	if err != nil && !errors.Is(err, repo.ErrNotFound) {
 		return model.User{}, err
 	}
 	if err == nil {
-		return u, nil
+		switch u.Status {
+		case model.UserStatusActive:
+			return u, nil
+		case model.UserStatusPending:
+			return u, ErrOIDCPendingApproval
+		case model.UserStatusDenied:
+			return model.User{}, ErrOIDCLoginNotAllowed
+		default:
+			return u, nil
+		}
 	}
 
 	// 2) Match by email and link.
@@ -644,12 +661,24 @@ func (s *OIDCService) findOrProvisionUser(ctx context.Context, issuer string, cl
 	if provision.DefaultRole == "admin" {
 		role = model.RoleAdmin
 	}
+	// First-user-becomes-admin shortcut bypasses approval — otherwise
+	// an admin-less instance with approval-required is unrecoverable.
+	firstUser := false
 	if n, err := s.users.Count(ctx); err == nil && n == 0 {
 		role = model.RoleAdmin
+		firstUser = true
 	}
 
 	if claims.Email == "" {
 		return model.User{}, errors.New("OIDC provider did not return an email claim and email is required")
+	}
+
+	if provision.RequireAdminApproval && !firstUser {
+		created, err := s.users.CreateOIDCPending(ctx, claims.Email, claims.Name, role, issuer, claims.Subject)
+		if err != nil {
+			return model.User{}, err
+		}
+		return created, ErrOIDCPendingApproval
 	}
 	return s.users.CreateOIDC(ctx, claims.Email, claims.Name, role, issuer, claims.Subject)
 }

--- a/ui/src/api/auth.ts
+++ b/ui/src/api/auth.ts
@@ -1,12 +1,16 @@
 import { api } from "./client"
 import type { ApiError } from "./client"
 
+export type UserStatus = "active" | "pending" | "denied"
+
 // Mirrors internal/handler/auth.go userDTO.
 export type AuthUser = {
   id: string
   email: string
   name: string
   role: "admin" | "user"
+  status: UserStatus
+  statusChangedAt?: string
   display: string
   initials: string
   createdAt: string

--- a/ui/src/api/oidc.ts
+++ b/ui/src/api/oidc.ts
@@ -31,6 +31,7 @@ export type OidcAutoProvision = {
   enableAutoProvisioning: boolean
   allowLocalAccountLinking: boolean
   defaultRole: "admin" | "user"
+  requireAdminApproval: boolean
 }
 
 export type OidcAdminSettings = {

--- a/ui/src/api/realtime.ts
+++ b/ui/src/api/realtime.ts
@@ -3,10 +3,11 @@ import { useQueryClient } from "@tanstack/react-query"
 
 import { bookdropQueryKey } from "./bookdrop"
 import { booksQueryKey, librariesQueryKey } from "./books"
+import { settingsUsersQueryKey } from "./settings"
 
 // Event names the server publishes. Keep the union narrow so the dispatch
 // map below is exhaustive — TypeScript will catch a typo before it ships.
-type RealtimeEvent = "bookdrop.updated" | "bookdrop.cleared"
+type RealtimeEvent = "bookdrop.updated" | "bookdrop.cleared" | "users.updated"
 
 type Handler = () => void
 
@@ -31,6 +32,9 @@ export function useRealtime() {
       // to refetch; books/libraries are unaffected by history deletion.
       "bookdrop.cleared": () => {
         queryClient.invalidateQueries({ queryKey: bookdropQueryKey })
+      },
+      "users.updated": () => {
+        queryClient.invalidateQueries({ queryKey: settingsUsersQueryKey })
       },
     }
 

--- a/ui/src/api/settings.ts
+++ b/ui/src/api/settings.ts
@@ -302,4 +302,20 @@ export async function deleteSettingsUser(id: string): Promise<void> {
   await api<void>(`/api/v1/settings/users/${id}`, { method: "DELETE" })
 }
 
+export async function approveSettingsUser(id: string): Promise<AuthUser> {
+  const { user } = await api<{ user: AuthUser }>(
+    `/api/v1/settings/users/${id}/approve`,
+    { method: "POST" }
+  )
+  return user
+}
+
+export async function denySettingsUser(id: string): Promise<AuthUser> {
+  const { user } = await api<{ user: AuthUser }>(
+    `/api/v1/settings/users/${id}/deny`,
+    { method: "POST" }
+  )
+  return user
+}
+
 export const settingsUsersQueryKey = ["settings", "users"] as const

--- a/ui/src/components/SettingsShared.tsx
+++ b/ui/src/components/SettingsShared.tsx
@@ -186,7 +186,12 @@ export function SettingsShell<TKey extends string>({
   isAdmin,
   children,
 }: {
-  sections: ReadonlyArray<{ key: TKey; label: string; adminOnly?: boolean }>
+  sections: ReadonlyArray<{
+    key: TKey
+    label: string
+    adminOnly?: boolean
+    badge?: ReactNode
+  }>
   active: TKey
   onSelect: (key: TKey) => void
   isAdmin: boolean
@@ -229,10 +234,14 @@ export function SettingsShell<TKey extends string>({
                     ? "var(--color-ink-1)"
                     : "var(--color-ink-2)",
                 opacity: gated ? 0.6 : 1,
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
               }}
               title={gated ? "Admin-only" : undefined}
             >
-              {s.label}
+              <span style={{ flex: 1 }}>{s.label}</span>
+              {s.badge}
             </button>
           )
         })}

--- a/ui/src/routeTree.gen.ts
+++ b/ui/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as LoginRouteImport } from './routes/login'
 import { Route as AppRouteImport } from './routes/_app'
 import { Route as AppIndexRouteImport } from './routes/_app.index'
 import { Route as ReadIdRouteImport } from './routes/read.$id'
+import { Route as LoginPendingRouteImport } from './routes/login.pending'
 import { Route as AppStatsRouteImport } from './routes/_app.stats'
 import { Route as AppSettingsRouteImport } from './routes/_app.settings'
 import { Route as AppNotebookRouteImport } from './routes/_app.notebook'
@@ -39,6 +40,11 @@ const ReadIdRoute = ReadIdRouteImport.update({
   id: '/read/$id',
   path: '/read/$id',
   getParentRoute: () => rootRouteImport,
+} as any)
+const LoginPendingRoute = LoginPendingRouteImport.update({
+  id: '/pending',
+  path: '/pending',
+  getParentRoute: () => LoginRoute,
 } as any)
 const AppStatsRoute = AppStatsRouteImport.update({
   id: '/stats',
@@ -78,23 +84,25 @@ const AppBookIdEditRoute = AppBookIdEditRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof AppIndexRoute
-  '/login': typeof LoginRoute
+  '/login': typeof LoginRouteWithChildren
   '/bookdrop': typeof AppBookdropRoute
   '/library': typeof AppLibraryRoute
   '/notebook': typeof AppNotebookRoute
   '/settings': typeof AppSettingsRoute
   '/stats': typeof AppStatsRoute
+  '/login/pending': typeof LoginPendingRoute
   '/read/$id': typeof ReadIdRoute
   '/book/$id': typeof AppBookIdRoute
   '/book/$id/edit': typeof AppBookIdEditRoute
 }
 export interface FileRoutesByTo {
-  '/login': typeof LoginRoute
+  '/login': typeof LoginRouteWithChildren
   '/bookdrop': typeof AppBookdropRoute
   '/library': typeof AppLibraryRoute
   '/notebook': typeof AppNotebookRoute
   '/settings': typeof AppSettingsRoute
   '/stats': typeof AppStatsRoute
+  '/login/pending': typeof LoginPendingRoute
   '/read/$id': typeof ReadIdRoute
   '/': typeof AppIndexRoute
   '/book/$id': typeof AppBookIdRoute
@@ -103,12 +111,13 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/_app': typeof AppRouteWithChildren
-  '/login': typeof LoginRoute
+  '/login': typeof LoginRouteWithChildren
   '/_app/bookdrop': typeof AppBookdropRoute
   '/_app/library': typeof AppLibraryRoute
   '/_app/notebook': typeof AppNotebookRoute
   '/_app/settings': typeof AppSettingsRoute
   '/_app/stats': typeof AppStatsRoute
+  '/login/pending': typeof LoginPendingRoute
   '/read/$id': typeof ReadIdRoute
   '/_app/': typeof AppIndexRoute
   '/_app/book/$id': typeof AppBookIdRoute
@@ -124,6 +133,7 @@ export interface FileRouteTypes {
     | '/notebook'
     | '/settings'
     | '/stats'
+    | '/login/pending'
     | '/read/$id'
     | '/book/$id'
     | '/book/$id/edit'
@@ -135,6 +145,7 @@ export interface FileRouteTypes {
     | '/notebook'
     | '/settings'
     | '/stats'
+    | '/login/pending'
     | '/read/$id'
     | '/'
     | '/book/$id'
@@ -148,6 +159,7 @@ export interface FileRouteTypes {
     | '/_app/notebook'
     | '/_app/settings'
     | '/_app/stats'
+    | '/login/pending'
     | '/read/$id'
     | '/_app/'
     | '/_app/book/$id'
@@ -156,7 +168,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   AppRoute: typeof AppRouteWithChildren
-  LoginRoute: typeof LoginRoute
+  LoginRoute: typeof LoginRouteWithChildren
   ReadIdRoute: typeof ReadIdRoute
 }
 
@@ -189,6 +201,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/read/$id'
       preLoaderRoute: typeof ReadIdRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/login/pending': {
+      id: '/login/pending'
+      path: '/pending'
+      fullPath: '/login/pending'
+      preLoaderRoute: typeof LoginPendingRouteImport
+      parentRoute: typeof LoginRoute
     }
     '/_app/stats': {
       id: '/_app/stats'
@@ -266,9 +285,19 @@ const AppRouteChildren: AppRouteChildren = {
 
 const AppRouteWithChildren = AppRoute._addFileChildren(AppRouteChildren)
 
+interface LoginRouteChildren {
+  LoginPendingRoute: typeof LoginPendingRoute
+}
+
+const LoginRouteChildren: LoginRouteChildren = {
+  LoginPendingRoute: LoginPendingRoute,
+}
+
+const LoginRouteWithChildren = LoginRoute._addFileChildren(LoginRouteChildren)
+
 const rootRouteChildren: RootRouteChildren = {
   AppRoute: AppRouteWithChildren,
-  LoginRoute: LoginRoute,
+  LoginRoute: LoginRouteWithChildren,
   ReadIdRoute: ReadIdRoute,
 }
 export const routeTree = rootRouteImport

--- a/ui/src/routes/_app.settings.tsx
+++ b/ui/src/routes/_app.settings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
 import { toast } from "sonner"
@@ -20,10 +20,12 @@ import type {
 } from "@/api/oidc"
 import type { AuthUser } from "@/api/auth"
 import {
+  approveSettingsUser,
   createLibrary,
   createSettingsUser,
   deleteLibrary,
   deleteSettingsUser,
+  denySettingsUser,
   fetchInstanceInfo,
   fetchMetadataSettings,
   fetchProviderSettings,
@@ -86,7 +88,12 @@ type SectionKey =
   | "backups"
   | "about"
 
-type SectionSpec = { key: SectionKey; label: string; adminOnly?: boolean }
+type SectionSpec = {
+  key: SectionKey
+  label: string
+  adminOnly?: boolean
+  badge?: ReactNode
+}
 
 const SECTIONS: Array<SectionSpec> = [
   { key: "libraries", label: "Libraries", adminOnly: true },
@@ -108,6 +115,28 @@ function Admin() {
   const isAdmin = me.data?.role === "admin"
   const [active, setActive] = useState<SectionKey>("libraries")
 
+  const usersQuery = useQuery({
+    queryKey: settingsUsersQueryKey,
+    queryFn: fetchSettingsUsers,
+    enabled: isAdmin,
+  })
+
+  const pendingCount = useMemo(
+    () =>
+      (usersQuery.data ?? []).filter((u) => u.status === "pending").length,
+    [usersQuery.data]
+  )
+
+  const sections = useMemo<Array<SectionSpec>>(
+    () =>
+      SECTIONS.map((s) =>
+        s.key === "users" && pendingCount > 0
+          ? { ...s, badge: <PendingBadge count={pendingCount} /> }
+          : s
+      ),
+    [pendingCount]
+  )
+
   return (
     <div className="fade-in">
       <TopBar
@@ -115,7 +144,7 @@ function Admin() {
         subtitle="Instance, users, metadata providers, SSO."
       />
       <SettingsShell
-        sections={SECTIONS}
+        sections={sections}
         active={active}
         onSelect={setActive}
         isAdmin={isAdmin}
@@ -1137,6 +1166,25 @@ function EmailPanel({ isAdmin }: { isAdmin: boolean }) {
 // Users & roles (admin CRUD)
 // ---------------------------------------------------------------------------
 
+function PendingBadge({ count }: { count: number }) {
+  return (
+    <span
+      data-testid="users-tab-badge"
+      style={{
+        padding: "1px 6px",
+        borderRadius: 999,
+        background: "var(--color-amber-bg, #fff5cc)",
+        color: "var(--color-amber-ink, #8a5b00)",
+        fontSize: 10,
+        fontWeight: 600,
+        lineHeight: 1.6,
+      }}
+    >
+      {count}
+    </span>
+  )
+}
+
 function UsersPanel({
   isAdmin,
   me,
@@ -1150,6 +1198,23 @@ function UsersPanel({
     queryFn: fetchSettingsUsers,
     enabled: isAdmin,
   })
+
+  const sortedUsers = useMemo(() => {
+    const all = users.data ?? []
+    const rank = (s: AuthUser["status"]) =>
+      s === "pending" ? 0 : s === "active" ? 1 : 2
+    return [...all].sort((a, b) => {
+      const r = rank(a.status) - rank(b.status)
+      if (r !== 0) return r
+      if (a.status === "pending" && b.status === "pending") {
+        return (
+          new Date(a.statusChangedAt ?? a.createdAt).getTime() -
+          new Date(b.statusChangedAt ?? b.createdAt).getTime()
+        )
+      }
+      return a.email.localeCompare(b.email)
+    })
+  }, [users.data])
 
   const [createOpen, setCreateOpen] = useState(false)
   const [draft, setDraft] = useState({
@@ -1192,6 +1257,24 @@ function UsersPanel({
     onSuccess: () => {
       invalidate()
       toast.success("User deleted.")
+    },
+    onError: (e) => toast.error((e as unknown as ApiError).message),
+  })
+
+  const approveMut = useMutation({
+    mutationFn: (id: string) => approveSettingsUser(id),
+    onSuccess: () => {
+      invalidate()
+      toast.success("User approved.")
+    },
+    onError: (e) => toast.error((e as unknown as ApiError).message),
+  })
+
+  const denyMut = useMutation({
+    mutationFn: (id: string) => denySettingsUser(id),
+    onSuccess: () => {
+      invalidate()
+      toast.success("User denied.")
     },
     onError: (e) => toast.error((e as unknown as ApiError).message),
   })
@@ -1295,11 +1378,13 @@ function UsersPanel({
           marginTop: 16,
         }}
       >
-        {(users.data ?? []).map((u) => {
+        {sortedUsers.map((u) => {
           const isMe = u.id === me?.id
           return (
             <div
               key={u.id}
+              data-row="user"
+              data-user-id={u.id}
               style={{
                 display: "flex",
                 alignItems: "center",
@@ -1310,6 +1395,27 @@ function UsersPanel({
               }}
             >
               <Avatar initials={u.initials} size={32} />
+              {u.status !== "active" && (
+                <span
+                  data-row-status={u.status}
+                  style={{
+                    padding: "2px 8px",
+                    borderRadius: 999,
+                    background:
+                      u.status === "pending"
+                        ? "var(--color-amber-bg, #fff5cc)"
+                        : "var(--color-paper-2)",
+                    color:
+                      u.status === "pending"
+                        ? "var(--color-amber-ink, #8a5b00)"
+                        : "var(--color-ink-soft)",
+                    fontSize: 11,
+                    fontWeight: 500,
+                  }}
+                >
+                  {u.status === "pending" ? "Pending" : "Denied"}
+                </span>
+              )}
               <div style={{ flex: 1, minWidth: 0 }}>
                 <div className="t-item-title">
                   {u.display} {isMe && <span className="t-micro">you</span>}
@@ -1324,38 +1430,73 @@ function UsersPanel({
                     ` · last seen ${new Date(u.lastSeenAt).toLocaleDateString()}`}
                 </div>
               </div>
-              <Select
-                value={u.role}
-                onChange={(v) =>
-                  roleMut.mutate({ id: u.id, role: v as "admin" | "user" })
-                }
-                options={[
-                  { value: "user", label: "User" },
-                  { value: "admin", label: "Admin" },
-                ]}
-                disabled={isMe || roleMut.isPending}
-                triggerClassName="w-[110px] shrink-0"
-              />
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-sm"
-                disabled={isMe || deleteMut.isPending}
-                onClick={() => {
-                  if (
-                    window.confirm(
-                      `Delete ${u.display}? This cannot be undone.`
-                    )
-                  ) {
-                    deleteMut.mutate(u.id)
-                  }
-                }}
-                className="text-(--color-accent-ink)"
-                aria-label="Delete user"
-                title={isMe ? "You can't delete yourself" : "Delete user"}
-              >
-                <Icon name="close" size={12} />
-              </Button>
+              {u.status === "active" && (
+                <>
+                  <Select
+                    value={u.role}
+                    onChange={(v) =>
+                      roleMut.mutate({ id: u.id, role: v as "admin" | "user" })
+                    }
+                    options={[
+                      { value: "user", label: "User" },
+                      { value: "admin", label: "Admin" },
+                    ]}
+                    disabled={isMe || roleMut.isPending}
+                    triggerClassName="w-[110px] shrink-0"
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    disabled={isMe || deleteMut.isPending}
+                    onClick={() => {
+                      if (
+                        window.confirm(
+                          `Delete ${u.display}? This cannot be undone.`
+                        )
+                      ) {
+                        deleteMut.mutate(u.id)
+                      }
+                    }}
+                    className="text-(--color-accent-ink)"
+                    aria-label="Delete user"
+                    title={isMe ? "You can't delete yourself" : "Delete user"}
+                  >
+                    <Icon name="close" size={12} />
+                  </Button>
+                </>
+              )}
+              {u.status === "pending" && (
+                <>
+                  <Button
+                    type="button"
+                    size="sm"
+                    onClick={() => approveMut.mutate(u.id)}
+                    disabled={approveMut.isPending}
+                  >
+                    Approve
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => denyMut.mutate(u.id)}
+                    disabled={denyMut.isPending || isMe}
+                  >
+                    Deny
+                  </Button>
+                </>
+              )}
+              {u.status === "denied" && (
+                <Button
+                  type="button"
+                  size="sm"
+                  onClick={() => approveMut.mutate(u.id)}
+                  disabled={approveMut.isPending}
+                >
+                  Approve
+                </Button>
+              )}
             </div>
           )
         })}

--- a/ui/src/routes/_app.settings.tsx
+++ b/ui/src/routes/_app.settings.tsx
@@ -1541,6 +1541,29 @@ function OidcPanel({ isAdmin }: { isAdmin: boolean }) {
               }
             />
           </div>
+          <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+            <div className="grow">
+              <div className="t-item-title">Require admin approval</div>
+              <div className="t-item-sub">
+                New SSO users are created in a pending state and cannot sign in
+                until an admin approves them in Users &amp; roles. Disabling
+                this later does not auto-promote already-pending users.
+              </div>
+            </div>
+            <Switch
+              checked={draft.autoProvision.requireAdminApproval}
+              disabled={!draft.autoProvision.enableAutoProvisioning}
+              onCheckedChange={(v) =>
+                setDraft({
+                  ...draft,
+                  autoProvision: {
+                    ...draft.autoProvision,
+                    requireAdminApproval: v,
+                  },
+                })
+              }
+            />
+          </div>
           <Field label="Default role for new users">
             <Select
               value={draft.autoProvision.defaultRole}

--- a/ui/src/routes/login.pending.tsx
+++ b/ui/src/routes/login.pending.tsx
@@ -1,0 +1,92 @@
+import { Link, createFileRoute } from "@tanstack/react-router"
+
+export const Route = createFileRoute("/login/pending")({
+  component: PendingApproval,
+})
+
+function PendingApproval() {
+  return (
+    <main
+      style={{
+        minHeight: "100vh",
+        background: "var(--color-paper-1)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: 32,
+      }}
+    >
+      <div style={{ width: "100%", maxWidth: 420 }}>
+        <div
+          style={{
+            textAlign: "center",
+            marginBottom: 24,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: 10,
+          }}
+        >
+          <img
+            src="/logo.png"
+            alt="embookshelf"
+            style={{
+              width: 40,
+              height: 40,
+              objectFit: "contain",
+              borderRadius: 2,
+            }}
+          />
+          <div
+            style={{
+              fontFamily: "var(--font-serif)",
+              fontSize: 22,
+              fontWeight: 500,
+              letterSpacing: "-0.01em",
+            }}
+          >
+            embookshelf
+          </div>
+        </div>
+
+        <div
+          style={{
+            background: "var(--color-paper-0)",
+            border: "1px solid var(--color-rule-soft)",
+            padding: 32,
+            borderRadius: 3,
+            boxShadow: "0 12px 32px -8px oklch(0.2 0.02 60 / 0.14)",
+          }}
+        >
+          <h1 className="t-h2" style={{ marginBottom: 4 }}>
+            Pending approval
+          </h1>
+          <p
+            className="t-small"
+            style={{ marginBottom: 16, fontStyle: "italic" }}
+          >
+            Your account has been created and is awaiting review.
+          </p>
+          <p className="t-body" style={{ marginBottom: 12 }}>
+            An administrator will approve or deny new sign-ins from your SSO
+            provider before you can sign in. You will be able to sign in once
+            your account is approved.
+          </p>
+          <p
+            className="t-small"
+            style={{ marginBottom: 20, fontStyle: "italic" }}
+          >
+            You can close this tab — there is nothing else to do here.
+          </p>
+          <Link
+            to="/login"
+            className="t-link"
+            style={{ fontSize: 13 }}
+          >
+            Back to login
+          </Link>
+        </div>
+      </div>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds an opt-in `RequireAdminApproval` toggle on OIDC auto-provisioning. When enabled, brand-new OIDC users land in a `pending` state and cannot sign in until an admin approves them via Settings → Users & roles. Denied users are durably rejected on subsequent logins.
- Pending users get redirected to a new `/login/pending` page (no session issued). Existing OIDC accounts are unaffected unless their status changes.
- Admins see an amber count badge on the Users & roles tab and Approve / Deny actions per pending row, with last-admin and self-target guards. SSE broadcasts `users.updated` so open admin tabs refresh.

## Implementation notes
- New `users.status` enum (`active|pending|denied`) + `status_changed_at` with a partial index. Existing rows backfill to `active`, so upgrades are zero-impact.
- First-user-becomes-admin shortcut bypasses approval (otherwise an admin-less instance with the toggle on would be unrecoverable).
- `CountByRole` is now scoped to active admins so pending/denied admins never count toward the last-admin guard.
- TDD with a small `userStatusRepo` interface seam → unit tests for the approve/deny guards without a database. New handler test covers the `oidcErrorCode` mapping including `pendingApproval`.

Spec: [`docs/superpowers/specs/2026-04-27-oidc-admin-approval-design.md`](docs/superpowers/specs/2026-04-27-oidc-admin-approval-design.md)
Plan: [`docs/superpowers/plans/2026-04-27-oidc-admin-approval.md`](docs/superpowers/plans/2026-04-27-oidc-admin-approval.md)

## Test plan
- [x] Migration round-trip (`make migrate` → 23 → `make migrate-down` → 22 → re-apply)
- [x] `make ci-local` (golangci-lint 0 issues, `go test ./...` ok, vitest 8/8, ui-lint, ui-typecheck, full build)
- [x] Go unit tests for `approveUser` / `denyUser` guards (5/5)
- [x] Go handler test for `oidcErrorCode` mapping
- [ ] Run Playwright spec `OIDC admin approval` against the live binary (`make build && ./tmp/embookshelf`, then `cd e2e && bun run test -g "OIDC admin approval"`) — file written, live run not executed in CI sandbox
- [ ] Manual smoke: enable RequireAdminApproval against a real OIDC provider, complete an SSO sign-in for a fresh identity, confirm `/login/pending` is shown and no session cookie is set; admin approves → next login succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)