### PR TITLE
fix(ci): scan correct image tag for SBOM generation

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -81,11 +81,15 @@ jobs:
             VERSION=${{ github.ref_name }}
             COMMIT=${{ github.sha }}
 
+      # docker/metadata-action strips the leading "v" from semver tags
+      # (the pushed image is :0.1.4, not :v0.1.4), so reference its
+      # resolved version output rather than github.ref_name. The release
+      # name keeps the "v" prefix for the file name to match git tags.
       - name: Generate SPDX SBOM (tag only)
         if: startsWith(github.ref, 'refs/tags/v')
         uses: anchore/sbom-action@v0
         with:
-          image: ${{ steps.image.outputs.ref }}:${{ github.ref_name }}
+          image: ${{ steps.image.outputs.ref }}:${{ steps.meta.outputs.version }}
           format: spdx-json
           output-file: embookshelf_${{ github.ref_name }}_spdx.json
           upload-artifact: false


### PR DESCRIPTION
## Summary
The Image workflow's SBOM step used `${{ github.ref_name }}` (e.g. `v0.1.4`) when telling syft which image to scan, but `docker/metadata-action`'s `type=semver,pattern={{version}}` strips the leading `v` and pushes the image as `:0.1.4`. Result: syft kept failing with `MANIFEST_UNKNOWN`, and v0.1.4 shipped without an SBOM.

This switches the image reference to `${{ steps.meta.outputs.version }}` so the SBOM step always agrees with the tag the build step actually pushed. The output file name keeps the `v`-prefixed ref so the artifact name lines up with the git tag.

Verified locally: image is published at `ghcr.io/blackforgehq/embookshelf:0.1.4` (and `:0.1`, `:0`, `:latest`); no `:v0.1.4` exists.

## Test plan
- [ ] Next semver tag push (or manual `workflow_dispatch` against `v*`) generates an SPDX SBOM and attaches it to the GitHub release without `MANIFEST_UNKNOWN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)