### PR TITLE
feat: comic (CBZ) and audiobook (MP3/M4B) readers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/dhowden/tag v0.0.0-20240417053706-3d75831295e8 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54 h1:SG7nF6SRlWhcT7cNTs5R6Hk4V2lcmLz2NsG2VnInyNo=
 github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
+github.com/dhowden/tag v0.0.0-20240417053706-3d75831295e8 h1:OtSeLS5y0Uy01jaKK4mA/WVIYtpzVm63vLVAPzJXigg=
+github.com/dhowden/tag v0.0.0-20240417053706-3d75831295e8/go.mod h1:apkPC/CR3s48O2D7Y++n1XWEpgPNNCjXYga3PPbJe2E=
 github.com/dhui/dktest v0.4.6 h1:+DPKyScKSEp3VLtbMDHcUq6V5Lm5zfZZVb0Sk7Ahom4=
 github.com/dhui/dktest v0.4.6/go.mod h1:JHTSYDtKkvFNFHJKqCzVzqXecyv+tKt8EzceOmQOgbU=
 github.com/disintegration/gift v1.2.1 h1:Y005a1X4Z7Uc+0gLpSAsKhWi4qLtsdEcMIbbdvdZ6pc=

--- a/internal/fileproc/audio.go
+++ b/internal/fileproc/audio.go
@@ -1,0 +1,363 @@
+package fileproc
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/dhowden/tag"
+)
+
+// AudioProcessor handles single-file audiobooks: MP3 (ID3v2-tagged) and
+// M4B/M4A (iTunes-style atoms). Multi-file folder-as-book is a separate
+// design that's out of scope for now — each file is one book.
+//
+// Tag/cover parsing uses github.com/dhowden/tag. Duration is derived
+// in this package: for MP3 we look for an XING/Info header in the first
+// audio frame; for MP4 we parse the mvhd atom out of the moov box. Both
+// are best-effort — a missing header leaves DurationSeconds nil and the
+// reader UI just shows "—" instead.
+type AudioProcessor struct{}
+
+func (AudioProcessor) Extract(ctx context.Context, filePath string) (Metadata, error) {
+	_ = ctx
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		return Metadata{}, fmt.Errorf("open audio: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	m := Metadata{Format: audioFormatTag(filePath)}
+
+	// Tags + cover are best-effort. ReadFrom seeks the file; on bare MP3
+	// streams without an ID3v2 tag it can return an error — fall through
+	// without erroring out.
+	if t, err := tag.ReadFrom(f); err == nil {
+		applyAudioTags(&m, t)
+	}
+
+	// Duration: re-seek the file because tag.ReadFrom moved the cursor.
+	if _, err := f.Seek(0, io.SeekStart); err == nil {
+		switch m.Format {
+		case "MP3":
+			if secs, ok := mp3Duration(f); ok {
+				m.DurationSeconds = &secs
+			}
+		case "M4B":
+			if secs, ok := mp4Duration(f); ok {
+				m.DurationSeconds = &secs
+			}
+		}
+	}
+
+	// Title fallback: if we still have nothing, derive from filename
+	// (minus extension) so the bookdrop UI shows something humane.
+	if strings.TrimSpace(m.Title) == "" {
+		base := filepath.Base(filePath)
+		m.Title = strings.TrimSuffix(base, filepath.Ext(base))
+	}
+
+	return m, nil
+}
+
+// audioFormatTag normalizes the file extension to one of the canonical
+// format tags the rest of the system uses. M4A rides under MP3 today
+// (the bookshelf grouping treats them as one row in filter chips).
+func audioFormatTag(p string) string {
+	switch strings.ToLower(filepath.Ext(p)) {
+	case ".mp3":
+		return "MP3"
+	case ".m4a", ".m4b":
+		return "M4B"
+	}
+	return "MP3"
+}
+
+func applyAudioTags(m *Metadata, t tag.Metadata) {
+	if title := strings.TrimSpace(t.Title()); title != "" {
+		m.Title = title
+	} else if alb := strings.TrimSpace(t.Album()); alb != "" {
+		// Audiobook conventions: Album = book title, Artist = author or
+		// narrator depending on the tagger. When Title is empty (rare
+		// for audiobooks but happens in podcast-style tagging) the album
+		// is the closer match.
+		m.Title = alb
+	}
+	// Author is the audiobook's writer; many taggers store it as
+	// "AlbumArtist" with the narrator in "Artist". Fall back to Artist
+	// when AlbumArtist is empty.
+	if aa := strings.TrimSpace(t.AlbumArtist()); aa != "" {
+		m.Author = aa
+	} else if ar := strings.TrimSpace(t.Artist()); ar != "" {
+		m.Author = ar
+	}
+	// Narrator: when both AlbumArtist and Artist are populated and
+	// distinct, the Artist field is the narrator.
+	aa := strings.TrimSpace(t.AlbumArtist())
+	ar := strings.TrimSpace(t.Artist())
+	if aa != "" && ar != "" && aa != ar {
+		m.Narrator = ar
+	}
+	if c := strings.TrimSpace(t.Comment()); c != "" {
+		m.Description = c
+	}
+
+	if pic := t.Picture(); pic != nil && len(pic.Data) > 0 {
+		m.HasCover = true
+		m.CoverBytes = pic.Data
+		switch strings.ToLower(pic.MIMEType) {
+		case "":
+			m.CoverMime = "image/jpeg" // common default for ID3 APIC w/o MIME
+		default:
+			m.CoverMime = pic.MIMEType
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MP3 duration via XING/Info header.
+// ---------------------------------------------------------------------------
+
+// mp3Duration tries to read the XING / Info VBR header from the first
+// MPEG audio frame and compute total duration in seconds.
+//
+// Returns (0, false) when:
+//   - the file isn't a parseable MPEG stream
+//   - the first frame has no XING/Info header (CBR file, or stripped tag)
+//
+// We deliberately don't fall back to "scan every frame" — for a long
+// audiobook that's tens of MB of I/O on every ingest. Operators who
+// care can re-tag with a XING-aware encoder.
+func mp3Duration(f io.ReadSeeker) (int, bool) {
+	// Skip ID3v2 if present.
+	id3Hdr := make([]byte, 10)
+	if _, err := io.ReadFull(f, id3Hdr); err != nil {
+		return 0, false
+	}
+	if string(id3Hdr[:3]) == "ID3" {
+		// Synchsafe size at bytes 6..9 (each byte uses 7 bits).
+		size := int(id3Hdr[6]&0x7f)<<21 |
+			int(id3Hdr[7]&0x7f)<<14 |
+			int(id3Hdr[8]&0x7f)<<7 |
+			int(id3Hdr[9]&0x7f)
+		if _, err := f.Seek(int64(size), io.SeekCurrent); err != nil {
+			return 0, false
+		}
+	} else {
+		if _, err := f.Seek(0, io.SeekStart); err != nil {
+			return 0, false
+		}
+	}
+
+	// Read up to 4KB and scan for the next MPEG sync (0xFFE_).
+	scan := make([]byte, 4096)
+	n, _ := io.ReadFull(f, scan)
+	if n < 4 {
+		return 0, false
+	}
+	frameStart := -1
+	for i := 0; i+1 < n; i++ {
+		if scan[i] == 0xFF && (scan[i+1]&0xE0) == 0xE0 {
+			frameStart = i
+			break
+		}
+	}
+	if frameStart < 0 || frameStart+4 > n {
+		return 0, false
+	}
+
+	hdr := scan[frameStart : frameStart+4]
+	mpegVer := (hdr[1] >> 3) & 0x03 // 0=v2.5, 2=v2, 3=v1
+	layer := (hdr[1] >> 1) & 0x03   // 1=layer3
+	if mpegVer == 1 || layer != 1 { // reserved version, or non-layer-3
+		return 0, false
+	}
+	sampleRateIdx := (hdr[2] >> 2) & 0x03
+	if sampleRateIdx == 3 {
+		return 0, false
+	}
+	channelMode := (hdr[3] >> 6) & 0x03
+
+	// Sample rates by version.
+	var srTable [4]int
+	switch mpegVer {
+	case 3: // MPEG-1
+		srTable = [4]int{44100, 48000, 32000, 0}
+	case 2: // MPEG-2
+		srTable = [4]int{22050, 24000, 16000, 0}
+	case 0: // MPEG-2.5
+		srTable = [4]int{11025, 12000, 8000, 0}
+	}
+	sampleRate := srTable[sampleRateIdx]
+	if sampleRate == 0 {
+		return 0, false
+	}
+
+	// Samples per frame: MPEG-1 layer III = 1152, MPEG-2/2.5 layer III = 576.
+	samplesPerFrame := 1152
+	if mpegVer != 3 {
+		samplesPerFrame = 576
+	}
+
+	// XING / Info header offset within the frame depends on version + channel.
+	var xingOffset int
+	switch {
+	case mpegVer == 3 && channelMode == 3: // MPEG-1 mono
+		xingOffset = 4 + 17
+	case mpegVer == 3: // MPEG-1 stereo / joint / dual
+		xingOffset = 4 + 32
+	case channelMode == 3: // MPEG-2/2.5 mono
+		xingOffset = 4 + 9
+	default: // MPEG-2/2.5 stereo
+		xingOffset = 4 + 17
+	}
+
+	// Need at least frameStart + xingOffset + 8 bytes (tag + flags + frames).
+	end := frameStart + xingOffset + 8
+	if end > n {
+		return 0, false
+	}
+	tagBytes := scan[frameStart+xingOffset : frameStart+xingOffset+4]
+	if string(tagBytes) != "Xing" && string(tagBytes) != "Info" {
+		return 0, false
+	}
+	flags := binary.BigEndian.Uint32(scan[frameStart+xingOffset+4 : frameStart+xingOffset+8])
+	if flags&0x01 == 0 {
+		// "frames" field absent — can't compute duration without scanning.
+		return 0, false
+	}
+	if frameStart+xingOffset+12 > n {
+		return 0, false
+	}
+	totalFrames := binary.BigEndian.Uint32(scan[frameStart+xingOffset+8 : frameStart+xingOffset+12])
+	if totalFrames == 0 {
+		return 0, false
+	}
+	secs := int(int64(totalFrames) * int64(samplesPerFrame) / int64(sampleRate))
+	if secs <= 0 {
+		return 0, false
+	}
+	return secs, true
+}
+
+// ---------------------------------------------------------------------------
+// MP4 (M4B/M4A) duration via mvhd atom.
+// ---------------------------------------------------------------------------
+
+// mp4Duration walks the top-level atoms of an MP4 container looking for
+// moov.mvhd, then computes duration_seconds = mvhd.duration / mvhd.timescale.
+//
+// We only descend into the moov atom — that's where mvhd lives — so the
+// I/O cost is bounded to a few hundred KB even on multi-GB audiobooks.
+func mp4Duration(f io.ReadSeeker) (int, bool) {
+	const maxAtomSearch = 64 // safety: never walk past the first 64 atoms
+	r := io.ReadSeeker(f)
+	for atomCount := 0; atomCount < maxAtomSearch; atomCount++ {
+		size, name, ok := readAtomHeader(r)
+		if !ok {
+			return 0, false
+		}
+		switch name {
+		case "moov":
+			// Recurse into moov; size is the full atom size including the
+			// 8-byte header we already consumed. Pass size-8 as the body
+			// length so we know when to stop reading children.
+			return findMvhd(r, int64(size)-8)
+		case "mdat":
+			// Audiobook data — large. Skip.
+			fallthrough
+		default:
+			// Skip body; if size is 0 it means "to EOF" which means we
+			// won't find mvhd anyway.
+			if size <= 8 {
+				return 0, false
+			}
+			if _, err := r.Seek(int64(size)-8, io.SeekCurrent); err != nil {
+				return 0, false
+			}
+		}
+	}
+	return 0, false
+}
+
+// findMvhd walks one level of children inside the moov atom (bounded by
+// `body` bytes) looking for the mvhd atom. Returns duration in seconds
+// when found.
+func findMvhd(r io.ReadSeeker, body int64) (int, bool) {
+	for body > 8 {
+		size, name, ok := readAtomHeader(r)
+		if !ok {
+			return 0, false
+		}
+		body -= int64(size)
+		if name == "mvhd" {
+			// mvhd payload layout:
+			//   v=0: version(1) flags(3) created(4) modified(4) timescale(4) duration(4) ...
+			//   v=1: version(1) flags(3) created(8) modified(8) timescale(4) duration(8) ...
+			payload := make([]byte, size-8)
+			if _, err := io.ReadFull(r, payload); err != nil {
+				return 0, false
+			}
+			if len(payload) < 1 {
+				return 0, false
+			}
+			version := payload[0]
+			var timescale uint32
+			var duration uint64
+			switch version {
+			case 0:
+				if len(payload) < 4+4+4+4+4 {
+					return 0, false
+				}
+				timescale = binary.BigEndian.Uint32(payload[4+4+4 : 4+4+4+4])
+				duration = uint64(binary.BigEndian.Uint32(payload[4+4+4+4 : 4+4+4+4+4]))
+			case 1:
+				if len(payload) < 4+8+8+4+8 {
+					return 0, false
+				}
+				timescale = binary.BigEndian.Uint32(payload[4+8+8 : 4+8+8+4])
+				duration = binary.BigEndian.Uint64(payload[4+8+8+4 : 4+8+8+4+8])
+			default:
+				return 0, false
+			}
+			if timescale == 0 || duration == 0 {
+				return 0, false
+			}
+			secs := int(duration / uint64(timescale))
+			if secs <= 0 {
+				return 0, false
+			}
+			return secs, true
+		}
+		// Skip non-mvhd children.
+		if size <= 8 {
+			return 0, false
+		}
+		if _, err := r.Seek(int64(size)-8, io.SeekCurrent); err != nil {
+			return 0, false
+		}
+	}
+	return 0, false
+}
+
+// readAtomHeader reads an 8-byte MP4 atom header (size + 4-char type).
+// Returns false on EOF or short read. Doesn't handle extended 64-bit sizes
+// (size==1) — those are vanishingly rare in audiobooks.
+func readAtomHeader(r io.Reader) (size uint32, name string, ok bool) {
+	hdr := make([]byte, 8)
+	if _, err := io.ReadFull(r, hdr); err != nil {
+		if !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+			return 0, "", false
+		}
+		return 0, "", false
+	}
+	size = binary.BigEndian.Uint32(hdr[:4])
+	name = string(hdr[4:8])
+	return size, name, true
+}

--- a/internal/fileproc/cbz.go
+++ b/internal/fileproc/cbz.go
@@ -1,0 +1,257 @@
+package fileproc
+
+import (
+	"archive/zip"
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"path"
+	"sort"
+	"strings"
+)
+
+// CBZProcessor extracts metadata and cover image from a CBZ comic archive.
+//
+// CBZ is a ZIP of page images, sorted by filename. Some scene-released
+// archives also embed a `ComicInfo.xml` with series/issue/year/summary —
+// when present we surface those into the regular metadata fields so the
+// library UI shows useful info without manual enrichment.
+//
+// Cover = the first page after natural sort, OR a file matching `cover.*`
+// at the archive root if present.
+type CBZProcessor struct{}
+
+type comicInfoXML struct {
+	XMLName     xml.Name `xml:"ComicInfo"`
+	Title       string   `xml:"Title"`
+	Series      string   `xml:"Series"`
+	Number      string   `xml:"Number"`
+	Year        string   `xml:"Year"`
+	Summary     string   `xml:"Summary"`
+	Writer      string   `xml:"Writer"`
+	Penciller   string   `xml:"Penciller"`
+	Inker       string   `xml:"Inker"`
+	Colorist    string   `xml:"Colorist"`
+	LanguageISO string   `xml:"LanguageISO"`
+	PageCount   string   `xml:"PageCount"`
+}
+
+func (CBZProcessor) Extract(ctx context.Context, filePath string) (Metadata, error) {
+	_ = ctx
+
+	zr, err := zip.OpenReader(filePath)
+	if err != nil {
+		return Metadata{}, fmt.Errorf("open cbz: %w", err)
+	}
+	defer func() { _ = zr.Close() }()
+
+	pages := comicPages(&zr.Reader)
+	if len(pages) == 0 {
+		return Metadata{}, fmt.Errorf("cbz contains no images")
+	}
+
+	m := Metadata{Format: "CBZ"}
+
+	// ComicInfo.xml is optional. Match case-insensitively because some
+	// authoring tools save as `comicinfo.xml`.
+	for _, f := range zr.File {
+		base := strings.ToLower(path.Base(f.Name))
+		if base != "comicinfo.xml" {
+			continue
+		}
+		if b, err := readZipFile(&zr.Reader, f.Name); err == nil {
+			var info comicInfoXML
+			if xml.Unmarshal(b, &info) == nil {
+				applyComicInfo(&m, info)
+			}
+		}
+		break
+	}
+
+	// Cover: prefer a top-level `cover.*` if present, otherwise first
+	// page after natural sort.
+	coverName := preferredCoverName(&zr.Reader)
+	if coverName == "" {
+		coverName = pages[0]
+	}
+	if b, err := readZipFile(&zr.Reader, coverName); err == nil {
+		m.HasCover = true
+		m.CoverBytes = b
+		m.CoverMime = mimeFromExt(path.Ext(coverName))
+	}
+
+	return m, nil
+}
+
+func applyComicInfo(m *Metadata, info comicInfoXML) {
+	title := strings.TrimSpace(info.Title)
+	series := strings.TrimSpace(info.Series)
+	number := strings.TrimSpace(info.Number)
+	switch {
+	case title != "":
+		m.Title = title
+	case series != "" && number != "":
+		m.Title = fmt.Sprintf("%s #%s", series, number)
+	case series != "":
+		m.Title = series
+	}
+	// "Writer" is the closest to "author" for comics; fall back to penciller.
+	if w := strings.TrimSpace(info.Writer); w != "" {
+		m.Author = w
+	} else if p := strings.TrimSpace(info.Penciller); p != "" {
+		m.Author = p
+	}
+	if s := strings.TrimSpace(info.Summary); s != "" {
+		m.Description = s
+	}
+	if l := strings.TrimSpace(info.LanguageISO); l != "" {
+		m.Language = l
+	}
+}
+
+// comicPages returns a naturally-sorted list of image entry names inside
+// the archive. ComicInfo.xml and other non-image entries are filtered out.
+func comicPages(zr *zip.Reader) []string {
+	var pages []string
+	for _, f := range zr.File {
+		if f.FileInfo().IsDir() {
+			continue
+		}
+		if !isImageExt(path.Ext(f.Name)) {
+			continue
+		}
+		pages = append(pages, f.Name)
+	}
+	sort.Slice(pages, func(i, j int) bool {
+		return naturalLess(pages[i], pages[j])
+	})
+	return pages
+}
+
+// preferredCoverName returns the archive entry name for a top-level
+// `cover.{jpg,jpeg,png,webp}` file, if present. Empty string otherwise.
+func preferredCoverName(zr *zip.Reader) string {
+	for _, f := range zr.File {
+		if f.FileInfo().IsDir() {
+			continue
+		}
+		base := strings.ToLower(path.Base(f.Name))
+		// Only a top-level file (no directory component) qualifies; we
+		// don't want to grab a chapter-internal "cover.jpg".
+		if path.Dir(f.Name) != "." && path.Dir(f.Name) != "" {
+			continue
+		}
+		switch base {
+		case "cover.jpg", "cover.jpeg", "cover.png", "cover.webp":
+			return f.Name
+		}
+	}
+	return ""
+}
+
+func isImageExt(ext string) bool {
+	switch strings.ToLower(ext) {
+	case ".jpg", ".jpeg", ".png", ".webp", ".gif":
+		return true
+	}
+	return false
+}
+
+// naturalLess compares two strings such that embedded numeric runs sort
+// numerically (so "page2.jpg" < "page10.jpg"). Falls back to byte order
+// outside of digit runs.
+func naturalLess(a, b string) bool {
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		ai, aj := a[i], b[j]
+		if isDigit(ai) && isDigit(aj) {
+			// Walk both digit runs and compare as integers (without
+			// converting — leading-zero-safe).
+			is, ie := i, i
+			for ie < len(a) && isDigit(a[ie]) {
+				ie++
+			}
+			js, je := j, j
+			for je < len(b) && isDigit(b[je]) {
+				je++
+			}
+			ar := stripLeadingZeros(a[is:ie])
+			br := stripLeadingZeros(b[js:je])
+			if len(ar) != len(br) {
+				return len(ar) < len(br)
+			}
+			if ar != br {
+				return ar < br
+			}
+			i, j = ie, je
+			continue
+		}
+		if ai != aj {
+			return ai < aj
+		}
+		i++
+		j++
+	}
+	return len(a) < len(b)
+}
+
+func isDigit(b byte) bool { return b >= '0' && b <= '9' }
+
+func stripLeadingZeros(s string) string {
+	for i := 0; i < len(s)-1; i++ {
+		if s[i] != '0' {
+			return s[i:]
+		}
+	}
+	if len(s) > 0 && s[len(s)-1] == '0' && len(s) > 1 {
+		return "0"
+	}
+	return s
+}
+
+// CBZPages opens the archive at filePath and returns the page entry names
+// in natural sort order. Used by the page-streaming handler so the reader
+// can resolve "page n" to a real archive entry without re-listing on every
+// request (callers are expected to cache the slice).
+func CBZPages(filePath string) ([]string, error) {
+	zr, err := zip.OpenReader(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("open cbz: %w", err)
+	}
+	defer func() { _ = zr.Close() }()
+	return comicPages(&zr.Reader), nil
+}
+
+// CBZPage opens the archive at filePath and copies the n-th page (0-indexed,
+// natural sort order) into w. Returns the resolved MIME type so the caller
+// can set the response Content-Type. Returns os.ErrNotExist (wrapped) when
+// n is out of range.
+func CBZPage(filePath string, n int, w io.Writer) (mime string, err error) {
+	zr, err := zip.OpenReader(filePath)
+	if err != nil {
+		return "", fmt.Errorf("open cbz: %w", err)
+	}
+	defer func() { _ = zr.Close() }()
+
+	pages := comicPages(&zr.Reader)
+	if n < 0 || n >= len(pages) {
+		return "", fmt.Errorf("page %d out of range (0..%d)", n, len(pages)-1)
+	}
+	name := pages[n]
+	for _, f := range zr.File {
+		if f.Name != name {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return "", fmt.Errorf("open page: %w", err)
+		}
+		defer func() { _ = rc.Close() }()
+		if _, err := io.Copy(w, rc); err != nil {
+			return "", fmt.Errorf("stream page: %w", err)
+		}
+		return mimeFromExt(path.Ext(name)), nil
+	}
+	return "", fmt.Errorf("page %d entry %q vanished", n, name)
+}

--- a/internal/fileproc/cbz_test.go
+++ b/internal/fileproc/cbz_test.go
@@ -1,0 +1,180 @@
+package fileproc
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNaturalLess(t *testing.T) {
+	cases := []struct {
+		a, b string
+		less bool
+	}{
+		{"page2.jpg", "page10.jpg", true},  // numeric run sorts numerically
+		{"page10.jpg", "page2.jpg", false}, // reverse
+		{"a.jpg", "b.jpg", true},           // pure lex
+		{"chapter1/p01.jpg", "chapter2/p01.jpg", true},
+		{"01.png", "10.png", true}, // zero-padded sequence sorts numerically
+	}
+	for _, tc := range cases {
+		if got := naturalLess(tc.a, tc.b); got != tc.less {
+			t.Errorf("naturalLess(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.less)
+		}
+	}
+}
+
+// fakePNG is the minimal 1x1 PNG signature + IHDR + IDAT + IEND. Just
+// enough that mimeFromExt is happy and the cover bytes round-trip.
+var fakePNG = []byte{
+	0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a,
+	0x00, 0x00, 0x00, 0x0d, 'I', 'H', 'D', 'R',
+	0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+	0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+	0x89,
+}
+
+func writeCBZ(t *testing.T, dir string, entries map[string][]byte) string {
+	t.Helper()
+	p := filepath.Join(dir, "test.cbz")
+	f, err := os.Create(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	zw := zip.NewWriter(f)
+	for name, body := range entries {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write(body); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestCBZExtract_BasicCover(t *testing.T) {
+	dir := t.TempDir()
+	cbz := writeCBZ(t, dir, map[string][]byte{
+		"page10.png": []byte("ten"),  // out-of-order: tests natural sort
+		"page2.png":  fakePNG,        // should win as cover (page 2 < page 10)
+		"notes.txt":  []byte("skip"), // non-image, ignored
+	})
+	meta, err := CBZProcessor{}.Extract(context.Background(), cbz)
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if meta.Format != "CBZ" {
+		t.Errorf("Format = %q, want CBZ", meta.Format)
+	}
+	if !meta.HasCover {
+		t.Fatal("expected HasCover")
+	}
+	if !bytes.Equal(meta.CoverBytes, fakePNG) {
+		t.Error("CoverBytes != page2.png — natural sort failed")
+	}
+	if meta.CoverMime != "image/png" {
+		t.Errorf("CoverMime = %q, want image/png", meta.CoverMime)
+	}
+}
+
+func TestCBZExtract_PreferredCover(t *testing.T) {
+	dir := t.TempDir()
+	cbz := writeCBZ(t, dir, map[string][]byte{
+		"01.png":    []byte("first-page"),
+		"cover.png": fakePNG, // should win over 01.png
+	})
+	meta, err := CBZProcessor{}.Extract(context.Background(), cbz)
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if !bytes.Equal(meta.CoverBytes, fakePNG) {
+		t.Error("CoverBytes != cover.png — preferred-cover lookup failed")
+	}
+}
+
+func TestCBZExtract_ComicInfo(t *testing.T) {
+	dir := t.TempDir()
+	info := []byte(`<?xml version="1.0"?>
+<ComicInfo>
+  <Series>Saga</Series>
+  <Number>1</Number>
+  <Writer>Brian K. Vaughan</Writer>
+  <Summary>Test summary.</Summary>
+  <LanguageISO>en</LanguageISO>
+</ComicInfo>`)
+	cbz := writeCBZ(t, dir, map[string][]byte{
+		"01.png":        fakePNG,
+		"ComicInfo.xml": info,
+	})
+	meta, err := CBZProcessor{}.Extract(context.Background(), cbz)
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if meta.Title != "Saga #1" {
+		t.Errorf("Title = %q, want %q", meta.Title, "Saga #1")
+	}
+	if meta.Author != "Brian K. Vaughan" {
+		t.Errorf("Author = %q", meta.Author)
+	}
+	if meta.Description != "Test summary." {
+		t.Errorf("Description = %q", meta.Description)
+	}
+	if meta.Language != "en" {
+		t.Errorf("Language = %q", meta.Language)
+	}
+}
+
+func TestCBZExtract_NoImagesFails(t *testing.T) {
+	dir := t.TempDir()
+	cbz := writeCBZ(t, dir, map[string][]byte{
+		"readme.txt": []byte("nothing here"),
+	})
+	if _, err := (CBZProcessor{}).Extract(context.Background(), cbz); err == nil {
+		t.Fatal("expected error for image-less archive")
+	}
+}
+
+func TestCBZPagesAndPage(t *testing.T) {
+	dir := t.TempDir()
+	cbz := writeCBZ(t, dir, map[string][]byte{
+		"03.png": []byte("three"),
+		"01.png": []byte("one"),
+		"02.png": []byte("two"),
+	})
+	pages, err := CBZPages(cbz)
+	if err != nil {
+		t.Fatalf("CBZPages: %v", err)
+	}
+	if len(pages) != 3 {
+		t.Fatalf("len(pages) = %d, want 3", len(pages))
+	}
+	if pages[0] != "01.png" || pages[2] != "03.png" {
+		t.Errorf("page order wrong: %v", pages)
+	}
+
+	var buf bytes.Buffer
+	mime, err := CBZPage(cbz, 1, &buf)
+	if err != nil {
+		t.Fatalf("CBZPage(1): %v", err)
+	}
+	if mime != "image/png" {
+		t.Errorf("mime = %q", mime)
+	}
+	if buf.String() != "two" {
+		t.Errorf("page 1 body = %q, want 'two'", buf.String())
+	}
+
+	if _, err := CBZPage(cbz, 99, io.Discard); err == nil {
+		t.Error("expected error for out-of-range page")
+	}
+}

--- a/internal/fileproc/processor.go
+++ b/internal/fileproc/processor.go
@@ -29,6 +29,13 @@ type Metadata struct {
 	// Format is the canonical format tag (EPUB, PDF, CBZ, ...). The caller
 	// uses this to populate books.format when approving.
 	Format string
+	// DurationSeconds is populated only for audio formats (MP3, M4B). nil
+	// when the processor couldn't determine a duration — the UI surfaces
+	// "—" rather than implying a misleading "0".
+	DurationSeconds *int
+	// Narrator is populated only for audio formats. Empty for everything
+	// else.
+	Narrator string
 }
 
 // Processor is the strategy interface implemented per file format.
@@ -47,7 +54,13 @@ func Dispatch(path string) (Processor, string, error) {
 		return &EPUBProcessor{}, "EPUB", nil
 	case ".pdf":
 		return &PDFProcessor{}, "PDF", nil
-	// TODO: cbz, cbr, mp3, m4b, azw3, mobi, fb2
+	case ".cbz":
+		return &CBZProcessor{}, "CBZ", nil
+	case ".mp3":
+		return &AudioProcessor{}, "MP3", nil
+	case ".m4a", ".m4b":
+		return &AudioProcessor{}, "M4B", nil
+	// TODO: cbr, azw3, mobi, fb2
 	default:
 		return nil, strings.ToUpper(strings.TrimPrefix(ext, ".")), ErrUnsupportedFormat
 	}
@@ -64,8 +77,10 @@ func FormatForExt(ext string) string {
 		return "PDF"
 	case "cbz", "cbr", "cb7":
 		return "CBZ"
-	case "mp3", "m4a", "m4b":
+	case "mp3":
 		return "MP3"
+	case "m4a", "m4b":
+		return "M4B"
 	case "mobi":
 		return "MOBI"
 	case "azw3":

--- a/internal/handler/comic.go
+++ b/internal/handler/comic.go
@@ -1,0 +1,154 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/blackforge/embookshelf/internal/fileproc"
+	"github.com/blackforge/embookshelf/internal/repo"
+)
+
+// ComicPagesIndex returns the page count for a CBZ book. The reader uses
+// this to size its navigation UI before requesting individual pages.
+//
+// Response: {"count": 142}
+func (h *Handler) ComicPagesIndex(c *gin.Context) {
+	userID := requireUserID(c)
+	if userID == "" {
+		return
+	}
+	id := c.Param("id")
+	book, err := h.lib.GetBook(c.Request.Context(), userID, id)
+	if err != nil {
+		if errors.Is(err, repo.ErrNotFound) {
+			writeError(c, http.StatusNotFound, "book not found")
+			return
+		}
+		writeServerError(c, "comic pages lookup", err)
+		return
+	}
+	if book.Format != "CBZ" {
+		writeError(c, http.StatusUnsupportedMediaType, "not a comic book")
+		return
+	}
+	if book.Path == "" {
+		writeError(c, http.StatusNotFound, "no file on disk for this book")
+		return
+	}
+	if err := h.assertPathAllowed(c, book.Path); err != nil {
+		writeError(c, http.StatusForbidden, err.Error())
+		return
+	}
+	pages, err := fileproc.CBZPages(book.Path)
+	if err != nil {
+		writeServerError(c, "list comic pages", err)
+		return
+	}
+	c.Header("Cache-Control", "private, max-age=3600")
+	c.JSON(http.StatusOK, gin.H{"count": len(pages)})
+}
+
+// ComicPage streams a single page (image bytes) from a CBZ archive.
+// Pages are 0-indexed in natural sort order (page2.jpg before page10.jpg).
+func (h *Handler) ComicPage(c *gin.Context) {
+	userID := requireUserID(c)
+	if userID == "" {
+		return
+	}
+	id := c.Param("id")
+	nStr := strings.TrimSpace(c.Param("n"))
+	n, err := strconv.Atoi(nStr)
+	if err != nil || n < 0 {
+		writeError(c, http.StatusBadRequest, "invalid page number")
+		return
+	}
+	book, err := h.lib.GetBook(c.Request.Context(), userID, id)
+	if err != nil {
+		if errors.Is(err, repo.ErrNotFound) {
+			writeError(c, http.StatusNotFound, "book not found")
+			return
+		}
+		writeServerError(c, "comic page lookup", err)
+		return
+	}
+	if book.Format != "CBZ" {
+		writeError(c, http.StatusUnsupportedMediaType, "not a comic book")
+		return
+	}
+	if book.Path == "" {
+		writeError(c, http.StatusNotFound, "no file on disk for this book")
+		return
+	}
+	if err := h.assertPathAllowed(c, book.Path); err != nil {
+		writeError(c, http.StatusForbidden, err.Error())
+		return
+	}
+
+	// Long cache: page bytes within an archive are immutable for the
+	// life of the underlying file. ETag would be more correct but the
+	// content rarely changes — a 1-day private cache is plenty.
+	c.Header("Cache-Control", "private, max-age=86400, immutable")
+
+	// We can't know the MIME type without opening the archive once.
+	// CBZPage handles that and writes directly into the response body.
+	mime, err := fileproc.CBZPage(book.Path, n, c.Writer)
+	if err != nil {
+		// Headers may already be on the wire if the archive opened but
+		// the entry was bad mid-stream. We do our best to surface a
+		// clean error before any body bytes were written.
+		if c.Writer.Written() {
+			writeServerError(c, "stream comic page", err)
+			return
+		}
+		writeError(c, http.StatusNotFound, err.Error())
+		return
+	}
+	if !c.Writer.Written() {
+		// Belt-and-suspenders: if Copy wrote zero bytes (empty entry),
+		// still set the type so the browser knows what it got.
+		c.Header("Content-Type", mime)
+	}
+}
+
+// assertPathAllowed runs the same sandbox check serveBookFile uses, but
+// without writing to the response. Returns nil when path is rooted under
+// BOOKDROP_PATH or any registered library_path.
+func (h *Handler) assertPathAllowed(c *gin.Context, p string) error {
+	absPath, err := filepath.Abs(p)
+	if err != nil {
+		return errors.New("bad path")
+	}
+	roots := []string{}
+	if h.cfg.BookDropPath != "" {
+		if r, err := filepath.Abs(h.cfg.BookDropPath); err == nil {
+			roots = append(roots, r)
+		}
+	}
+	if h.lib != nil {
+		if libs, err := h.lib.List(c.Request.Context()); err == nil {
+			for _, l := range libs {
+				if l.Path == "" {
+					continue
+				}
+				if r, err := filepath.Abs(l.Path); err == nil {
+					roots = append(roots, r)
+				}
+			}
+		}
+	}
+	if len(roots) == 0 {
+		return errors.New("no allowed roots configured")
+	}
+	sep := string(filepath.Separator)
+	for _, root := range roots {
+		if absPath == root || strings.HasPrefix(absPath, root+sep) {
+			return nil
+		}
+	}
+	return errors.New("path outside allowed roots")
+}

--- a/internal/handler/files.go
+++ b/internal/handler/files.go
@@ -17,6 +17,13 @@ func mimeForFormat(format string) string {
 		return "application/epub+zip"
 	case "PDF":
 		return "application/pdf"
+	case "CBZ":
+		return "application/vnd.comicbook+zip"
+	case "MP3":
+		return "audio/mpeg"
+	case "M4B":
+		// Apple uses audio/mp4; the m4b container is identical to m4a.
+		return "audio/mp4"
 	}
 	return ""
 }

--- a/internal/handler/library.go
+++ b/internal/handler/library.go
@@ -80,9 +80,22 @@ type bookDTO struct {
 	HasCover      bool     `json:"hasCover"`
 	CoverMime     string   `json:"coverMime,omitempty"`
 	AddedAt       string   `json:"addedAt"`
+	// DurationSeconds is populated only for audio formats (MP3, M4B);
+	// nil otherwise (omitted from the JSON via *int + omitempty).
+	DurationSeconds *int         `json:"durationSeconds,omitempty"`
+	Narrator        string       `json:"narrator,omitempty"`
+	Chapters        []chapterDTO `json:"chapters,omitempty"`
 	// Locks is a sparse map — only fields currently locked appear, so
 	// unlocked books keep the payload small. Keys match model.LockFields.
 	Locks map[string]bool `json:"locks,omitempty"`
+}
+
+// chapterDTO mirrors model.Chapter on the wire — keeps the JSON shape
+// camel-case for the TypeScript client.
+type chapterDTO struct {
+	Title  string  `json:"title"`
+	StartS float64 `json:"startS"`
+	EndS   float64 `json:"endS"`
 }
 
 func toBookDTO(b model.Book) bookDTO {
@@ -103,38 +116,52 @@ func toBookDTO(b model.Book) bookDTO {
 		publishDate = b.PublishDate.UTC().Format("2006-01-02")
 	}
 	return bookDTO{
-		ID:            b.ID,
-		LibraryID:     b.LibraryID,
-		Title:         b.Title,
-		Subtitle:      b.Subtitle,
-		Author:        b.Author,
-		Format:        b.Format,
-		Year:          b.Year,
-		PublishDate:   publishDate,
-		Language:      b.Language,
-		Progress:      float64(b.Progress) / 100.0,
-		ResumeCFI:     b.ResumeCFI,
-		Rating:        b.Rating,
-		Palette:       firstNonEmpty(b.CoverPalette, "navy"),
-		Description:   b.Description,
-		ISBN:          b.ISBN,
-		ISBN10:        b.ISBN10,
-		Publisher:     b.Publisher,
-		Series:        b.Series,
-		SeriesNum:     b.SeriesIndex,
-		SeriesTotal:   b.SeriesTotal,
-		Genres:        genres,
-		Moods:         moods,
-		Tags:          tags,
-		AgeRating:     b.AgeRating,
-		ContentRating: b.ContentRating,
-		Pages:         b.Pages,
-		PublicReviews: b.PublicReviews,
-		HasCover:      b.HasCover,
-		CoverMime:     b.CoverMime,
-		AddedAt:       b.CreatedAt.UTC().Format(time.RFC3339),
-		Locks:         serializeLocks(b.Locks),
+		ID:              b.ID,
+		LibraryID:       b.LibraryID,
+		Title:           b.Title,
+		Subtitle:        b.Subtitle,
+		Author:          b.Author,
+		Format:          b.Format,
+		Year:            b.Year,
+		PublishDate:     publishDate,
+		Language:        b.Language,
+		Progress:        float64(b.Progress) / 100.0,
+		ResumeCFI:       b.ResumeCFI,
+		Rating:          b.Rating,
+		Palette:         firstNonEmpty(b.CoverPalette, "navy"),
+		Description:     b.Description,
+		ISBN:            b.ISBN,
+		ISBN10:          b.ISBN10,
+		Publisher:       b.Publisher,
+		Series:          b.Series,
+		SeriesNum:       b.SeriesIndex,
+		SeriesTotal:     b.SeriesTotal,
+		Genres:          genres,
+		Moods:           moods,
+		Tags:            tags,
+		AgeRating:       b.AgeRating,
+		ContentRating:   b.ContentRating,
+		Pages:           b.Pages,
+		PublicReviews:   b.PublicReviews,
+		HasCover:        b.HasCover,
+		CoverMime:       b.CoverMime,
+		AddedAt:         b.CreatedAt.UTC().Format(time.RFC3339),
+		DurationSeconds: b.DurationSeconds,
+		Narrator:        b.Narrator,
+		Chapters:        chaptersToDTO(b.Chapters),
+		Locks:           serializeLocks(b.Locks),
 	}
+}
+
+func chaptersToDTO(in []model.Chapter) []chapterDTO {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]chapterDTO, len(in))
+	for i, c := range in {
+		out[i] = chapterDTO{Title: c.Title, StartS: c.StartS, EndS: c.EndS}
+	}
+	return out
 }
 
 // serializeLocks emits a sparse map of just the set flags. nil when

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -72,6 +72,8 @@ func (h *Handler) Engine() *gin.Engine {
 			authed.GET("/books/:id", h.BookDetail)
 			authed.GET("/books/:id/cover", h.BookCover)
 			authed.GET("/books/:id/file", h.BookFile)
+			authed.GET("/books/:id/pages", h.ComicPagesIndex)
+			authed.GET("/books/:id/pages/:n", h.ComicPage)
 			authed.PATCH("/books/:id", h.BookPatch)
 			authed.DELETE("/books/:id", auth.RequireRole(model.RoleAdmin), h.BookDelete)
 			authed.POST("/books/:id/progress", h.BookProgressUpdate)

--- a/internal/migrator/migrations/postgres/000024_audiobook_metadata.down.sql
+++ b/internal/migrator/migrations/postgres/000024_audiobook_metadata.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE books
+    DROP COLUMN IF EXISTS duration_seconds,
+    DROP COLUMN IF EXISTS narrator,
+    DROP COLUMN IF EXISTS chapters;

--- a/internal/migrator/migrations/postgres/000024_audiobook_metadata.up.sql
+++ b/internal/migrator/migrations/postgres/000024_audiobook_metadata.up.sql
@@ -1,0 +1,15 @@
+-- Audiobook metadata: duration, narrator, and chapter list.
+--
+-- Used by Phase 2 of the multi-format reader work (MP3 / M4B). Other
+-- formats leave these NULL — the reader only consults them when
+-- format = 'MP3'.
+--
+-- chapters is JSONB so the column can hold the canonical chapter shape
+-- ([{title, start_s, end_s}, ...]) without a join table; reader queries
+-- pull the whole document at once and the audiobook UI is the only
+-- consumer today.
+
+ALTER TABLE books
+    ADD COLUMN IF NOT EXISTS duration_seconds INTEGER,
+    ADD COLUMN IF NOT EXISTS narrator         TEXT NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS chapters         JSONB;

--- a/internal/migrator/migrations/sqlite/000024_audiobook_metadata.down.sql
+++ b/internal/migrator/migrations/sqlite/000024_audiobook_metadata.down.sql
@@ -1,0 +1,7 @@
+-- SQLite >= 3.35 supports DROP COLUMN; the targeted modernc.org/sqlite
+-- driver is well past that. The columns added in the up-migration are
+-- pure additions with no indexes, so dropping them is safe.
+
+ALTER TABLE books DROP COLUMN duration_seconds;
+ALTER TABLE books DROP COLUMN narrator;
+ALTER TABLE books DROP COLUMN chapters;

--- a/internal/migrator/migrations/sqlite/000024_audiobook_metadata.up.sql
+++ b/internal/migrator/migrations/sqlite/000024_audiobook_metadata.up.sql
@@ -1,0 +1,10 @@
+-- See postgres/000024_audiobook_metadata.up.sql.
+--
+-- SQLite type translations:
+--   INTEGER (nullable)  → INTEGER (no constraint added; NULL when not set)
+--   TEXT NOT NULL DEFAULT '' → TEXT NOT NULL DEFAULT ''
+--   JSONB (nullable)    → TEXT CHECK (col IS NULL OR json_valid(col))
+
+ALTER TABLE books ADD COLUMN duration_seconds INTEGER;
+ALTER TABLE books ADD COLUMN narrator         TEXT NOT NULL DEFAULT '';
+ALTER TABLE books ADD COLUMN chapters         TEXT CHECK (chapters IS NULL OR json_valid(chapters));

--- a/internal/model/book.go
+++ b/internal/model/book.go
@@ -70,10 +70,28 @@ type Book struct {
 	// ResumeCFI is the current user's last-known reading position (EPUB CFI).
 	// Empty when the user hasn't opened the reader yet.
 	ResumeCFI string
+	// Audiobook fields — populated for MP3 / M4B and left zero for other
+	// formats. DurationSeconds is nil when unknown (no MP3 frame header,
+	// no MP4 mvhd atom, or simply non-audio); the UI treats nil as "—".
+	DurationSeconds *int
+	Narrator        string
+	// Chapters is the audiobook chapter list (or EPUB TOC, future use).
+	// Stored as a JSON document on disk; nil means "no chapter data".
+	Chapters []Chapter
 	// Locks pins individual metadata fields against automatic overwrite.
 	// The apply-metadata flow consults each flag before copying a
 	// candidate value over the stored one; manual PATCHes always write.
 	Locks BookLocks
+}
+
+// Chapter is one entry in the audiobook chapter list. Times are in
+// seconds (float so we can preserve sub-second M4B metadata without
+// quantization). Title is non-empty; an "Untitled chapter N" fallback
+// is the processor's job, not the model's.
+type Chapter struct {
+	Title  string  `json:"title"`
+	StartS float64 `json:"start_s"`
+	EndS   float64 `json:"end_s"`
 }
 
 // BookLocks is the per-field lock set for a book. Each flag corresponds

--- a/internal/repo/library.go
+++ b/internal/repo/library.go
@@ -3,6 +3,7 @@ package repo
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -33,7 +34,8 @@ const bookCols = `
 	b.description_locked, b.publisher_locked, b.series_locked,
 	b.isbn_locked, b.isbn10_locked, b.language_locked,
 	b.publish_date_locked, b.genres_locked, b.moods_locked,
-	b.tags_locked, b.pages_locked, b.cover_locked
+	b.tags_locked, b.pages_locked, b.cover_locked,
+	b.duration_seconds, b.narrator, b.chapters
 `
 
 // bookFromPG is the FROM + LEFT JOIN clause for Postgres queries, where
@@ -476,7 +478,8 @@ func (r *LibraryRepo) Create(ctx context.Context, b model.Book) (model.Book, err
 		       b.description_locked, b.publisher_locked, b.series_locked,
 		       b.isbn_locked, b.isbn10_locked, b.language_locked,
 		       b.publish_date_locked, b.genres_locked, b.moods_locked,
-		       b.tags_locked, b.pages_locked, b.cover_locked
+		       b.tags_locked, b.pages_locked, b.cover_locked,
+		       b.duration_seconds, b.narrator, b.chapters
 		FROM inserted b
 	`
 
@@ -510,7 +513,8 @@ func (r *LibraryRepo) Create(ctx context.Context, b model.Book) (model.Book, err
 		    description_locked, publisher_locked, series_locked,
 		    isbn_locked, isbn10_locked, language_locked,
 		    publish_date_locked, genres_locked, moods_locked,
-		    tags_locked, pages_locked, cover_locked
+		    tags_locked, pages_locked, cover_locked,
+		    duration_seconds, narrator, chapters
 	`
 
 	row := r.db.SQL.QueryRowContext(ctx, db.SelectQ(r.db.Dialect, qPG, qSQLite), args...)
@@ -766,6 +770,64 @@ func (r *LibraryRepo) UpdateMetadata(ctx context.Context, b model.Book) error {
 	return nil
 }
 
+// UpdateAudio writes the audiobook-specific metadata fields onto an
+// existing books row. Used right after Create() in the bookdrop Approve
+// flow for MP3/M4B imports — those fields aren't part of the bookdrop
+// review surface, so it's cheaper to re-extract on approval than to
+// schema-bloat bookdrop_items.
+//
+// chapters is JSON-encoded into TEXT (SQLite) / JSONB (PG). Passing
+// a nil slice writes SQL NULL so the UI can distinguish "no chapter
+// metadata" from "empty chapter list".
+func (r *LibraryRepo) UpdateAudio(
+	ctx context.Context,
+	id string,
+	durationSeconds *int,
+	narrator string,
+	chapters []model.Chapter,
+) error {
+	var chaptersVal any
+	if chapters != nil {
+		b, err := json.Marshal(chapters)
+		if err != nil {
+			return fmt.Errorf("encode chapters: %w", err)
+		}
+		chaptersVal = string(b)
+	}
+
+	const qPG = `
+		UPDATE books SET
+			duration_seconds = $1,
+			narrator         = $2,
+			chapters         = $3,
+			updated_at       = now()
+		WHERE id = $4 AND deleted_at IS NULL
+	`
+	const qSQLite = `
+		UPDATE books SET
+			duration_seconds = ?,
+			narrator         = ?,
+			chapters         = ?,
+			updated_at       = (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+		WHERE id = ? AND deleted_at IS NULL
+	`
+	res, err := r.db.SQL.ExecContext(ctx,
+		db.SelectQ(r.db.Dialect, qPG, qSQLite),
+		durationSeconds, narrator, chaptersVal, id,
+	)
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 // scanner lets us reuse scanBook for both Row and Rows.
 type scanner interface {
 	Scan(dest ...any) error
@@ -774,6 +836,7 @@ type scanner interface {
 func scanBook(d db.Dialect, s scanner) (model.Book, error) {
 	var b model.Book
 	var genresAny, moodsAny, tagsAny, publishDateAny, createdAny any
+	var durationAny, chaptersAny any
 	err := s.Scan(
 		&b.ID, &b.LibraryID, &b.Title, &b.Subtitle, &b.Author, &b.Format, &b.Year,
 		&publishDateAny, &b.Language,
@@ -790,6 +853,7 @@ func scanBook(d db.Dialect, s scanner) (model.Book, error) {
 		&b.Locks.ISBN, &b.Locks.ISBN10, &b.Locks.Language,
 		&b.Locks.PublishDate, &b.Locks.Genres, &b.Locks.Moods,
 		&b.Locks.Tags, &b.Locks.Pages, &b.Locks.Cover,
+		&durationAny, &b.Narrator, &chaptersAny,
 	)
 	if err != nil {
 		return b, err
@@ -808,6 +872,27 @@ func scanBook(d db.Dialect, s scanner) (model.Book, error) {
 	}
 	if err := db.ScanStringSlice(d, tagsAny, &b.Tags); err != nil {
 		return b, fmt.Errorf("scan tags: %w", err)
+	}
+	if v, ok := durationAny.(int64); ok {
+		n := int(v)
+		b.DurationSeconds = &n
+	}
+	// chapters: TEXT JSON on SQLite, JSONB on PG (delivered as []byte or
+	// string by pgx stdlib). NULL → nil slice; non-NULL → JSON-decode.
+	if chaptersAny != nil {
+		var raw []byte
+		switch v := chaptersAny.(type) {
+		case []byte:
+			raw = v
+		case string:
+			raw = []byte(v)
+		}
+		if len(raw) > 0 {
+			var ch []model.Chapter
+			if err := json.Unmarshal(raw, &ch); err == nil && len(ch) > 0 {
+				b.Chapters = ch
+			}
+		}
 	}
 	return b, nil
 }

--- a/internal/service/bookdrop.go
+++ b/internal/service/bookdrop.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/blackforge/embookshelf/internal/coverstore"
+	"github.com/blackforge/embookshelf/internal/fileproc"
 	"github.com/blackforge/embookshelf/internal/model"
 	"github.com/blackforge/embookshelf/internal/pattern"
 	"github.com/blackforge/embookshelf/internal/repo"
@@ -172,11 +173,45 @@ func (s *BookDropService) Approve(ctx context.Context, id, libraryID string) (mo
 		}
 	}
 
+	// Audiobook metadata: re-extract duration / narrator / chapters off
+	// the file we just imported. The bookdrop schema doesn't carry audio
+	// fields (the review surface only shows title/author/cover), so the
+	// pragmatic option is one extra processor pass on approve. The cost
+	// is bounded — for a typical M4B it's a single mvhd atom read; for
+	// MP3 the XING header at the start of the file. Failure is logged
+	// but never fatal: the book still imports without duration.
+	if isAudioFormat(created.Format) && created.Path != "" {
+		if meta, err := (fileproc.AudioProcessor{}).Extract(ctx, created.Path); err == nil {
+			if err := s.libs.UpdateAudio(ctx, created.ID,
+				meta.DurationSeconds, meta.Narrator, nil,
+			); err != nil {
+				slog.Warn("update audio metadata", "book_id", created.ID, "err", err)
+			} else {
+				if meta.DurationSeconds != nil {
+					created.DurationSeconds = meta.DurationSeconds
+				}
+				created.Narrator = meta.Narrator
+			}
+		} else {
+			slog.Warn("re-extract audio metadata", "book_id", created.ID, "err", err)
+		}
+	}
+
 	if err := s.bdrop.MarkImported(ctx, item.ID, created.ID); err != nil {
 		return created, err
 	}
 	s.broadcast(item.ID)
 	return created, nil
+}
+
+// isAudioFormat reports whether a books.format value names an audio file
+// the AudioProcessor can extract metadata from.
+func isAudioFormat(f string) bool {
+	switch f {
+	case "MP3", "M4B":
+		return true
+	}
+	return false
 }
 
 // ClearProcessed drops every bookdrop row in a terminal state from the

--- a/ui/src/api/books.ts
+++ b/ui/src/api/books.ts
@@ -90,8 +90,21 @@ export type Book = {
   hasCover: boolean
   coverMime?: string
   addedAt: string
+  // Audiobook fields. durationSeconds is undefined for non-audio formats
+  // and may also be undefined for audio when the processor couldn't
+  // determine a duration (no XING header, no MP4 mvhd atom).
+  durationSeconds?: number
+  narrator?: string
+  chapters?: Array<Chapter>
   // Sparse map — only locked fields appear. Keys match LockField.
   locks?: Partial<Record<LockField, boolean>>
+}
+
+// Mirrors internal/handler/library.go chapterDTO. Times are seconds.
+export type Chapter = {
+  title: string
+  startS: number
+  endS: number
 }
 
 // Field keys accepted by PUT /books/:id/metadata/locks. Keep in sync
@@ -231,6 +244,18 @@ export async function updateProgress(
     method: "POST",
     body: JSON.stringify({ progress, resumeCfi }),
   })
+}
+
+// fetchComicPageCount returns the total page count for a CBZ book. The
+// reader needs this before it can size navigation; pages themselves are
+// fetched lazily as <img src="/api/v1/books/:id/pages/:n">.
+export async function fetchComicPageCount(id: string): Promise<number> {
+  const r = await api<{ count: number }>(`/api/v1/books/${id}/pages`)
+  return r.count
+}
+
+export function comicPageURL(id: string, page: number): string {
+  return `/api/v1/books/${id}/pages/${page}`
 }
 
 export async function addBookToShelf(

--- a/ui/src/components/AudioReader.tsx
+++ b/ui/src/components/AudioReader.tsx
@@ -1,0 +1,212 @@
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react"
+
+import type { Chapter } from "@/api/books"
+
+export type AudioProgress = {
+  percent: number // 0..1, normalized to duration
+  seconds: number // current playback position
+  duration: number // total duration in seconds (0 until metadata loads)
+}
+
+export type AudioReaderHandle = {
+  play: () => void
+  pause: () => void
+  toggle: () => void
+  seekTo: (seconds: number) => void
+  skip: (delta: number) => void
+  setRate: (rate: number) => void
+}
+
+type Props = {
+  url: string
+  initialSeconds?: number
+  initialRate?: number
+  chapters?: Array<Chapter>
+  // Book metadata for the OS-level Media Session UI (lockscreen,
+  // headphones, CarPlay-style integrations). All optional.
+  title?: string
+  author?: string
+  artworkURL?: string
+  onReady?: (meta: { duration: number }) => void
+  onProgress?: (p: AudioProgress) => void
+  onChapterChange?: (chapterIndex: number) => void
+  onError?: (err: unknown) => void
+}
+
+// AudioReader wraps an HTML5 <audio> element with the controls + Media
+// Session integration the audiobook reader shell needs. It deliberately
+// owns NO chrome (play/pause buttons, scrubber, chapter list) — the
+// shell composes those around it. The component emits progress events
+// every ~250 ms during playback so the shell's debounced persist matches
+// the cadence other readers use.
+export const AudioReader = forwardRef<AudioReaderHandle, Props>(
+  function AudioReaderImpl(
+    {
+      url,
+      initialSeconds,
+      initialRate = 1,
+      chapters,
+      title,
+      author,
+      artworkURL,
+      onReady,
+      onProgress,
+      onChapterChange,
+      onError,
+    },
+    ref
+  ) {
+    const audioRef = useRef<HTMLAudioElement | null>(null)
+    const [duration, setDuration] = useState(0)
+    const [chapterIndex, setChapterIndex] = useState(-1)
+    // Track the seek-to-initial step separately so an external seekTo() call
+    // on a freshly-mounted element doesn't fight the resume logic.
+    const initialApplied = useRef(false)
+    const onProgressRef = useRef(onProgress)
+    onProgressRef.current = onProgress
+    const onChapterChangeRef = useRef(onChapterChange)
+    onChapterChangeRef.current = onChapterChange
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        play: () => {
+          void audioRef.current?.play().catch((err) => onError?.(err))
+        },
+        pause: () => audioRef.current?.pause(),
+        toggle: () => {
+          const a = audioRef.current
+          if (!a) return
+          if (a.paused) void a.play().catch((err) => onError?.(err))
+          else a.pause()
+        },
+        seekTo: (seconds: number) => {
+          const a = audioRef.current
+          if (!a) return
+          const clamped = Math.max(0, Math.min(duration || a.duration || 0, seconds))
+          a.currentTime = clamped
+        },
+        skip: (delta: number) => {
+          const a = audioRef.current
+          if (!a) return
+          a.currentTime = Math.max(
+            0,
+            Math.min(duration || a.duration || 0, a.currentTime + delta)
+          )
+        },
+        setRate: (rate: number) => {
+          const a = audioRef.current
+          if (!a) return
+          a.playbackRate = rate
+        },
+      }),
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [duration]
+    )
+
+    // Set up Media Session metadata once we know the title/author. The
+    // browser drops the metadata when the audio element pauses for too
+    // long, but it'll re-pick-up on the next play().
+    useEffect(() => {
+      if (!("mediaSession" in navigator)) return
+      const ms = navigator.mediaSession
+      try {
+        ms.metadata = new MediaMetadata({
+          title: title ?? "",
+          artist: author ?? "",
+          album: title ?? "",
+          artwork: artworkURL
+            ? [{ src: artworkURL, sizes: "512x512", type: "image/jpeg" }]
+            : [],
+        })
+        ms.setActionHandler("play", () => audioRef.current?.play())
+        ms.setActionHandler("pause", () => audioRef.current?.pause())
+        ms.setActionHandler("seekbackward", (e) => {
+          const a = audioRef.current
+          if (!a) return
+          a.currentTime = Math.max(0, a.currentTime - (e.seekOffset ?? 15))
+        })
+        ms.setActionHandler("seekforward", (e) => {
+          const a = audioRef.current
+          if (!a) return
+          a.currentTime = Math.min(
+            a.duration || 0,
+            a.currentTime + (e.seekOffset ?? 30)
+          )
+        })
+      } catch {
+        // Older browsers without all action handlers — fail open.
+      }
+    }, [title, author, artworkURL])
+
+    // Reset when the URL changes (e.g. switching audiobooks within the
+    // same shell mount).
+    useEffect(() => {
+      setDuration(0)
+      setChapterIndex(-1)
+      initialApplied.current = false
+    }, [url])
+
+    return (
+      <audio
+        ref={audioRef}
+        src={url}
+        preload="metadata"
+        playsInline
+        // crossOrigin not needed — the file endpoint is same-origin via
+        // the Vite proxy in dev and the embedded SPA in prod.
+        onLoadedMetadata={(e) => {
+          const a = e.currentTarget
+          const d = Number.isFinite(a.duration) ? a.duration : 0
+          setDuration(d)
+          onReady?.({ duration: d })
+          if (initialRate !== 1) a.playbackRate = initialRate
+          if (
+            !initialApplied.current &&
+            initialSeconds !== undefined &&
+            initialSeconds > 0 &&
+            initialSeconds < d
+          ) {
+            a.currentTime = initialSeconds
+          }
+          initialApplied.current = true
+        }}
+        onTimeUpdate={(e) => {
+          const a = e.currentTarget
+          if (!a.duration || !Number.isFinite(a.duration)) return
+          const seconds = a.currentTime
+          const percent = a.duration > 0 ? seconds / a.duration : 0
+          onProgressRef.current?.({
+            seconds,
+            duration: a.duration,
+            percent,
+          })
+          // Compute current chapter purely client-side. Chapters are a
+          // sorted list — a small linear scan is fine; a binary search
+          // would optimize past 50+ chapters but no audiobook has that.
+          if (chapters && chapters.length > 0) {
+            let idx = -1
+            for (let i = 0; i < chapters.length; i++) {
+              const c = chapters[i]
+              if (!c) break
+              if (seconds >= c.startS) idx = i
+              else break
+            }
+            if (idx !== chapterIndex) {
+              setChapterIndex(idx)
+              onChapterChangeRef.current?.(idx)
+            }
+          }
+        }}
+        onError={(e) => onError?.(new Error(`Audio error: ${e.type}`))}
+        style={{ display: "none" }}
+      />
+    )
+  }
+)

--- a/ui/src/components/ComicReader.tsx
+++ b/ui/src/components/ComicReader.tsx
@@ -1,0 +1,279 @@
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
+
+import { comicPageURL, fetchComicPageCount } from "@/api/books"
+
+export type ComicProgress = {
+  percent: number // 0..1
+  page: number // 0-indexed
+  totalPages: number
+}
+
+export type ComicReaderHandle = {
+  next: () => void
+  prev: () => void
+  goTo: (page: number) => void
+}
+
+export type ComicFitMode = "width" | "height" | "page"
+
+type Props = {
+  bookId: string
+  initialPage?: number // 0-indexed
+  fitMode?: ComicFitMode
+  onReady?: (meta: { totalPages: number }) => void
+  onProgress?: (p: ComicProgress) => void
+  onError?: (err: unknown) => void
+}
+
+// ComicReader displays one page of a CBZ archive at a time. Pages are
+// served lazily by the backend as image bytes from a streaming endpoint;
+// we preload n+1 (and a tiny window backwards) so a normal page-turn is
+// instant while not paying memory for the whole book up front.
+//
+// Progress = current page / (total - 1). Persisted as `page:N` (0-indexed)
+// to mirror PDF's existing scheme.
+export const ComicReader = forwardRef<ComicReaderHandle, Props>(
+  function ComicReaderImpl(
+    { bookId, initialPage, fitMode = "page", onReady, onProgress, onError },
+    ref
+  ) {
+    const [total, setTotal] = useState<number | null>(null)
+    const [page, setPage] = useState<number>(Math.max(0, initialPage ?? 0))
+    const [loaded, setLoaded] = useState(false)
+    const onProgressRef = useRef(onProgress)
+    onProgressRef.current = onProgress
+
+    // One-shot load of the page count.
+    useEffect(() => {
+      let cancelled = false as boolean
+      ;(async () => {
+        try {
+          const count = await fetchComicPageCount(bookId)
+          if (cancelled) return
+          setTotal(count)
+          onReady?.({ totalPages: count })
+        } catch (err) {
+          if (!cancelled) onError?.(err)
+        }
+      })()
+      return () => {
+        cancelled = true
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [bookId])
+
+    // Clamp page once total is known. Initial page may have been beyond
+    // a now-shorter archive (rare, but possible after a re-import).
+    useEffect(() => {
+      if (total === null) return
+      const clamped = Math.max(0, Math.min(total - 1, page))
+      if (clamped !== page) setPage(clamped)
+      // Emit initial progress once we know the page is valid.
+      if (total > 0) {
+        onProgressRef.current?.({
+          page: clamped,
+          totalPages: total,
+          percent: total <= 1 ? 1 : clamped / (total - 1),
+        })
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [total])
+
+    const setAndEmit = (next: number) => {
+      if (total === null) return
+      const clamped = Math.max(0, Math.min(total - 1, next))
+      if (clamped === page) return
+      setPage(clamped)
+      setLoaded(false)
+      onProgressRef.current?.({
+        page: clamped,
+        totalPages: total,
+        percent: total <= 1 ? 1 : clamped / (total - 1),
+      })
+    }
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        next: () => setAndEmit(page + 1),
+        prev: () => setAndEmit(page - 1),
+        goTo: (n: number) => setAndEmit(n),
+      }),
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [page, total]
+    )
+
+    // Keyboard navigation: arrows, space, page-up/down. Bound on window so
+    // it works even when the focus is on a button in the chrome.
+    useEffect(() => {
+      const onKey = (e: KeyboardEvent) => {
+        if (e.target instanceof HTMLInputElement) return
+        switch (e.key) {
+          case "ArrowRight":
+          case "PageDown":
+          case " ":
+            e.preventDefault()
+            setAndEmit(page + 1)
+            break
+          case "ArrowLeft":
+          case "PageUp":
+            e.preventDefault()
+            setAndEmit(page - 1)
+            break
+          case "Home":
+            e.preventDefault()
+            setAndEmit(0)
+            break
+          case "End":
+            e.preventDefault()
+            if (total !== null) setAndEmit(total - 1)
+            break
+        }
+      }
+      window.addEventListener("keydown", onKey)
+      return () => window.removeEventListener("keydown", onKey)
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [page, total])
+
+    // Preload neighbors. Browsers cache the GET responses, so subsequent
+    // navigations to recently-seen pages are instant. We don't preload an
+    // unbounded window — just ±2 around the current page.
+    const preloadURLs = useMemo(() => {
+      if (total === null) return []
+      const out: Array<string> = []
+      for (let d = 1; d <= 2; d++) {
+        if (page + d < total) out.push(comicPageURL(bookId, page + d))
+        if (page - d >= 0) out.push(comicPageURL(bookId, page - d))
+      }
+      return out
+    }, [bookId, page, total])
+
+    // Fit-mode CSS shape. "page" = whichever axis fills first; "width"
+    // and "height" are explicit overrides for tall vs wide layouts.
+    const imgStyle = useMemo<React.CSSProperties>(() => {
+      switch (fitMode) {
+        case "width":
+          return { width: "100%", height: "auto", maxWidth: "100%" }
+        case "height":
+          return { height: "100%", width: "auto", maxHeight: "100%" }
+        default:
+          return {
+            maxWidth: "100%",
+            maxHeight: "100%",
+            width: "auto",
+            height: "auto",
+          }
+      }
+    }, [fitMode])
+
+    return (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          background: "var(--color-paper-2)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          position: "relative",
+          overflow: "hidden",
+          userSelect: "none",
+        }}
+      >
+        {total === null && (
+          <div className="t-small" style={{ fontStyle: "italic" }}>
+            Loading comic…
+          </div>
+        )}
+        {total !== null && total === 0 && (
+          <div className="t-small" style={{ fontStyle: "italic" }}>
+            This archive contains no pages.
+          </div>
+        )}
+        {total !== null && total > 0 && (
+          <>
+            {/* Click-to-navigate zones. Left half = prev, right half = next.
+                Sits behind the image so the image still receives layout. */}
+            <button
+              aria-label="Previous page"
+              onClick={() => setAndEmit(page - 1)}
+              style={{
+                position: "absolute",
+                left: 0,
+                top: 0,
+                width: "30%",
+                height: "100%",
+                background: "transparent",
+                border: "none",
+                cursor: "w-resize",
+                zIndex: 1,
+              }}
+            />
+            <button
+              aria-label="Next page"
+              onClick={() => setAndEmit(page + 1)}
+              style={{
+                position: "absolute",
+                right: 0,
+                top: 0,
+                width: "30%",
+                height: "100%",
+                background: "transparent",
+                border: "none",
+                cursor: "e-resize",
+                zIndex: 1,
+              }}
+            />
+            <img
+              key={page}
+              src={comicPageURL(bookId, page)}
+              alt={`Page ${page + 1}`}
+              draggable={false}
+              onLoad={() => setLoaded(true)}
+              onError={(e) => {
+                setLoaded(true)
+                onError?.(
+                  new Error(`Failed to load page ${page}: ${e.type}`)
+                )
+              }}
+              style={{
+                ...imgStyle,
+                objectFit: "contain",
+                opacity: loaded ? 1 : 0,
+                transition: "opacity 120ms ease",
+                boxShadow: "0 2px 12px oklch(0.2 0.02 60 / 0.25)",
+              }}
+            />
+            {!loaded && (
+              <div
+                className="t-small"
+                style={{
+                  position: "absolute",
+                  fontStyle: "italic",
+                  pointerEvents: "none",
+                }}
+              >
+                Loading page {page + 1}…
+              </div>
+            )}
+            {/* Hidden preloads. <link rel=preload> would be ideal but
+                only works at document level; an off-screen <img> is the
+                portable in-component equivalent. */}
+            <div style={{ position: "absolute", width: 0, height: 0, overflow: "hidden" }}>
+              {preloadURLs.map((u) => (
+                <img key={u} src={u} alt="" />
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    )
+  }
+)

--- a/ui/src/components/Icon.tsx
+++ b/ui/src/components/Icon.tsx
@@ -53,6 +53,8 @@ export type IconName =
   | "library"
   | "lock"
   | "unlock"
+  | "play"
+  | "pause"
 
 type Props = {
   name: IconName
@@ -362,6 +364,17 @@ function renderPath(name: IconName) {
         <>
           <rect x="5" y="11" width="14" height="9" rx="1" />
           <path d="M8 11V8a4 4 0 017.46-2" />
+        </>
+      )
+    case "play":
+      // Filled triangle reads better at the audiobook reader's prominent
+      // play button than a hollow stroke.
+      return <path d="M7 5l12 7-12 7V5z" fill="currentColor" stroke="none" />
+    case "pause":
+      return (
+        <>
+          <rect x="6" y="5" width="4" height="14" fill="currentColor" stroke="none" />
+          <rect x="14" y="5" width="4" height="14" fill="currentColor" stroke="none" />
         </>
       )
     default:

--- a/ui/src/routes/read.$id.tsx
+++ b/ui/src/routes/read.$id.tsx
@@ -7,6 +7,15 @@ import type { ApiError } from "@/api/client"
 import type { Annotation } from "@/api/annotations"
 import type { BookDetail } from "@/api/books"
 import type {
+  AudioProgress,
+  AudioReaderHandle,
+} from "@/components/AudioReader"
+import type {
+  ComicFitMode,
+  ComicProgress,
+  ComicReaderHandle,
+} from "@/components/ComicReader"
+import type {
   EpubHighlight,
   EpubProgress,
   EpubReaderHandle,
@@ -22,6 +31,8 @@ import {
   recentAnnotationsQueryKey,
 } from "@/api/annotations"
 import { bookQueryKey, fetchBook, updateProgress } from "@/api/books"
+import { AudioReader } from "@/components/AudioReader"
+import { ComicReader } from "@/components/ComicReader"
 import { EpubReader } from "@/components/EpubReader"
 import { Icon } from "@/components/Icon"
 import { PdfReader } from "@/components/PdfReader"
@@ -36,11 +47,19 @@ type TocItem = { label: string; href: string }
 // parseResumeToken separates the two resume-token shapes we store in the
 // database: raw CFI strings (EPUB) and page:N tokens (PDF). Unknown tokens
 // fall back to "start from the beginning".
-function parseResumeToken(raw?: string): { cfi?: string; page?: number } {
+function parseResumeToken(raw?: string): {
+  cfi?: string
+  page?: number
+  seconds?: number
+} {
   if (!raw) return {}
   if (raw.startsWith("page:")) {
     const page = Number.parseInt(raw.slice(5), 10)
     return Number.isFinite(page) ? { page } : {}
+  }
+  if (raw.startsWith("time:")) {
+    const seconds = Number.parseFloat(raw.slice(5))
+    return Number.isFinite(seconds) ? { seconds } : {}
   }
   return { cfi: raw }
 }
@@ -61,6 +80,12 @@ function Reader() {
     return <FullScreenMessage>Book not found.</FullScreenMessage>
   }
   const b = book.data
+  if (b.format === "CBZ") {
+    return <ComicReaderShell book={b} />
+  }
+  if (b.format === "MP3" || b.format === "M4B") {
+    return <AudioReaderShell book={b} />
+  }
   if (b.format !== "EPUB" && b.format !== "PDF") {
     return (
       <FullScreenMessage>
@@ -776,6 +801,691 @@ function ReaderShell({ book }: { book: BookDetail }) {
 
     </div>
   )
+}
+
+// ComicReaderShell is the chrome around a CBZ ComicReader. It's deliberately
+// a parallel implementation to ReaderShell rather than an extension: comics
+// have no TOC, no text selection / annotations flow, and use a 0-indexed
+// page model — folding all that into the existing shell would have made it
+// significantly harder to read. The two shells share the progress
+// debounce/persist pattern (queueProgress) but otherwise stand alone.
+function ComicReaderShell({ book }: { book: BookDetail }) {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+
+  // Initial page (0-indexed) parsed out of the same `page:N` token
+  // PDF readers persist; comics happen to also use 0-indexed pages
+  // internally so we re-use the parser without translation.
+  const initialPage = useMemo(() => {
+    const t = parseResumeToken(book.resumeCfi)
+    return typeof t.page === "number" ? Math.max(0, t.page) : 0
+  }, [book.resumeCfi])
+
+  const [chromeVisible, setChromeVisible] = useState(true)
+  const [fitMode, setFitMode] = useState<ComicFitMode>("page")
+  const [page, setPage] = useState<number>(initialPage)
+  const [total, setTotal] = useState<number>(0)
+  const comicRef = useRef<ComicReaderHandle>(null)
+
+  const progressMut = useMutation({
+    mutationFn: (args: { progress: number; resumeCfi: string }) =>
+      updateProgress(book.id, args.progress, args.resumeCfi),
+  })
+
+  const bookmarkMut = useMutation({
+    mutationFn: (locator: string) =>
+      createAnnotation(book.id, {
+        locator,
+        selectedText: `Bookmark · page ${page + 1}`,
+        color: "bookmark",
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: bookAnnotationsQueryKey(book.id),
+      })
+      queryClient.invalidateQueries({ queryKey: recentAnnotationsQueryKey })
+      toast.success("Bookmark saved")
+    },
+    onError: (err) =>
+      toast.error((err as unknown as ApiError).message || "Bookmark failed"),
+  })
+
+  // Progress persistence: same debounce shape as ReaderShell so a quick
+  // session still records the last page on unmount.
+  const pendingRef = useRef<{ progress: number; resumeCfi: string } | null>(
+    null
+  )
+  const timerRef = useRef<number | null>(null)
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) window.clearTimeout(timerRef.current)
+      if (pendingRef.current) {
+        void updateProgress(
+          book.id,
+          pendingRef.current.progress,
+          pendingRef.current.resumeCfi
+        )
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const queueProgress = (progress: number, locator: string) => {
+    pendingRef.current = { progress, resumeCfi: locator }
+    if (timerRef.current) window.clearTimeout(timerRef.current)
+    timerRef.current = window.setTimeout(() => {
+      const snapshot = pendingRef.current
+      pendingRef.current = null
+      timerRef.current = null
+      if (snapshot) progressMut.mutate(snapshot)
+    }, 600)
+  }
+
+  const onComicProgress = (p: ComicProgress) => {
+    setPage(p.page)
+    setTotal(p.totalPages)
+    queueProgress(p.percent, `page:${p.page}`)
+  }
+
+  const exit = () => void navigate({ to: "/book/$id", params: { id: book.id } })
+  const percent = total <= 1 ? 1 : page / Math.max(1, total - 1)
+
+  return (
+    <div
+      className="fade-in"
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "var(--color-paper-2)",
+        zIndex: 200,
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      {chromeVisible && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+            padding: "10px 22px",
+            borderBottom: "1px solid var(--color-rule-soft)",
+            background: "var(--color-paper-1)",
+          }}
+        >
+          <Button variant="ghost" size="sm" onClick={exit}>
+            <Icon name="arrow-left" size={14} /> Library
+          </Button>
+          <div
+            style={{
+              flex: 1,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+            }}
+          >
+            <div style={{ fontSize: 13, fontWeight: 500, fontStyle: "italic" }}>
+              {book.title}
+            </div>
+            <div className="t-micro" style={{ fontSize: 10 }}>
+              {book.author} · p.{page + 1}
+              {total > 0 ? ` / p.${total}` : ""}
+            </div>
+          </div>
+          <div style={{ display: "flex", gap: 4 }}>
+            <Button
+              variant={fitMode === "page" ? "default" : "ghost"}
+              size="sm"
+              onClick={() => setFitMode("page")}
+              title="Fit page"
+            >
+              Fit
+            </Button>
+            <Button
+              variant={fitMode === "width" ? "default" : "ghost"}
+              size="sm"
+              onClick={() => setFitMode("width")}
+              title="Fit width"
+            >
+              W
+            </Button>
+            <Button
+              variant={fitMode === "height" ? "default" : "ghost"}
+              size="sm"
+              onClick={() => setFitMode("height")}
+              title="Fit height"
+            >
+              H
+            </Button>
+          </div>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Bookmark"
+            disabled={bookmarkMut.isPending}
+            onClick={() => bookmarkMut.mutate(`page:${page}`)}
+          >
+            <Icon name="bookmark" size={14} />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => setChromeVisible(false)}
+            title="Hide chrome"
+          >
+            <Icon name="close" size={14} />
+          </Button>
+        </div>
+      )}
+
+      <div
+        onDoubleClick={() => setChromeVisible((v) => !v)}
+        style={{ flex: 1, position: "relative", overflow: "hidden" }}
+      >
+        <ComicReader
+          ref={comicRef}
+          bookId={book.id}
+          initialPage={initialPage}
+          fitMode={fitMode}
+          onReady={({ totalPages }) => setTotal(totalPages)}
+          onProgress={onComicProgress}
+        />
+      </div>
+
+      <div
+        style={{
+          borderTop: "1px solid var(--color-rule-soft)",
+          padding: "10px 22px",
+          display: "flex",
+          alignItems: "center",
+          gap: 14,
+          background: "var(--color-paper-1)",
+        }}
+      >
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => comicRef.current?.prev()}
+        >
+          <Icon name="chevron-left" size={14} /> Prev
+        </Button>
+        <div
+          style={{ flex: 1, display: "flex", alignItems: "center", gap: 12 }}
+        >
+          <span
+            className="mono"
+            style={{ fontSize: 10.5, color: "var(--color-ink-3)" }}
+          >
+            p.{page + 1}
+          </span>
+          <div
+            style={{
+              flex: 1,
+              position: "relative",
+              height: 4,
+              background: "var(--color-paper-3)",
+              borderRadius: 2,
+              cursor: total > 0 ? "pointer" : "default",
+            }}
+            onClick={(e) => {
+              if (total <= 0) return
+              const rect = e.currentTarget.getBoundingClientRect()
+              const ratio = (e.clientX - rect.left) / rect.width
+              const target = Math.max(
+                0,
+                Math.min(total - 1, Math.round(ratio * (total - 1)))
+              )
+              comicRef.current?.goTo(target)
+            }}
+          >
+            <div
+              style={{
+                height: 4,
+                width: `${Math.round(percent * 100)}%`,
+                background: "var(--color-accent)",
+                borderRadius: 2,
+                transition: "width 120ms ease",
+              }}
+            />
+          </div>
+          <span
+            className="mono"
+            style={{ fontSize: 10.5, color: "var(--color-ink-3)" }}
+          >
+            {total > 0 ? `p.${total}` : "—"}
+          </span>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => comicRef.current?.next()}
+        >
+          Next <Icon name="chevron-right" size={14} />
+        </Button>
+      </div>
+
+      {!chromeVisible && (
+        <Button
+          variant="outline"
+          size="icon-sm"
+          onClick={() => setChromeVisible(true)}
+          className="absolute top-2 right-2 z-10"
+        >
+          <Icon name="menu" size={14} />
+        </Button>
+      )}
+    </div>
+  )
+}
+
+// AudioReaderShell wraps AudioReader with the chrome an audiobook listener
+// expects: cover + title at the top, big play/pause + skip controls
+// in the middle, scrubber + chapter list at the bottom. Like
+// ComicReaderShell, this is deliberately a parallel implementation
+// instead of folded into ReaderShell — audio has a fundamentally
+// different progress model (continuous time vs. discrete pages/CFIs).
+function AudioReaderShell({ book }: { book: BookDetail }) {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+
+  const initialSeconds = useMemo(() => {
+    const t = parseResumeToken(book.resumeCfi)
+    return typeof t.seconds === "number" ? Math.max(0, t.seconds) : 0
+  }, [book.resumeCfi])
+
+  const [seconds, setSeconds] = useState(initialSeconds)
+  const [duration, setDuration] = useState(book.durationSeconds ?? 0)
+  const [playing, setPlaying] = useState(false)
+  const [rate, setRate] = useState(1)
+  const [chapterIndex, setChapterIndex] = useState(-1)
+  const [chaptersOpen, setChaptersOpen] = useState(false)
+  const audioRef = useRef<AudioReaderHandle>(null)
+
+  const progressMut = useMutation({
+    mutationFn: (args: { progress: number; resumeCfi: string }) =>
+      updateProgress(book.id, args.progress, args.resumeCfi),
+  })
+
+  const bookmarkMut = useMutation({
+    mutationFn: (locator: string) =>
+      createAnnotation(book.id, {
+        locator,
+        selectedText: `Bookmark · ${formatHMS(seconds)}`,
+        color: "bookmark",
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: bookAnnotationsQueryKey(book.id),
+      })
+      queryClient.invalidateQueries({ queryKey: recentAnnotationsQueryKey })
+      toast.success("Bookmark saved")
+    },
+    onError: (err) =>
+      toast.error((err as unknown as ApiError).message || "Bookmark failed"),
+  })
+
+  // Same debounced-persist shape the other shells use, plus an
+  // additional save-on-pause path so a quick listening session that
+  // ends with the user just hitting pause still records position.
+  const pendingRef = useRef<{ progress: number; resumeCfi: string } | null>(
+    null
+  )
+  const timerRef = useRef<number | null>(null)
+  const flush = () => {
+    if (timerRef.current) window.clearTimeout(timerRef.current)
+    timerRef.current = null
+    const snap = pendingRef.current
+    pendingRef.current = null
+    if (snap) progressMut.mutate(snap)
+  }
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) window.clearTimeout(timerRef.current)
+      if (pendingRef.current) {
+        void updateProgress(
+          book.id,
+          pendingRef.current.progress,
+          pendingRef.current.resumeCfi
+        )
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const queueProgress = (progress: number, locator: string) => {
+    pendingRef.current = { progress, resumeCfi: locator }
+    if (timerRef.current) window.clearTimeout(timerRef.current)
+    timerRef.current = window.setTimeout(() => {
+      flush()
+    }, 5000) // longer debounce: time updates fire several times a second
+  }
+
+  const onAudioProgress = (p: AudioProgress) => {
+    setSeconds(p.seconds)
+    setDuration(p.duration)
+    queueProgress(p.percent, `time:${p.seconds.toFixed(2)}`)
+  }
+
+  const exit = () => {
+    flush()
+    void navigate({ to: "/book/$id", params: { id: book.id } })
+  }
+
+  const togglePlay = () => {
+    audioRef.current?.toggle()
+    setPlaying((v) => !v)
+  }
+
+  const percent = duration > 0 ? seconds / duration : 0
+
+  return (
+    <div
+      className="fade-in"
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "var(--color-paper-1)",
+        zIndex: 200,
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 12,
+          padding: "10px 22px",
+          borderBottom: "1px solid var(--color-rule-soft)",
+          background: "var(--color-paper-1)",
+        }}
+      >
+        <Button variant="ghost" size="sm" onClick={exit}>
+          <Icon name="arrow-left" size={14} /> Library
+        </Button>
+        <div style={{ flex: 1 }} />
+        <Button
+          variant={chaptersOpen ? "default" : "ghost"}
+          size="icon-sm"
+          disabled={!book.chapters || book.chapters.length === 0}
+          onClick={() => setChaptersOpen((v) => !v)}
+          title="Chapters"
+        >
+          <Icon name="contents" size={14} />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Bookmark"
+          disabled={bookmarkMut.isPending}
+          onClick={() => bookmarkMut.mutate(`time:${seconds.toFixed(2)}`)}
+        >
+          <Icon name="bookmark" size={14} />
+        </Button>
+      </div>
+
+      <div
+        style={{
+          flex: 1,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: 32,
+          gap: 32,
+          overflow: "auto",
+        }}
+      >
+        {/* Cover */}
+        <div
+          style={{
+            width: 280,
+            height: 280,
+            background: book.hasCover
+              ? `var(--color-paper-3) url(/api/v1/books/${book.id}/cover) center / cover no-repeat`
+              : "var(--color-paper-3)",
+            borderRadius: 6,
+            boxShadow: "0 12px 36px -8px oklch(0.2 0.02 60 / 0.32)",
+            flexShrink: 0,
+          }}
+        />
+
+        {/* Title block + transport + chapter list */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 14,
+            maxWidth: 480,
+            width: "100%",
+          }}
+        >
+          <div>
+            <div
+              style={{
+                fontSize: 24,
+                fontStyle: "italic",
+                fontWeight: 500,
+                lineHeight: 1.2,
+              }}
+            >
+              {book.title}
+            </div>
+            <div className="t-small" style={{ marginTop: 4 }}>
+              {book.author}
+              {book.narrator && book.narrator !== book.author
+                ? ` · narr. ${book.narrator}`
+                : ""}
+            </div>
+            {chapterIndex >= 0 && book.chapters?.[chapterIndex] && (
+              <div
+                className="t-micro"
+                style={{ marginTop: 6, fontStyle: "italic" }}
+              >
+                {book.chapters[chapterIndex].title}
+              </div>
+            )}
+          </div>
+
+          {/* Big transport row: skip back, play/pause, skip forward, rate. */}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 14,
+              padding: "8px 0",
+            }}
+          >
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={() => audioRef.current?.skip(-15)}
+              title="Back 15s"
+            >
+              <Icon name="chevron-left" size={16} />
+            </Button>
+            <Button
+              variant="default"
+              size="lg"
+              onClick={togglePlay}
+              style={{ minWidth: 72 }}
+            >
+              <Icon name={playing ? "pause" : "play"} size={18} />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={() => audioRef.current?.skip(30)}
+              title="Forward 30s"
+            >
+              <Icon name="chevron-right" size={16} />
+            </Button>
+            <div style={{ flex: 1 }} />
+            <select
+              value={rate}
+              onChange={(e) => {
+                const r = Number.parseFloat(e.target.value)
+                setRate(r)
+                audioRef.current?.setRate(r)
+              }}
+              className="mono"
+              style={{
+                fontSize: 12,
+                padding: "4px 8px",
+                background: "var(--color-paper-0)",
+                border: "1px solid var(--color-ink-3)",
+                borderRadius: 2,
+              }}
+            >
+              {[0.75, 1, 1.25, 1.5, 1.75, 2].map((r) => (
+                <option key={r} value={r}>
+                  {r}×
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Scrubber */}
+          <div
+            style={{ display: "flex", alignItems: "center", gap: 10 }}
+          >
+            <span
+              className="mono"
+              style={{ fontSize: 11, color: "var(--color-ink-3)", minWidth: 50 }}
+            >
+              {formatHMS(seconds)}
+            </span>
+            <div
+              style={{
+                flex: 1,
+                position: "relative",
+                height: 4,
+                background: "var(--color-paper-3)",
+                borderRadius: 2,
+                cursor: duration > 0 ? "pointer" : "default",
+              }}
+              onClick={(e) => {
+                if (duration <= 0) return
+                const rect = e.currentTarget.getBoundingClientRect()
+                const ratio = (e.clientX - rect.left) / rect.width
+                audioRef.current?.seekTo(
+                  Math.max(0, Math.min(duration, ratio * duration))
+                )
+              }}
+            >
+              <div
+                style={{
+                  height: 4,
+                  width: `${Math.round(percent * 100)}%`,
+                  background: "var(--color-accent)",
+                  borderRadius: 2,
+                  transition: "width 120ms linear",
+                }}
+              />
+              {/* Chapter tick marks */}
+              {book.chapters?.map((c, i) => {
+                if (duration <= 0) return null
+                const left = (c.startS / duration) * 100
+                if (left < 0 || left > 100) return null
+                return (
+                  <div
+                    key={i}
+                    style={{
+                      position: "absolute",
+                      top: -2,
+                      left: `${left}%`,
+                      width: 1,
+                      height: 8,
+                      background: "var(--color-ink-3)",
+                      opacity: 0.4,
+                    }}
+                  />
+                )
+              })}
+            </div>
+            <span
+              className="mono"
+              style={{ fontSize: 11, color: "var(--color-ink-3)", minWidth: 50 }}
+            >
+              {formatHMS(duration)}
+            </span>
+          </div>
+
+          {chaptersOpen && book.chapters && book.chapters.length > 0 && (
+            <div
+              style={{
+                marginTop: 8,
+                background: "var(--color-paper-0)",
+                border: "1px solid var(--color-rule-soft)",
+                borderRadius: 3,
+                maxHeight: 240,
+                overflow: "auto",
+              }}
+            >
+              {book.chapters.map((c, i) => (
+                <button
+                  key={i}
+                  onClick={() => audioRef.current?.seekTo(c.startS)}
+                  style={{
+                    display: "block",
+                    width: "100%",
+                    textAlign: "left",
+                    padding: "6px 12px",
+                    border: "none",
+                    background:
+                      i === chapterIndex
+                        ? "var(--color-paper-2)"
+                        : "transparent",
+                    fontFamily: "var(--font-serif)",
+                    fontSize: 13,
+                    color: "var(--color-ink-2)",
+                    cursor: "pointer",
+                  }}
+                >
+                  <span
+                    className="mono"
+                    style={{
+                      marginRight: 10,
+                      fontSize: 10.5,
+                      color: "var(--color-ink-3)",
+                    }}
+                  >
+                    {formatHMS(c.startS)}
+                  </span>
+                  {c.title}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <AudioReader
+        ref={audioRef}
+        url={`/api/v1/books/${book.id}/file`}
+        initialSeconds={initialSeconds}
+        initialRate={rate}
+        chapters={book.chapters}
+        title={book.title}
+        author={book.author}
+        artworkURL={book.hasCover ? `/api/v1/books/${book.id}/cover` : undefined}
+        onReady={({ duration: d }) => setDuration(d)}
+        onProgress={onAudioProgress}
+        onChapterChange={(i) => setChapterIndex(i)}
+      />
+    </div>
+  )
+}
+
+// formatHMS renders a seconds count as H:MM:SS (or M:SS for short
+// clips). NaN / negative values render as "—:—".
+function formatHMS(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return "—:—"
+  const total = Math.floor(seconds)
+  const h = Math.floor(total / 3600)
+  const m = Math.floor((total % 3600) / 60)
+  const s = total % 60
+  const pad = (n: number) => n.toString().padStart(2, "0")
+  return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${m}:${pad(s)}`
 }
 
 function FullScreenMessage({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## Summary

Adds two new reader formats end-to-end. EPUB / PDF flows are unchanged.

### Phase 1 — Comics (CBZ)
- **Ingest:** `CBZProcessor` lists images by natural sort, extracts cover (prefers `cover.*` at archive root, else first page), parses optional `ComicInfo.xml` (Series/Number → Title, Writer → Author, Summary → Description).
- **Streaming:** `GET /api/v1/books/:id/pages` returns `{count}`; `GET /api/v1/books/:id/pages/:n` streams the n-th image with `Cache-Control: private, max-age=86400, immutable`. Reuses the existing library-root sandbox check.
- **Reader:** new `ComicReader` (single-image, fit modes, keyboard nav, ±2 page preload) + a dedicated `ComicReaderShell`. Progress persists as `page:N` — same scheme the PDF reader uses, so resume just works.
- **Tests:** new `internal/fileproc/cbz_test.go` covers natural sort, basic cover, preferred cover, ComicInfo parsing, page streaming, out-of-range handling.

### Phase 2 — Audiobooks (MP3 / M4B)
- **Schema:** parity migration #24 adds `duration_seconds`, `narrator`, `chapters` to `books` (Postgres JSONB / SQLite TEXT-with-json_valid).
- **Ingest:** `AudioProcessor` covers `.mp3` / `.m4a` / `.m4b`. Tags + cover via `github.com/dhowden/tag`; duration via custom XING/Info parser (MP3) and mvhd atom walker (MP4). Approve flow re-extracts post-create so the `bookdrop_items` schema stays clean.
- **Streaming:** `gin.Context.File` delegates to `http.ServeFile` which already honors Range requests — verified in gin source. `mimeForFormat` extended (`audio/mpeg`, `audio/mp4`).
- **Reader:** `AudioReader` wraps HTML5 `<audio>` with Media Session API for OS lockscreen / headphone controls. `AudioReaderShell` adds cover + title block, transport (±15s / ±30s skip, big play/pause), playback rate selector (0.75× – 2×), scrubber with chapter tick marks, expandable chapter list. Resume token format `time:NNN.NN`; 5-second debounced position persistence.

### Architectural choice — parallel shells

Both `ComicReaderShell` and `AudioReaderShell` are deliberately **parallel** to the existing EPUB/PDF `ReaderShell` rather than folded in: comics have no TOC / text-selection / annotation model, and audio has a fundamentally different (continuous-time) progress shape. Sharing the debounce-and-persist pattern was the right amount of reuse.

### Deferred follow-ups
- M4B `chap`-track / ID3v2 CHAP atom parsing (chapter UI + DB plumbing already in place; processor returns `nil` for now).
- Multi-file audiobooks (folder of MP3s = one book) — separate ingest redesign.
- Timestamped audio annotations beyond the simple bookmark already supported.
- Library-card duration display (`book.durationSeconds` is on the wire but no card consumer yet).
- CBR / CB7 (RAR licensing).

## Test plan
- [x] `make ci-local` (Go tests, golangci-lint, tsc, eslint, UI build, Go binary build) — all green locally.
- [ ] Drop a CBZ in BookDrop → approve → `/read/:id` shows the comic reader; arrows / space / click zones navigate; resume position survives reload.
- [ ] Drop an MP3 with XING header → approve → cover shows in BookDrop and on the audio reader; duration renders in scrubber; ±15/30 buttons + scrubber work.
- [ ] Drop an M4B → approve → narrator (when distinct from author) shows in the title block; mvhd-based duration is correct.
- [ ] `curl -H "Range: bytes=1000-2000" http://localhost:6060/api/v1/books/:id/file` returns `206 Partial Content` for an audiobook.
- [ ] OS-level Media Session controls work on Chrome/Safari (lockscreen play/pause, headphone double-tap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)