### PR TITLE
feat(db): storage_v2 schema + content-hash identity (Plan B of 8)

### DIFF
--- a/cmd/embookshelf/main.go
+++ b/cmd/embookshelf/main.go
@@ -86,6 +86,10 @@ func main() {
 			slog.Error("migrate", "err", err)
 			os.Exit(1)
 		}
+		if err := migrator.BackfillStorageV2(ctx, dbh); err != nil {
+			slog.Error("storage_v2 backfill", "err", err)
+			os.Exit(1)
+		}
 	}
 
 	fileStorage, err := local.New("/")

--- a/cmd/embookshelf/main.go
+++ b/cmd/embookshelf/main.go
@@ -111,6 +111,7 @@ func main() {
 	readingSessionRepo := repo.NewReadingSessionRepo(dbh)
 	deviceRepo := repo.NewDeviceRepo(dbh)
 	appSettingsRepo := repo.NewAppSettingsRepo(dbh)
+	fileRepo := repo.NewFileRepo(dbh)
 
 	// SSE hub — shared between services that broadcast and the handler that serves /events.
 	hub := sse.NewHub()
@@ -123,7 +124,7 @@ func main() {
 	shelfSvc := service.NewShelfService(shelfRepo)
 	searchSvc := service.NewSearchService(libRepo, shelfRepo)
 	authSvc := service.NewAuthService(userRepo, sessionRepo, hub)
-	bdropSvc := service.NewBookDropService(bdropRepo, libRepo, appSettingsRepo, covers, hub)
+	bdropSvc := service.NewBookDropService(bdropRepo, libRepo, appSettingsRepo, covers, hub, fileRepo)
 	progressSvc := service.NewProgressService(progressRepo, readingSessionRepo)
 	annotationSvc := service.NewAnnotationService(annotationRepo)
 	statsSvc := service.NewStatsService(statsRepo)
@@ -216,7 +217,7 @@ func main() {
 	}
 
 	// Background queue. PG → River; SQLite → polling worker (queue.New dispatches by dialect).
-	q, err := queue.New(ctx, dbh, bdropSvc, libSvc, fileStorage)
+	q, err := queue.New(ctx, dbh, bdropSvc, libSvc, fileStorage, fileRepo)
 	if err != nil {
 		slog.Error("queue", "err", err)
 		os.Exit(1)
@@ -240,7 +241,7 @@ func main() {
 		backfillCtx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
 		defer cancel()
 		if err := task.RunFilesBackfill(backfillCtx, task.FilesBackfillDeps{
-			Files:     repo.NewFileRepo(dbh),
+			Files:     fileRepo,
 			Libraries: libRepo,
 			Backends:  repo.NewStorageBackendRepo(dbh),
 			Storage:   fileStorage,

--- a/cmd/embookshelf/main.go
+++ b/cmd/embookshelf/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/blackforge/embookshelf/internal/sse"
 	"github.com/blackforge/embookshelf/internal/staticfs"
 	"github.com/blackforge/embookshelf/internal/storage/local"
+	"github.com/blackforge/embookshelf/internal/task"
 	"github.com/blackforge/embookshelf/internal/telemetry"
 )
 
@@ -230,6 +231,23 @@ func main() {
 
 	// Requeue anything still mid-flight from a previous process.
 	ingest.DiscoverOnStartup(ctx, bdropRepo, q)
+
+	// Boot-time files backfill: hash any files rows that are still missing a
+	// content_hash. Runs in the background so it doesn't block startup.
+	// 1-hour timeout is generous; real deployments have hundreds of files at most.
+	go func() {
+		slog.Info("files backfill starting")
+		backfillCtx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+		defer cancel()
+		if err := task.RunFilesBackfill(backfillCtx, task.FilesBackfillDeps{
+			Files:     repo.NewFileRepo(dbh),
+			Libraries: libRepo,
+			Backends:  repo.NewStorageBackendRepo(dbh),
+			Storage:   fileStorage,
+		}); err != nil {
+			slog.Warn("files backfill", "err", err)
+		}
+	}()
 
 	// File watcher goroutine.
 	watcher := &ingest.Watcher{

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -74,6 +74,9 @@ func main() {
 		if err := migrator.Up(m); err != nil {
 			fatal("up: %v", err)
 		}
+		if err := migrator.BackfillStorageV2(ctx, d); err != nil {
+			fatal("storage_v2 backfill: %v", err)
+		}
 		fmt.Println("ok")
 	case "down":
 		if err := m.Down(); err != nil && !errors.Is(err, migrate.ErrNoChange) {

--- a/internal/db/dberr/dberr.go
+++ b/internal/db/dberr/dberr.go
@@ -22,6 +22,20 @@ func IsNotFound(err error) bool {
 	return errors.Is(err, sql.ErrNoRows)
 }
 
+// IsForeignKeyViolation reports whether err denotes a foreign-key
+// constraint violation. On Postgres that is SQLSTATE 23503; on SQLite
+// the driver emits a message containing "FOREIGN KEY constraint failed".
+func IsForeignKeyViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == "23503"
+	}
+	return strings.Contains(err.Error(), "FOREIGN KEY constraint failed")
+}
+
 // IsUniqueViolation reports whether err denotes a unique-constraint
 // violation, and if so returns a stable identifier for the violated
 // constraint.

--- a/internal/hashing/hasher.go
+++ b/internal/hashing/hasher.go
@@ -1,0 +1,36 @@
+// Package hashing computes content hashes from a storage.Storage
+// stream. sha256 is the project-wide identity primitive.
+package hashing
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+
+	"github.com/blackforge/embookshelf/internal/storage"
+)
+
+// HashFile streams bytes from store at key, returning the sha256
+// digest and the byte count read. The underlying ReadCloser is
+// closed before return. Cancellation is honored via ctx — if the
+// caller cancels, io.Copy aborts and the partial hash is discarded.
+func HashFile(ctx context.Context, store storage.Storage, key string) ([]byte, int64, error) {
+	rc, err := store.Get(ctx, key)
+	if err != nil {
+		return nil, 0, fmt.Errorf("hashing: get %q: %w", key, err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	// Check for cancellation before starting the potentially-large read.
+	if err := ctx.Err(); err != nil {
+		return nil, 0, fmt.Errorf("hashing: read %q: %w", key, err)
+	}
+
+	h := sha256.New()
+	n, err := io.Copy(h, rc)
+	if err != nil {
+		return nil, 0, fmt.Errorf("hashing: read %q: %w", key, err)
+	}
+	return h.Sum(nil), n, nil
+}

--- a/internal/hashing/hasher_test.go
+++ b/internal/hashing/hasher_test.go
@@ -1,0 +1,114 @@
+package hashing_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/blackforge/embookshelf/internal/hashing"
+	"github.com/blackforge/embookshelf/internal/storage/local"
+)
+
+// helper writes content to a temp file and returns the filename (key).
+func writeFile(t *testing.T, dir, name string, content []byte) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, content, 0o600); err != nil {
+		t.Fatalf("writeFile %s: %v", name, err)
+	}
+	return name
+}
+
+func TestHashFile_knownInput(t *testing.T) {
+	dir := t.TempDir()
+	fs, err := local.New(dir)
+	if err != nil {
+		t.Fatalf("local.New: %v", err)
+	}
+
+	// "hello world\n" → known sha256
+	key := writeFile(t, dir, "hello.txt", []byte("hello world\n"))
+	want, _ := hex.DecodeString("a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447")
+
+	digest, n, err := hashing.HashFile(context.Background(), fs, key)
+	if err != nil {
+		t.Fatalf("HashFile: %v", err)
+	}
+	if !bytes.Equal(digest, want) {
+		t.Fatalf("digest=%x want=%x", digest, want)
+	}
+	if n != int64(len("hello world\n")) {
+		t.Fatalf("n=%d want %d", n, len("hello world\n"))
+	}
+}
+
+func TestHashFile_emptyFile(t *testing.T) {
+	dir := t.TempDir()
+	fs, err := local.New(dir)
+	if err != nil {
+		t.Fatalf("local.New: %v", err)
+	}
+
+	key := writeFile(t, dir, "empty.txt", []byte{})
+	want, _ := hex.DecodeString("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+
+	digest, n, err := hashing.HashFile(context.Background(), fs, key)
+	if err != nil {
+		t.Fatalf("HashFile empty: %v", err)
+	}
+	if !bytes.Equal(digest, want) {
+		t.Fatalf("digest=%x want=%x", digest, want)
+	}
+	if n != 0 {
+		t.Fatalf("n=%d want 0", n)
+	}
+}
+
+func TestHashFile_1MBRandom(t *testing.T) {
+	dir := t.TempDir()
+	fs, err := local.New(dir)
+	if err != nil {
+		t.Fatalf("local.New: %v", err)
+	}
+
+	data := make([]byte, 1<<20)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+	key := writeFile(t, dir, "random.bin", data)
+
+	_, n, err := hashing.HashFile(context.Background(), fs, key)
+	if err != nil {
+		t.Fatalf("HashFile 1MB: %v", err)
+	}
+	if n != 1<<20 {
+		t.Fatalf("size=%d want %d", n, 1<<20)
+	}
+}
+
+func TestHashFile_cancelledContext(t *testing.T) {
+	dir := t.TempDir()
+	fs, err := local.New(dir)
+	if err != nil {
+		t.Fatalf("local.New: %v", err)
+	}
+
+	key := writeFile(t, dir, "some.txt", []byte("some content"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+
+	_, _, err = hashing.HashFile(ctx, fs, key)
+	if err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
+	}
+	// The error should wrap ctx.Err() (context.Canceled).
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error %v does not wrap context.Canceled", err)
+	}
+}

--- a/internal/migrator/backfill_storage_v2.go
+++ b/internal/migrator/backfill_storage_v2.go
@@ -1,0 +1,312 @@
+package migrator
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/blackforge/embookshelf/internal/db"
+)
+
+// BackfillStorageV2 populates the columns added by migration 000025.
+// Idempotent: re-running on an already-backfilled DB is a no-op.
+//
+// Strategy: short-circuit on the app_settings sentinel; otherwise run
+// the four steps below in sequence. Each step is itself guarded by
+// WHERE NOT EXISTS so a partial run that crashed mid-way still
+// converges to a valid state on the next call.
+func BackfillStorageV2(ctx context.Context, d *db.DB) error {
+	done, err := storageV2AlreadyBackfilled(ctx, d)
+	if err != nil {
+		return fmt.Errorf("storage_v2 backfill: check sentinel: %w", err)
+	}
+	if done {
+		return nil
+	}
+	start := time.Now()
+
+	backends, err := seedStorageBackends(ctx, d)
+	if err != nil {
+		return fmt.Errorf("seed backends: %w", err)
+	}
+	libs, err := wireLibraries(ctx, d)
+	if err != nil {
+		return fmt.Errorf("wire libraries: %w", err)
+	}
+	uuidsAssigned, err := assignBookUUIDs(ctx, d)
+	if err != nil {
+		return fmt.Errorf("assign book uuids: %w", err)
+	}
+	files, err := seedFilesFromBooks(ctx, d)
+	if err != nil {
+		return fmt.Errorf("seed files: %w", err)
+	}
+
+	if err := setStorageV2Sentinel(ctx, d); err != nil {
+		return fmt.Errorf("write sentinel: %w", err)
+	}
+	slog.Info("storage_v2 backfill complete",
+		"backends", backends,
+		"libraries_wired", libs,
+		"uuids_assigned", uuidsAssigned,
+		"files_seeded", files,
+		"duration", time.Since(start),
+	)
+	return nil
+}
+
+func storageV2AlreadyBackfilled(ctx context.Context, d *db.DB) (bool, error) {
+	var v string
+	err := d.SQL.QueryRowContext(ctx,
+		`SELECT value FROM app_settings WHERE name = 'storage_v2_backfilled'`,
+	).Scan(&v)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return v != "" && v != "false", nil
+}
+
+func setStorageV2Sentinel(ctx context.Context, d *db.DB) error {
+	val := `"true"` // JSON-encoded scalar string
+	switch d.Dialect {
+	case db.DialectPostgres:
+		_, err := d.SQL.ExecContext(ctx, `
+			INSERT INTO app_settings (name, value)
+			VALUES ('storage_v2_backfilled', $1::jsonb)
+			ON CONFLICT (name) DO UPDATE SET value = EXCLUDED.value, updated_at = now()
+		`, val)
+		return err
+	case db.DialectSQLite:
+		_, err := d.SQL.ExecContext(ctx, `
+			INSERT INTO app_settings (name, value, updated_at)
+			VALUES ('storage_v2_backfilled', $1, strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+			ON CONFLICT (name) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at
+		`, val)
+		return err
+	}
+	return fmt.Errorf("unsupported dialect %q", d.Dialect)
+}
+
+// seedStorageBackends inserts one storage_backends row per distinct non-empty
+// libraries.path. Returns the number of rows inserted.
+func seedStorageBackends(ctx context.Context, d *db.DB) (int, error) {
+	rows, err := d.SQL.QueryContext(ctx,
+		`SELECT DISTINCT path FROM libraries WHERE path <> ''`,
+	)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var paths []string
+	for rows.Next() {
+		var p string
+		if err := rows.Scan(&p); err != nil {
+			return 0, err
+		}
+		paths = append(paths, p)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+
+	inserted := 0
+	for _, p := range paths {
+		cfg, err := json.Marshal(map[string]string{"root": p})
+		if err != nil {
+			return inserted, fmt.Errorf("marshal backend config: %w", err)
+		}
+
+		var existsCount int
+		var checkSQL string
+		switch d.Dialect {
+		case db.DialectPostgres:
+			checkSQL = `SELECT count(*) FROM storage_backends WHERE kind = 'local' AND config->>'root' = $1`
+		case db.DialectSQLite:
+			checkSQL = `SELECT count(*) FROM storage_backends WHERE kind = 'local' AND json_extract(config, '$.root') = $1`
+		default:
+			return inserted, fmt.Errorf("unsupported dialect %q", d.Dialect)
+		}
+		if err := d.SQL.QueryRowContext(ctx, checkSQL, p).Scan(&existsCount); err != nil {
+			return inserted, err
+		}
+		if existsCount > 0 {
+			continue
+		}
+
+		id := uuid.NewString()
+		var insertSQL string
+		switch d.Dialect {
+		case db.DialectPostgres:
+			insertSQL = `INSERT INTO storage_backends (id, kind, config) VALUES ($1, 'local', $2::jsonb)`
+		case db.DialectSQLite:
+			insertSQL = `INSERT INTO storage_backends (id, kind, config, created_at) VALUES ($1, 'local', $2, strftime('%Y-%m-%dT%H:%M:%fZ','now'))`
+		default:
+			return inserted, fmt.Errorf("unsupported dialect %q", d.Dialect)
+		}
+		if _, err := d.SQL.ExecContext(ctx, insertSQL, id, string(cfg)); err != nil {
+			return inserted, err
+		}
+		inserted++
+	}
+	return inserted, nil
+}
+
+// wireLibraries updates each library with a non-empty path to reference its
+// storage_backend and copies path → root. Returns the number of rows updated.
+func wireLibraries(ctx context.Context, d *db.DB) (int, error) {
+	var sqlStr string
+	switch d.Dialect {
+	case db.DialectPostgres:
+		sqlStr = `
+			UPDATE libraries
+			SET backend_id = sb.id,
+			    root       = libraries.path
+			FROM storage_backends sb
+			WHERE sb.kind = 'local'
+			  AND sb.config->>'root' = libraries.path
+			  AND libraries.path <> ''
+			  AND libraries.backend_id IS NULL
+		`
+	case db.DialectSQLite:
+		// SQLite UPDATE doesn't support FROM; use a subquery.
+		sqlStr = `
+			UPDATE libraries
+			SET backend_id = (
+				SELECT id FROM storage_backends
+				WHERE kind = 'local' AND json_extract(config, '$.root') = libraries.path
+			),
+			root = libraries.path
+			WHERE libraries.path <> '' AND libraries.backend_id IS NULL
+		`
+	default:
+		return 0, fmt.Errorf("unsupported dialect %q", d.Dialect)
+	}
+	res, err := d.SQL.ExecContext(ctx, sqlStr)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}
+
+// assignBookUUIDs assigns a fresh UUID to every book where uuid IS NULL.
+// Returns the number of books updated.
+func assignBookUUIDs(ctx context.Context, d *db.DB) (int, error) {
+	rows, err := d.SQL.QueryContext(ctx, `SELECT id FROM books WHERE uuid IS NULL`)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return 0, err
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+
+	for _, id := range ids {
+		if _, err := d.SQL.ExecContext(ctx,
+			`UPDATE books SET uuid = $1 WHERE id = $2 AND uuid IS NULL`,
+			uuid.NewString(), id,
+		); err != nil {
+			return 0, err
+		}
+	}
+	return len(ids), nil
+}
+
+type bookForFile struct {
+	bookID    string
+	libraryID string
+	path      string
+	libRoot   sql.NullString
+	format    string
+	updatedAt time.Time
+}
+
+// seedFilesFromBooks inserts one files row per book that has a non-empty path
+// and no existing files row. The location is the book path relative to the
+// library root; if it doesn't fall under the root the absolute path is stored
+// verbatim. Returns the number of rows inserted.
+func seedFilesFromBooks(ctx context.Context, d *db.DB) (int, error) {
+	rows, err := d.SQL.QueryContext(ctx, `
+		SELECT b.id, b.library_id, b.path, l.root, b.format, b.updated_at
+		FROM books b
+		JOIN libraries l ON l.id = b.library_id
+		WHERE b.path <> ''
+		  AND b.deleted_at IS NULL
+		  AND NOT EXISTS (SELECT 1 FROM files WHERE files.book_id = b.id)
+	`)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var batch []bookForFile
+	for rows.Next() {
+		var bf bookForFile
+		var rawUpdatedAt any
+		if err := rows.Scan(
+			&bf.bookID, &bf.libraryID, &bf.path, &bf.libRoot, &bf.format, &rawUpdatedAt,
+		); err != nil {
+			return 0, err
+		}
+		if err := db.ScanTime(d.Dialect, rawUpdatedAt, &bf.updatedAt); err != nil {
+			return 0, fmt.Errorf("scan updated_at for book %s: %w", bf.bookID, err)
+		}
+		batch = append(batch, bf)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+
+	for _, bf := range batch {
+		loc := bf.path
+		if bf.libRoot.Valid && bf.libRoot.String != "" {
+			prefix := bf.libRoot.String
+			if !strings.HasSuffix(prefix, "/") {
+				prefix += "/"
+			}
+			if strings.HasPrefix(bf.path, prefix) {
+				loc = bf.path[len(prefix):]
+			}
+		}
+
+		var stmt string
+		switch d.Dialect {
+		case db.DialectPostgres:
+			stmt = `INSERT INTO files (id, library_id, book_id, location, size, mtime, format, last_scanned)
+					VALUES ($1, $2, $3, $4, 0, $5, $6, $5)
+					ON CONFLICT (library_id, location) DO NOTHING`
+		case db.DialectSQLite:
+			stmt = `INSERT INTO files (id, library_id, book_id, location, size, mtime, format, last_scanned)
+					VALUES ($1, $2, $3, $4, 0, $5, $6, $5)
+					ON CONFLICT(library_id, location) DO NOTHING`
+		default:
+			return 0, fmt.Errorf("unsupported dialect %q", d.Dialect)
+		}
+		if _, err := d.SQL.ExecContext(ctx, stmt,
+			uuid.NewString(), bf.libraryID, bf.bookID, loc, bf.updatedAt, bf.format,
+		); err != nil {
+			return 0, err
+		}
+	}
+	return len(batch), nil
+}

--- a/internal/migrator/backfill_storage_v2_test.go
+++ b/internal/migrator/backfill_storage_v2_test.go
@@ -1,0 +1,356 @@
+package migrator_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/blackforge/embookshelf/internal/db"
+	"github.com/blackforge/embookshelf/internal/migrator"
+	"github.com/blackforge/embookshelf/internal/repo/repotest"
+)
+
+// dialects returns the set of dialects to test. Postgres is included only when
+// TEST_DATABASE_URL is set; otherwise it logs a skip message and returns just
+// SQLite so the caller doesn't have to handle the nil slice case.
+func dialects(t *testing.T) []string {
+	t.Helper()
+	all := []string{"sqlite"}
+	if os.Getenv("TEST_DATABASE_URL") != "" {
+		all = append(all, "postgres")
+	} else {
+		t.Log("PG repotest unavailable, skipping postgres dialect (set TEST_DATABASE_URL to enable)")
+	}
+	return all
+}
+
+// insertLibrary inserts a minimal library row for testing.
+func insertLibrary(t *testing.T, ctx context.Context, d *db.DB, id, path string) {
+	t.Helper()
+	_, err := d.SQL.ExecContext(ctx, `
+		INSERT INTO libraries (id, name, slug, path)
+		VALUES ($1, $1, $1, $2)
+	`, id, path)
+	if err != nil {
+		t.Fatalf("insertLibrary(%s): %v", id, err)
+	}
+}
+
+// insertBook inserts a minimal book row for testing.
+func insertBook(t *testing.T, ctx context.Context, d *db.DB, id, libraryID, path, format string) {
+	t.Helper()
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := d.SQL.ExecContext(ctx, `
+		INSERT INTO books (id, library_id, title, path, format, updated_at, created_at)
+		VALUES ($1, $2, $1, $3, $4, $5, $5)
+	`, id, libraryID, path, format, now)
+	if err != nil {
+		t.Fatalf("insertBook(%s): %v", id, err)
+	}
+}
+
+// countRows returns the count of rows in the given table.
+func countRows(t *testing.T, ctx context.Context, d *db.DB, table string) int {
+	t.Helper()
+	var n int
+	//nolint:gosec // table is a test-internal constant, not user input
+	if err := d.SQL.QueryRowContext(ctx, fmt.Sprintf("SELECT count(*) FROM %s", table)).Scan(&n); err != nil {
+		t.Fatalf("count %s: %v", table, err)
+	}
+	return n
+}
+
+// getLibraryBackendID returns the backend_id for a library, or empty string if NULL.
+func getLibraryBackendID(t *testing.T, ctx context.Context, d *db.DB, libID string) string {
+	t.Helper()
+	var bid sql.NullString
+	if err := d.SQL.QueryRowContext(ctx,
+		`SELECT backend_id FROM libraries WHERE id = $1`, libID,
+	).Scan(&bid); err != nil {
+		t.Fatalf("getLibraryBackendID(%s): %v", libID, err)
+	}
+	if !bid.Valid {
+		return ""
+	}
+	return bid.String
+}
+
+// getBookUUID returns the uuid for a book, or empty string if NULL.
+func getBookUUID(t *testing.T, ctx context.Context, d *db.DB, bookID string) string {
+	t.Helper()
+	var u sql.NullString
+	if err := d.SQL.QueryRowContext(ctx,
+		`SELECT uuid FROM books WHERE id = $1`, bookID,
+	).Scan(&u); err != nil {
+		t.Fatalf("getBookUUID(%s): %v", bookID, err)
+	}
+	if !u.Valid {
+		return ""
+	}
+	return u.String
+}
+
+// getFileLocation returns the location for the single file row associated with
+// a book. Fails the test if there is not exactly one file row.
+func getFileLocation(t *testing.T, ctx context.Context, d *db.DB, bookID string) string {
+	t.Helper()
+	var loc string
+	if err := d.SQL.QueryRowContext(ctx,
+		`SELECT location FROM files WHERE book_id = $1`, bookID,
+	).Scan(&loc); err != nil {
+		t.Fatalf("getFileLocation(%s): %v", bookID, err)
+	}
+	return loc
+}
+
+// getSentinel returns the raw value stored for storage_v2_backfilled, or
+// empty string when absent.
+func getSentinel(t *testing.T, ctx context.Context, d *db.DB) string {
+	t.Helper()
+	var v string
+	err := d.SQL.QueryRowContext(ctx,
+		`SELECT value FROM app_settings WHERE name = 'storage_v2_backfilled'`,
+	).Scan(&v)
+	if err != nil {
+		return ""
+	}
+	return v
+}
+
+// --- Tests ---
+
+// TestBackfillStorageV2_EmptyDB verifies that running the backfill on a
+// freshly migrated DB with no libraries or books is a no-op that still writes
+// the sentinel.
+func TestBackfillStorageV2_EmptyDB(t *testing.T) {
+	for _, dialect := range dialects(t) {
+		dialect := dialect
+		t.Run(dialect, func(t *testing.T) {
+			d := repotest.NewWithDialect(t, dialect)
+			ctx := context.Background()
+
+			if err := migrator.BackfillStorageV2(ctx, d); err != nil {
+				t.Fatalf("BackfillStorageV2: %v", err)
+			}
+
+			if countRows(t, ctx, d, "storage_backends") != 0 {
+				t.Error("expected 0 storage_backends rows for empty DB")
+			}
+			if countRows(t, ctx, d, "files") != 0 {
+				t.Error("expected 0 files rows for empty DB")
+			}
+			if s := getSentinel(t, ctx, d); s == "" {
+				t.Error("sentinel not written after backfill")
+			}
+		})
+	}
+}
+
+// TestBackfillStorageV2_OneLibraryOneBook exercises the happy path:
+//   - One library with a non-empty path.
+//   - One book in that library with an absolute path under the library root.
+//
+// After backfill we expect:
+//   - 1 storage_backends row.
+//   - library.backend_id is set.
+//   - book.uuid is non-empty.
+//   - 1 files row with a relative location (prefix stripped).
+func TestBackfillStorageV2_OneLibraryOneBook(t *testing.T) {
+	for _, dialect := range dialects(t) {
+		dialect := dialect
+		t.Run(dialect, func(t *testing.T) {
+			d := repotest.NewWithDialect(t, dialect)
+			ctx := context.Background()
+
+			const (
+				libID  = "lib-001"
+				bookID = "book-001"
+				root   = "/srv/books"
+				bpath  = "/srv/books/Author/Title/Title.epub"
+			)
+			insertLibrary(t, ctx, d, libID, root)
+			insertBook(t, ctx, d, bookID, libID, bpath, "EPUB")
+
+			if err := migrator.BackfillStorageV2(ctx, d); err != nil {
+				t.Fatalf("BackfillStorageV2: %v", err)
+			}
+
+			// Backend created.
+			if n := countRows(t, ctx, d, "storage_backends"); n != 1 {
+				t.Errorf("storage_backends count = %d, want 1", n)
+			}
+			// Library wired.
+			if bid := getLibraryBackendID(t, ctx, d, libID); bid == "" {
+				t.Error("library.backend_id is still NULL after backfill")
+			}
+			// Book has uuid.
+			if u := getBookUUID(t, ctx, d, bookID); u == "" {
+				t.Error("book.uuid is still NULL after backfill")
+			}
+			// Files row with relative location.
+			if loc := getFileLocation(t, ctx, d, bookID); loc != "Author/Title/Title.epub" {
+				t.Errorf("files.location = %q, want %q", loc, "Author/Title/Title.epub")
+			}
+			// Sentinel written.
+			if s := getSentinel(t, ctx, d); s == "" {
+				t.Error("sentinel not written after backfill")
+			}
+		})
+	}
+}
+
+// TestBackfillStorageV2_Idempotent verifies that running the backfill twice
+// does not duplicate rows or change counts.
+func TestBackfillStorageV2_Idempotent(t *testing.T) {
+	for _, dialect := range dialects(t) {
+		dialect := dialect
+		t.Run(dialect, func(t *testing.T) {
+			d := repotest.NewWithDialect(t, dialect)
+			ctx := context.Background()
+
+			const (
+				libID  = "lib-002"
+				bookID = "book-002"
+				root   = "/data/library"
+				bpath  = "/data/library/book.epub"
+			)
+			insertLibrary(t, ctx, d, libID, root)
+			insertBook(t, ctx, d, bookID, libID, bpath, "EPUB")
+
+			if err := migrator.BackfillStorageV2(ctx, d); err != nil {
+				t.Fatalf("first BackfillStorageV2: %v", err)
+			}
+
+			beforeBackends := countRows(t, ctx, d, "storage_backends")
+			beforeFiles := countRows(t, ctx, d, "files")
+			uuid1 := getBookUUID(t, ctx, d, bookID)
+			bid1 := getLibraryBackendID(t, ctx, d, libID)
+
+			// Second run — sentinel should cause early exit.
+			if err := migrator.BackfillStorageV2(ctx, d); err != nil {
+				t.Fatalf("second BackfillStorageV2: %v", err)
+			}
+
+			if n := countRows(t, ctx, d, "storage_backends"); n != beforeBackends {
+				t.Errorf("storage_backends count changed: before=%d after=%d", beforeBackends, n)
+			}
+			if n := countRows(t, ctx, d, "files"); n != beforeFiles {
+				t.Errorf("files count changed: before=%d after=%d", beforeFiles, n)
+			}
+			if u := getBookUUID(t, ctx, d, bookID); u != uuid1 {
+				t.Errorf("book uuid changed: before=%s after=%s", uuid1, u)
+			}
+			if bid := getLibraryBackendID(t, ctx, d, libID); bid != bid1 {
+				t.Errorf("library backend_id changed: before=%s after=%s", bid1, bid)
+			}
+		})
+	}
+}
+
+// TestBackfillStorageV2_EmptyLibraryPath verifies that libraries with an empty
+// path are left unwired (no backend created, backend_id stays NULL).
+func TestBackfillStorageV2_EmptyLibraryPath(t *testing.T) {
+	for _, dialect := range dialects(t) {
+		dialect := dialect
+		t.Run(dialect, func(t *testing.T) {
+			d := repotest.NewWithDialect(t, dialect)
+			ctx := context.Background()
+
+			const libID = "lib-empty"
+			insertLibrary(t, ctx, d, libID, "")
+
+			if err := migrator.BackfillStorageV2(ctx, d); err != nil {
+				t.Fatalf("BackfillStorageV2: %v", err)
+			}
+
+			// No backends created.
+			if n := countRows(t, ctx, d, "storage_backends"); n != 0 {
+				t.Errorf("storage_backends count = %d, want 0 for empty-path library", n)
+			}
+			// Library stays unwired.
+			if bid := getLibraryBackendID(t, ctx, d, libID); bid != "" {
+				t.Errorf("library.backend_id = %q, want empty for empty-path library", bid)
+			}
+		})
+	}
+}
+
+// TestBackfillStorageV2_BookPathOutsideRoot verifies that a book whose path
+// does not fall under library.root stores the absolute path verbatim.
+func TestBackfillStorageV2_BookPathOutsideRoot(t *testing.T) {
+	for _, dialect := range dialects(t) {
+		dialect := dialect
+		t.Run(dialect, func(t *testing.T) {
+			d := repotest.NewWithDialect(t, dialect)
+			ctx := context.Background()
+
+			const (
+				libID  = "lib-003"
+				bookID = "book-003"
+				root   = "/srv/books"
+				// Deliberately outside the root.
+				bpath = "/other/place/book.epub"
+			)
+			insertLibrary(t, ctx, d, libID, root)
+			insertBook(t, ctx, d, bookID, libID, bpath, "EPUB")
+
+			if err := migrator.BackfillStorageV2(ctx, d); err != nil {
+				t.Fatalf("BackfillStorageV2: %v", err)
+			}
+
+			// Location must be the absolute path verbatim.
+			if loc := getFileLocation(t, ctx, d, bookID); loc != bpath {
+				t.Errorf("files.location = %q, want verbatim %q", loc, bpath)
+			}
+		})
+	}
+}
+
+// TestBackfillStorageV2_MultipleLibraries verifies that distinct paths produce
+// distinct backend rows and each library is correctly wired.
+func TestBackfillStorageV2_MultipleLibraries(t *testing.T) {
+	for _, dialect := range dialects(t) {
+		dialect := dialect
+		t.Run(dialect, func(t *testing.T) {
+			d := repotest.NewWithDialect(t, dialect)
+			ctx := context.Background()
+
+			const (
+				lib1  = "lib-a"
+				lib2  = "lib-b"
+				root1 = "/srv/fiction"
+				root2 = "/srv/nonfiction"
+			)
+			insertLibrary(t, ctx, d, lib1, root1)
+			insertLibrary(t, ctx, d, lib2, root2)
+
+			insertBook(t, ctx, d, "book-a1", lib1, root1+"/Book.epub", "EPUB")
+			insertBook(t, ctx, d, "book-b1", lib2, root2+"/Doc.pdf", "PDF")
+
+			if err := migrator.BackfillStorageV2(ctx, d); err != nil {
+				t.Fatalf("BackfillStorageV2: %v", err)
+			}
+
+			if n := countRows(t, ctx, d, "storage_backends"); n != 2 {
+				t.Errorf("storage_backends count = %d, want 2", n)
+			}
+			bid1 := getLibraryBackendID(t, ctx, d, lib1)
+			bid2 := getLibraryBackendID(t, ctx, d, lib2)
+			if bid1 == "" {
+				t.Errorf("library %s has no backend_id", lib1)
+			}
+			if bid2 == "" {
+				t.Errorf("library %s has no backend_id", lib2)
+			}
+			if bid1 != "" && bid2 != "" && bid1 == bid2 {
+				t.Errorf("both libraries share the same backend_id %s; expected distinct IDs", bid1)
+			}
+			if n := countRows(t, ctx, d, "files"); n != 2 {
+				t.Errorf("files count = %d, want 2", n)
+			}
+		})
+	}
+}

--- a/internal/migrator/migrations/postgres/000025_storage_v2.down.sql
+++ b/internal/migrator/migrations/postgres/000025_storage_v2.down.sql
@@ -1,0 +1,21 @@
+-- 000025_storage_v2.down.sql (PG)
+-- Reverses the additive changes from 000025_storage_v2.up.sql.
+-- Legacy books.path / libraries.path were never touched, so no restore needed.
+
+ALTER TABLE bookdrop_items DROP COLUMN IF EXISTS content_hash;
+
+ALTER TABLE books
+    DROP COLUMN IF EXISTS folder_path,
+    DROP COLUMN IF EXISTS uuid;
+
+DROP INDEX IF EXISTS idx_files_library;
+DROP INDEX IF EXISTS idx_files_book;
+DROP INDEX IF EXISTS idx_files_hash;
+DROP TABLE IF EXISTS files;
+
+ALTER TABLE libraries
+    DROP COLUMN IF EXISTS org_mode,
+    DROP COLUMN IF EXISTS root,
+    DROP COLUMN IF EXISTS backend_id;
+
+DROP TABLE IF EXISTS storage_backends;

--- a/internal/migrator/migrations/postgres/000025_storage_v2.up.sql
+++ b/internal/migrator/migrations/postgres/000025_storage_v2.up.sql
@@ -1,0 +1,43 @@
+-- 000025_storage_v2.up.sql (PG)
+-- Plan B of 8: backend-agnostic storage identity. Additive-only;
+-- legacy books.path / libraries.path are kept and read-mirrored by
+-- the Go-level backfill helper (internal/migrator/backfill_storage_v2.go).
+-- Plan B2 drops them once API consumers cut over.
+
+CREATE TABLE IF NOT EXISTS storage_backends (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    kind        TEXT NOT NULL CHECK (kind IN ('local', 's3')),
+    config      JSONB NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE libraries
+    ADD COLUMN IF NOT EXISTS backend_id  UUID REFERENCES storage_backends(id) ON DELETE RESTRICT,
+    ADD COLUMN IF NOT EXISTS root        TEXT,
+    ADD COLUMN IF NOT EXISTS org_mode    TEXT NOT NULL DEFAULT 'book_per_folder'
+        CHECK (org_mode IN ('book_per_file', 'book_per_folder'));
+
+CREATE TABLE IF NOT EXISTS files (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    library_id    UUID NOT NULL REFERENCES libraries(id) ON DELETE CASCADE,
+    book_id       UUID REFERENCES books(id) ON DELETE CASCADE,
+    location      TEXT NOT NULL,
+    size          BIGINT NOT NULL DEFAULT 0,
+    mtime         TIMESTAMPTZ NOT NULL DEFAULT now(),
+    etag          TEXT,
+    content_hash  BYTEA,
+    format        TEXT NOT NULL,
+    last_scanned  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE(library_id, location)
+);
+
+CREATE INDEX IF NOT EXISTS idx_files_hash ON files(content_hash) WHERE content_hash IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_files_book ON files(book_id);
+CREATE INDEX IF NOT EXISTS idx_files_library ON files(library_id);
+
+ALTER TABLE books
+    ADD COLUMN IF NOT EXISTS uuid         UUID UNIQUE,
+    ADD COLUMN IF NOT EXISTS folder_path  TEXT;
+
+ALTER TABLE bookdrop_items
+    ADD COLUMN IF NOT EXISTS content_hash BYTEA;

--- a/internal/migrator/migrations/sqlite/000025_storage_v2.down.sql
+++ b/internal/migrator/migrations/sqlite/000025_storage_v2.down.sql
@@ -1,0 +1,25 @@
+-- 000025_storage_v2.down.sql (SQLite)
+-- Reverses the additive changes from 000025_storage_v2.up.sql.
+-- Legacy books.path / libraries.path were never touched, so no restore needed.
+--
+-- Note: SQLite does not support DROP COLUMN on tables with indexes or
+-- constraints referencing the column in older versions, but SQLite 3.35+
+-- (used by this project) supports ALTER TABLE ... DROP COLUMN.
+-- The IF NOT EXISTS guard on the up migration means these may be no-ops
+-- on a partially-applied migration — that is safe.
+
+ALTER TABLE bookdrop_items DROP COLUMN IF EXISTS content_hash;
+
+ALTER TABLE books DROP COLUMN IF EXISTS folder_path;
+ALTER TABLE books DROP COLUMN IF EXISTS uuid;
+
+DROP INDEX IF EXISTS idx_files_library;
+DROP INDEX IF EXISTS idx_files_book;
+DROP INDEX IF EXISTS idx_files_hash;
+DROP TABLE IF EXISTS files;
+
+ALTER TABLE libraries DROP COLUMN IF EXISTS org_mode;
+ALTER TABLE libraries DROP COLUMN IF EXISTS root;
+ALTER TABLE libraries DROP COLUMN IF EXISTS backend_id;
+
+DROP TABLE IF EXISTS storage_backends;

--- a/internal/migrator/migrations/sqlite/000025_storage_v2.up.sql
+++ b/internal/migrator/migrations/sqlite/000025_storage_v2.up.sql
@@ -11,6 +11,10 @@
 --   JSONB NOT NULL                             → TEXT NOT NULL CHECK (json_valid(col))
 --   TIMESTAMPTZ NOT NULL DEFAULT now()         → TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 --   BIGINT                                     → INTEGER
+--
+-- SQLite limitations:
+--   - "ADD COLUMN IF NOT EXISTS" is not supported by modernc.org/sqlite; plain form used.
+--   - "ADD COLUMN ... UNIQUE" is not supported; uniqueness is enforced via a separate index.
 
 CREATE TABLE IF NOT EXISTS storage_backends (
     id          TEXT PRIMARY KEY NOT NULL,
@@ -19,9 +23,9 @@ CREATE TABLE IF NOT EXISTS storage_backends (
     created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );
 
-ALTER TABLE libraries ADD COLUMN IF NOT EXISTS backend_id  TEXT REFERENCES storage_backends(id) ON DELETE RESTRICT;
-ALTER TABLE libraries ADD COLUMN IF NOT EXISTS root        TEXT;
-ALTER TABLE libraries ADD COLUMN IF NOT EXISTS org_mode    TEXT NOT NULL DEFAULT 'book_per_folder'
+ALTER TABLE libraries ADD COLUMN backend_id  TEXT REFERENCES storage_backends(id) ON DELETE RESTRICT;
+ALTER TABLE libraries ADD COLUMN root        TEXT;
+ALTER TABLE libraries ADD COLUMN org_mode    TEXT NOT NULL DEFAULT 'book_per_folder'
     CHECK (org_mode IN ('book_per_file', 'book_per_folder'));
 
 CREATE TABLE IF NOT EXISTS files (
@@ -42,7 +46,10 @@ CREATE INDEX IF NOT EXISTS idx_files_hash ON files(content_hash) WHERE content_h
 CREATE INDEX IF NOT EXISTS idx_files_book ON files(book_id);
 CREATE INDEX IF NOT EXISTS idx_files_library ON files(library_id);
 
-ALTER TABLE books ADD COLUMN IF NOT EXISTS uuid         TEXT UNIQUE;
-ALTER TABLE books ADD COLUMN IF NOT EXISTS folder_path  TEXT;
+-- SQLite does not allow ADD COLUMN ... UNIQUE; enforce uniqueness via a partial index.
+ALTER TABLE books ADD COLUMN uuid        TEXT;
+ALTER TABLE books ADD COLUMN folder_path TEXT;
 
-ALTER TABLE bookdrop_items ADD COLUMN IF NOT EXISTS content_hash BLOB;
+CREATE UNIQUE INDEX IF NOT EXISTS books_uuid_key ON books(uuid) WHERE uuid IS NOT NULL;
+
+ALTER TABLE bookdrop_items ADD COLUMN content_hash BLOB;

--- a/internal/migrator/migrations/sqlite/000025_storage_v2.up.sql
+++ b/internal/migrator/migrations/sqlite/000025_storage_v2.up.sql
@@ -1,0 +1,48 @@
+-- 000025_storage_v2.up.sql (SQLite)
+-- Plan B of 8: backend-agnostic storage identity. Additive-only;
+-- legacy books.path / libraries.path are kept and read-mirrored by
+-- the Go-level backfill helper (internal/migrator/backfill_storage_v2.go).
+-- Plan B2 drops them once API consumers cut over.
+--
+-- SQLite type translations applied:
+--   UUID PRIMARY KEY DEFAULT gen_random_uuid() → TEXT PRIMARY KEY NOT NULL  (ID supplied by app)
+--   UUID (FK)                                  → TEXT
+--   BYTEA                                      → BLOB
+--   JSONB NOT NULL                             → TEXT NOT NULL CHECK (json_valid(col))
+--   TIMESTAMPTZ NOT NULL DEFAULT now()         → TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+--   BIGINT                                     → INTEGER
+
+CREATE TABLE IF NOT EXISTS storage_backends (
+    id          TEXT PRIMARY KEY NOT NULL,
+    kind        TEXT NOT NULL CHECK (kind IN ('local', 's3')),
+    config      TEXT NOT NULL CHECK (json_valid(config)),
+    created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
+ALTER TABLE libraries ADD COLUMN IF NOT EXISTS backend_id  TEXT REFERENCES storage_backends(id) ON DELETE RESTRICT;
+ALTER TABLE libraries ADD COLUMN IF NOT EXISTS root        TEXT;
+ALTER TABLE libraries ADD COLUMN IF NOT EXISTS org_mode    TEXT NOT NULL DEFAULT 'book_per_folder'
+    CHECK (org_mode IN ('book_per_file', 'book_per_folder'));
+
+CREATE TABLE IF NOT EXISTS files (
+    id            TEXT PRIMARY KEY NOT NULL,
+    library_id    TEXT NOT NULL REFERENCES libraries(id) ON DELETE CASCADE,
+    book_id       TEXT REFERENCES books(id) ON DELETE CASCADE,
+    location      TEXT NOT NULL,
+    size          INTEGER NOT NULL DEFAULT 0,
+    mtime         TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    etag          TEXT,
+    content_hash  BLOB,
+    format        TEXT NOT NULL,
+    last_scanned  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    UNIQUE(library_id, location)
+);
+
+CREATE INDEX IF NOT EXISTS idx_files_hash ON files(content_hash) WHERE content_hash IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_files_book ON files(book_id);
+CREATE INDEX IF NOT EXISTS idx_files_library ON files(library_id);
+
+ALTER TABLE books ADD COLUMN IF NOT EXISTS uuid         TEXT UNIQUE;
+ALTER TABLE books ADD COLUMN IF NOT EXISTS folder_path  TEXT;
+
+ALTER TABLE bookdrop_items ADD COLUMN IF NOT EXISTS content_hash BLOB;

--- a/internal/model/book.go
+++ b/internal/model/book.go
@@ -20,6 +20,18 @@ type Library struct {
 	// nil means "use the hard-coded fallback" (keep the original
 	// filename).
 	FileNamingPattern *string
+	// BackendID is the FK to storage_backends. nil when the library has
+	// not yet been wired to a backend (legacy libraries created before
+	// the storage_v2 migration).
+	BackendID *string
+	// Root is the root path within the backend (e.g. "/books" for a
+	// local backend). nil when BackendID is nil.
+	Root *string
+	// OrgMode controls how the scanner groups files into books.
+	// "book_per_file" treats each file as its own book;
+	// "book_per_folder" groups all files in a folder into one book.
+	// The column is NOT NULL with DEFAULT 'book_per_folder'.
+	OrgMode string
 }
 
 type Book struct {
@@ -62,6 +74,12 @@ type Book struct {
 	CreatedAt     time.Time
 	// Path is the absolute file path on disk (or empty for seed data).
 	Path string
+	// UUID is the stable identifier assigned during the storage_v2
+	// backfill. nil until the backfill worker populates it.
+	UUID *string
+	// FolderPath is the relative folder within the library that contains
+	// this book's files. nil until backfill or scan assigns it.
+	FolderPath *string
 	// HasCover is true when a cover image lives under coverstore/books/{ID}.
 	HasCover bool
 	// CoverMime is the image's content type (e.g. "image/jpeg"). Set only

--- a/internal/model/bookdrop.go
+++ b/internal/model/bookdrop.go
@@ -32,6 +32,9 @@ type BookDropItem struct {
 	BookID       *string
 	DiscoveredAt time.Time
 	UpdatedAt    time.Time
+	// ContentHash is the SHA-256 digest of the file content, computed
+	// during ingest. nil (or empty) until Task 9 fills it.
+	ContentHash []byte
 }
 
 // IsTerminal reports whether no further transitions are expected.

--- a/internal/model/file.go
+++ b/internal/model/file.go
@@ -1,0 +1,19 @@
+package model
+
+import "time"
+
+// File mirrors the files row: a physical artifact in storage tied to
+// a logical book. content_hash is sha256 (32 bytes) and may be nil
+// while the boot-time backfill is still running.
+type File struct {
+	ID          string
+	LibraryID   string
+	BookID      string // empty when the file is orphaned (not implemented yet)
+	Location    string // relative to library.root; slash-separated
+	Size        int64
+	Mtime       time.Time
+	ETag        string // empty for local FS
+	ContentHash []byte // nil until hashed
+	Format      string // canonical: "EPUB" | "PDF" | "CBZ" | "MP3" | "M4B"
+	LastScanned time.Time
+}

--- a/internal/model/storage_backend.go
+++ b/internal/model/storage_backend.go
@@ -1,0 +1,15 @@
+package model
+
+import "time"
+
+// StorageBackend identifies a backend (filesystem or S3-compatible)
+// that one or more libraries can be rooted under. Config is the
+// JSON-encoded backend-specific configuration. For kind="local" it
+// has a single key {"root": "/abs/path"}; for "s3" it carries
+// {bucket, region, endpoint, prefix} (Plan F).
+type StorageBackend struct {
+	ID        string
+	Kind      string // "local" | "s3"
+	Config    map[string]any
+	CreatedAt time.Time
+}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -15,6 +15,7 @@ import (
 	"github.com/riverqueue/river/rivermigrate"
 
 	"github.com/blackforge/embookshelf/internal/db"
+	"github.com/blackforge/embookshelf/internal/repo"
 	"github.com/blackforge/embookshelf/internal/service"
 	"github.com/blackforge/embookshelf/internal/storage"
 	"github.com/blackforge/embookshelf/internal/task"
@@ -35,12 +36,13 @@ func New(
 	bdropSvc *service.BookDropService,
 	libSvc *service.LibraryService,
 	store storage.Storage,
+	fileRepo *repo.FileRepo,
 ) (Client, error) {
 	switch d.Dialect {
 	case db.DialectPostgres:
-		return newRiver(ctx, d, bdropSvc, libSvc, store)
+		return newRiver(ctx, d, bdropSvc, libSvc, store, fileRepo)
 	case db.DialectSQLite:
-		return newSQLiteQueue(ctx, d, bdropSvc, libSvc, store)
+		return newSQLiteQueue(ctx, d, bdropSvc, libSvc, store, fileRepo)
 	default:
 		return nil, fmt.Errorf("queue: unknown dialect %q", d.Dialect)
 	}
@@ -59,6 +61,7 @@ func newRiver(
 	bdropSvc *service.BookDropService,
 	libSvc *service.LibraryService,
 	store storage.Storage,
+	fileRepo *repo.FileRepo,
 ) (*RiverClient, error) {
 	if d.PG == nil {
 		return nil, errors.New("queue: db.PG is nil for postgres dialect")
@@ -85,6 +88,7 @@ func newRiver(
 			BookDrop: bdropSvc,
 			Lib:      libSvc,
 			Storage:  store,
+			Files:    fileRepo,
 			// Queue is set after the river.Client is constructed (cyclic dep).
 		},
 	}

--- a/internal/queue/sqlite.go
+++ b/internal/queue/sqlite.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/blackforge/embookshelf/internal/db"
+	"github.com/blackforge/embookshelf/internal/repo"
 	"github.com/blackforge/embookshelf/internal/service"
 	"github.com/blackforge/embookshelf/internal/storage"
 	"github.com/blackforge/embookshelf/internal/task"
@@ -44,6 +45,7 @@ func newSQLiteQueue(
 	bdropSvc *service.BookDropService,
 	libSvc *service.LibraryService,
 	store storage.Storage,
+	fileRepo *repo.FileRepo,
 ) (*sqliteQueue, error) {
 	q := &sqliteQueue{
 		db:       d,
@@ -58,6 +60,7 @@ func newSQLiteQueue(
 		Lib:      libSvc,
 		Queue:    q, // back-reference so LibraryScan can enqueue children
 		Storage:  store,
+		Files:    fileRepo,
 	}
 
 	q.handlers = map[string]kindHandler{

--- a/internal/queue/sqlite_test.go
+++ b/internal/queue/sqlite_test.go
@@ -176,7 +176,7 @@ func TestSQLiteQueue_restartRecovery(t *testing.T) {
 	// Construct via the real path — newSQLiteQueue runs the recovery query.
 	// Pass nil services because this test only exercises the recovery query,
 	// not the handlers.
-	q, err := newSQLiteQueue(context.Background(), d, nil, nil, nil)
+	q, err := newSQLiteQueue(context.Background(), d, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("newSQLiteQueue: %v", err)
 	}

--- a/internal/repo/bookdrop.go
+++ b/internal/repo/bookdrop.go
@@ -21,7 +21,7 @@ func NewBookDropRepo(d *db.DB) *BookDropRepo {
 
 const bdCols = `id, path, file_size, format, state, progress, error_msg,
                 title, author, description, language, has_cover, cover_mime, book_id,
-                discovered_at, updated_at`
+                discovered_at, updated_at, content_hash`
 
 // Insert records a newly-discovered file. Returns the inserted row; if a row
 // already exists for that path, returns (existing, ErrAlreadyExists).
@@ -182,7 +182,7 @@ func (r *BookDropRepo) scanBookDrop(s scanner) (model.BookDropItem, error) {
 	err := s.Scan(
 		&item.ID, &item.Path, &item.FileSize, &item.Format, &state, &item.Progress, &item.ErrorMsg,
 		&item.Title, &item.Author, &item.Description, &item.Language, &item.HasCover, &item.CoverMime, &item.BookID,
-		&discoveredAny, &updatedAny,
+		&discoveredAny, &updatedAny, &item.ContentHash,
 	)
 	if err != nil {
 		if dberr.IsNotFound(err) {
@@ -198,6 +198,39 @@ func (r *BookDropRepo) scanBookDrop(s scanner) (model.BookDropItem, error) {
 		return item, fmt.Errorf("scan updated_at: %w", err)
 	}
 	return item, nil
+}
+
+// SetContentHash records the sha256 computed during ingest.
+// PG and SQLite both bind []byte natively to BYTEA / BLOB.
+func (r *BookDropRepo) SetContentHash(ctx context.Context, itemID string, hash []byte) error {
+	const qPG = `
+		UPDATE bookdrop_items
+		SET content_hash = $2, updated_at = now()
+		WHERE id = $1
+	`
+	const qSQLite = `
+		UPDATE bookdrop_items
+		SET content_hash = ?, updated_at = (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+		WHERE id = ?
+	`
+	var res sql.Result
+	var err error
+	if r.db.Dialect == db.DialectSQLite {
+		res, err = r.db.SQL.ExecContext(ctx, qSQLite, hash, itemID)
+	} else {
+		res, err = r.db.SQL.ExecContext(ctx, qPG, itemID, hash)
+	}
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
 }
 
 func (r *BookDropRepo) collectBookDrop(rows *sql.Rows) ([]model.BookDropItem, error) {

--- a/internal/repo/bookdrop_test.go
+++ b/internal/repo/bookdrop_test.go
@@ -1,0 +1,55 @@
+package repo_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"errors"
+	"testing"
+
+	"github.com/blackforge/embookshelf/internal/repo"
+	"github.com/blackforge/embookshelf/internal/repo/repotest"
+)
+
+// TestBookDropRepo_contentHash verifies that SetContentHash persists the
+// SHA-256 bytes on a bookdrop row and that they round-trip through the scan.
+func TestBookDropRepo_contentHash(t *testing.T) {
+	for _, dialect := range []string{"sqlite", "postgres"} {
+		dialect := dialect
+		t.Run(dialect, func(t *testing.T) {
+			d := repotest.NewWithDialect(t, dialect)
+			bdr := repo.NewBookDropRepo(d)
+			ctx := t.Context()
+
+			// 1. Insert a bookdrop item; content_hash should be nil.
+			item, err := bdr.Insert(ctx, "/drop/book.epub", "EPUB", 1024)
+			if err != nil {
+				t.Fatalf("Insert: %v", err)
+			}
+			if item.ContentHash != nil {
+				t.Fatalf("ContentHash should be nil on fresh insert, got %v", item.ContentHash)
+			}
+
+			// 2. SetContentHash writes the bytes.
+			h := sha256.Sum256([]byte("file content"))
+			hashBytes := h[:]
+			if err := bdr.SetContentHash(ctx, item.ID, hashBytes); err != nil {
+				t.Fatalf("SetContentHash: %v", err)
+			}
+
+			// 3. Read back and confirm round-trip.
+			got, err := bdr.GetByID(ctx, item.ID)
+			if err != nil {
+				t.Fatalf("GetByID after SetContentHash: %v", err)
+			}
+			if !bytes.Equal(got.ContentHash, hashBytes) {
+				t.Fatalf("ContentHash mismatch: got %x, want %x", got.ContentHash, hashBytes)
+			}
+
+			// 4. SetContentHash on a missing id → ErrNotFound.
+			err = bdr.SetContentHash(ctx, "00000000-0000-0000-0000-000000000000", hashBytes)
+			if !errors.Is(err, repo.ErrNotFound) {
+				t.Fatalf("SetContentHash missing id: got %v, want ErrNotFound", err)
+			}
+		})
+	}
+}

--- a/internal/repo/file.go
+++ b/internal/repo/file.go
@@ -1,0 +1,317 @@
+package repo
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/blackforge/embookshelf/internal/db"
+	"github.com/blackforge/embookshelf/internal/db/dberr"
+	"github.com/blackforge/embookshelf/internal/model"
+)
+
+// ErrFileLocationTaken is returned by Insert when (library_id, location)
+// already exists in the files table.
+var ErrFileLocationTaken = errors.New("file location already taken in this library")
+
+// FileRepo provides access to the files table.
+type FileRepo struct {
+	db *db.DB
+}
+
+// NewFileRepo constructs a FileRepo backed by d.
+func NewFileRepo(d *db.DB) *FileRepo {
+	return &FileRepo{db: d}
+}
+
+// Insert creates a new files row. Returns ErrFileLocationTaken on
+// (library_id, location) collision. The id on f is ignored; a fresh
+// id is generated app-side and returned on the result.
+func (r *FileRepo) Insert(ctx context.Context, f model.File) (model.File, error) {
+	id := db.NewID()
+
+	// book_id is nullable — pass nil when empty.
+	var bookID any
+	if f.BookID != "" {
+		bookID = f.BookID
+	}
+	// etag is nullable — pass nil when empty.
+	var etag any
+	if f.ETag != "" {
+		etag = f.ETag
+	}
+	// content_hash is nullable — pass nil when not set.
+	var contentHash any
+	if len(f.ContentHash) > 0 {
+		contentHash = f.ContentHash
+	}
+
+	const qPG = `
+		INSERT INTO files (id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+		RETURNING id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned
+	`
+	const qSQLite = `
+		INSERT INTO files (id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		RETURNING id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned
+	`
+
+	// mtime and last_scanned: pass as time.Time on PG (pgx handles TIMESTAMPTZ),
+	// pass as ISO-8601 string on SQLite.
+	var mtimeVal, lastScannedVal any
+	if r.db.Dialect == db.DialectSQLite {
+		mtimeVal = f.Mtime.UTC().Format("2006-01-02T15:04:05.999999999Z07:00")
+		lastScannedVal = f.LastScanned.UTC().Format("2006-01-02T15:04:05.999999999Z07:00")
+	} else {
+		mtimeVal = f.Mtime
+		lastScannedVal = f.LastScanned
+	}
+
+	row := r.db.SQL.QueryRowContext(ctx,
+		db.SelectQ(r.db.Dialect, qPG, qSQLite),
+		id, f.LibraryID, bookID, f.Location, f.Size,
+		mtimeVal, etag, contentHash, f.Format, lastScannedVal,
+	)
+	result, err := r.scanFile(row)
+	if err != nil {
+		if ok, _ := dberr.IsUniqueViolation(err); ok {
+			return model.File{}, ErrFileLocationTaken
+		}
+		return model.File{}, err
+	}
+	return result, nil
+}
+
+// GetByLocation returns the file at (library_id, location). Returns
+// ErrNotFound when missing.
+func (r *FileRepo) GetByLocation(ctx context.Context, libraryID, location string) (model.File, error) {
+	const qPG = `
+		SELECT id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned
+		FROM files
+		WHERE library_id = $1 AND location = $2
+	`
+	const qSQLite = `
+		SELECT id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned
+		FROM files
+		WHERE library_id = ? AND location = ?
+	`
+	row := r.db.SQL.QueryRowContext(ctx, db.SelectQ(r.db.Dialect, qPG, qSQLite), libraryID, location)
+	f, err := r.scanFile(row)
+	if err != nil {
+		if dberr.IsNotFound(err) {
+			return model.File{}, ErrNotFound
+		}
+		return model.File{}, err
+	}
+	return f, nil
+}
+
+// GetByContentHash returns every files row with the given content_hash.
+// Used for duplicate detection at scan time. An empty slice (not nil) is
+// returned when no rows match.
+func (r *FileRepo) GetByContentHash(ctx context.Context, hash []byte) ([]model.File, error) {
+	const qPG = `
+		SELECT id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned
+		FROM files
+		WHERE content_hash = $1
+	`
+	const qSQLite = `
+		SELECT id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned
+		FROM files
+		WHERE content_hash = ?
+	`
+	rows, err := r.db.SQL.QueryContext(ctx, db.SelectQ(r.db.Dialect, qPG, qSQLite), hash)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := []model.File{}
+	for rows.Next() {
+		f, err := r.scanFile(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, f)
+	}
+	return out, rows.Err()
+}
+
+// ExistsByLocation answers whether there is already a file at this
+// (library_id, location) key without fetching the full row.
+func (r *FileRepo) ExistsByLocation(ctx context.Context, libraryID, location string) (bool, error) {
+	const qPG = `SELECT count(*) FROM files WHERE library_id = $1 AND location = $2`
+	const qSQLite = `SELECT count(*) FROM files WHERE library_id = ? AND location = ?`
+	var n int
+	err := r.db.SQL.QueryRowContext(ctx,
+		db.SelectQ(r.db.Dialect, qPG, qSQLite),
+		libraryID, location,
+	).Scan(&n)
+	return n > 0, err
+}
+
+// SetContentHash records the hash, size, and mtime once a file has been
+// scanned. Used by the boot-time backfill worker.
+func (r *FileRepo) SetContentHash(ctx context.Context, fileID string, hash []byte, size int64, mtime time.Time) error {
+	const qPG = `
+		UPDATE files
+		SET content_hash = $2,
+		    size         = $3,
+		    mtime        = $4
+		WHERE id = $1
+	`
+	const qSQLite = `
+		UPDATE files
+		SET content_hash = ?,
+		    size         = ?,
+		    mtime        = ?
+		WHERE id = ?
+	`
+
+	var mtimeVal any
+	if r.db.Dialect == db.DialectSQLite {
+		mtimeVal = mtime.UTC().Format("2006-01-02T15:04:05.999999999Z07:00")
+	} else {
+		mtimeVal = mtime
+	}
+
+	var res sql.Result
+	var err error
+	if r.db.Dialect == db.DialectSQLite {
+		res, err = r.db.SQL.ExecContext(ctx, qSQLite, hash, size, mtimeVal, fileID)
+	} else {
+		res, err = r.db.SQL.ExecContext(ctx, qPG, fileID, hash, size, mtimeVal)
+	}
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ListPendingHash returns up to batchSize files whose content_hash is
+// still NULL. Used by the backfill worker to drain the queue.
+func (r *FileRepo) ListPendingHash(ctx context.Context, batchSize int) ([]model.File, error) {
+	const qPG = `
+		SELECT id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned
+		FROM files
+		WHERE content_hash IS NULL
+		ORDER BY id
+		LIMIT $1
+	`
+	const qSQLite = `
+		SELECT id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned
+		FROM files
+		WHERE content_hash IS NULL
+		ORDER BY id
+		LIMIT ?
+	`
+	rows, err := r.db.SQL.QueryContext(ctx, db.SelectQ(r.db.Dialect, qPG, qSQLite), batchSize)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []model.File
+	for rows.Next() {
+		f, err := r.scanFile(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, f)
+	}
+	return out, rows.Err()
+}
+
+// MarkScanned bumps last_scanned to now without changing the hash. Used
+// by the scan worker to record that a file was inspected.
+func (r *FileRepo) MarkScanned(ctx context.Context, fileID string) error {
+	const qPG = `UPDATE files SET last_scanned = now() WHERE id = $1`
+	const qSQLite = `UPDATE files SET last_scanned = (strftime('%Y-%m-%dT%H:%M:%fZ','now')) WHERE id = ?`
+	res, err := r.db.SQL.ExecContext(ctx, db.SelectQ(r.db.Dialect, qPG, qSQLite), fileID)
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// scanFile scans a files row into a model.File. s may be a *sql.Row or
+// *sql.Rows — both implement the scanner interface.
+func (r *FileRepo) scanFile(s scanner) (model.File, error) {
+	var f model.File
+	var bookIDAny any
+	var etagAny any
+	var contentHashAny any
+	var mtimeAny any
+	var lastScannedAny any
+
+	err := s.Scan(
+		&f.ID, &f.LibraryID, &bookIDAny, &f.Location,
+		&f.Size, &mtimeAny, &etagAny, &contentHashAny,
+		&f.Format, &lastScannedAny,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return f, sql.ErrNoRows
+		}
+		return f, err
+	}
+
+	// Nullable book_id
+	if bookIDAny != nil {
+		switch v := bookIDAny.(type) {
+		case string:
+			f.BookID = v
+		case []byte:
+			f.BookID = string(v)
+		}
+	}
+
+	// Nullable etag
+	if etagAny != nil {
+		switch v := etagAny.(type) {
+		case string:
+			f.ETag = v
+		case []byte:
+			f.ETag = string(v)
+		}
+	}
+
+	// Nullable content_hash — BYTEA on PG, BLOB on SQLite, both map to []byte.
+	if contentHashAny != nil {
+		switch v := contentHashAny.(type) {
+		case []byte:
+			f.ContentHash = v
+		case string:
+			f.ContentHash = []byte(v)
+		}
+	}
+
+	// mtime: non-nullable TIMESTAMPTZ (PG) / TEXT ISO-8601 (SQLite)
+	if err := db.ScanTime(r.db.Dialect, mtimeAny, &f.Mtime); err != nil {
+		return f, fmt.Errorf("scan mtime: %w", err)
+	}
+
+	// last_scanned: non-nullable
+	if err := db.ScanTime(r.db.Dialect, lastScannedAny, &f.LastScanned); err != nil {
+		return f, fmt.Errorf("scan last_scanned: %w", err)
+	}
+
+	return f, nil
+}

--- a/internal/repo/file_test.go
+++ b/internal/repo/file_test.go
@@ -1,0 +1,213 @@
+package repo_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/blackforge/embookshelf/internal/model"
+	"github.com/blackforge/embookshelf/internal/repo"
+	"github.com/blackforge/embookshelf/internal/repo/repotest"
+)
+
+func TestFileRepo_matrix(t *testing.T) {
+	for _, dialect := range []string{"sqlite", "postgres"} {
+		dialect := dialect
+		t.Run(dialect, func(t *testing.T) {
+			d := repotest.NewWithDialect(t, dialect)
+			fr := repo.NewFileRepo(d)
+			lr := repo.NewLibraryRepo(d)
+			ctx := context.Background()
+
+			// Seed a library that files can reference.
+			lib, err := lr.CreateLibrary(ctx, "Test Library", "test-library", "/tmp/test")
+			if err != nil {
+				t.Fatalf("CreateLibrary: %v", err)
+			}
+
+			// --- 1. Insert + GetByLocation roundtrip ---
+			now := time.Now().UTC().Truncate(time.Millisecond)
+			f := model.File{
+				LibraryID:   lib.ID,
+				Location:    "subdir/book.epub",
+				Size:        1024,
+				Mtime:       now,
+				Format:      "EPUB",
+				LastScanned: now,
+			}
+			inserted, err := fr.Insert(ctx, f)
+			if err != nil {
+				t.Fatalf("Insert: %v", err)
+			}
+			if inserted.ID == "" {
+				t.Fatal("Insert returned empty ID")
+			}
+			if inserted.LibraryID != lib.ID {
+				t.Fatalf("LibraryID=%q want %q", inserted.LibraryID, lib.ID)
+			}
+			if inserted.Location != f.Location {
+				t.Fatalf("Location=%q want %q", inserted.Location, f.Location)
+			}
+			if inserted.Format != "EPUB" {
+				t.Fatalf("Format=%q want EPUB", inserted.Format)
+			}
+			if inserted.ContentHash != nil {
+				t.Fatal("ContentHash should be nil on fresh insert")
+			}
+
+			got, err := fr.GetByLocation(ctx, lib.ID, "subdir/book.epub")
+			if err != nil {
+				t.Fatalf("GetByLocation: %v", err)
+			}
+			if got.ID != inserted.ID {
+				t.Fatalf("GetByLocation ID=%q want %q", got.ID, inserted.ID)
+			}
+
+			// --- 2. GetByLocation not found ---
+			_, err = fr.GetByLocation(ctx, lib.ID, "nonexistent/path.epub")
+			if !errors.Is(err, repo.ErrNotFound) {
+				t.Fatalf("GetByLocation missing: got %v, want ErrNotFound", err)
+			}
+
+			// --- 3. ExistsByLocation true/false ---
+			exists, err := fr.ExistsByLocation(ctx, lib.ID, "subdir/book.epub")
+			if err != nil {
+				t.Fatalf("ExistsByLocation: %v", err)
+			}
+			if !exists {
+				t.Fatal("ExistsByLocation: should be true for existing file")
+			}
+			exists, err = fr.ExistsByLocation(ctx, lib.ID, "no/such/file.epub")
+			if err != nil {
+				t.Fatalf("ExistsByLocation missing: %v", err)
+			}
+			if exists {
+				t.Fatal("ExistsByLocation: should be false for missing file")
+			}
+
+			// --- 4. GetByContentHash returns multiple ---
+			// Hash two different files with the same content so they share a hash.
+			h := sha256.Sum256([]byte("shared content"))
+			hashBytes := h[:]
+
+			f2 := model.File{
+				LibraryID:   lib.ID,
+				Location:    "copy1.pdf",
+				Size:        100,
+				Mtime:       now,
+				Format:      "PDF",
+				LastScanned: now,
+				ContentHash: hashBytes,
+			}
+			f3 := model.File{
+				LibraryID:   lib.ID,
+				Location:    "copy2.pdf",
+				Size:        100,
+				Mtime:       now,
+				Format:      "PDF",
+				LastScanned: now,
+				ContentHash: hashBytes,
+			}
+			ins2, err := fr.Insert(ctx, f2)
+			if err != nil {
+				t.Fatalf("Insert f2: %v", err)
+			}
+			ins3, err := fr.Insert(ctx, f3)
+			if err != nil {
+				t.Fatalf("Insert f3: %v", err)
+			}
+			byHash, err := fr.GetByContentHash(ctx, hashBytes)
+			if err != nil {
+				t.Fatalf("GetByContentHash: %v", err)
+			}
+			if len(byHash) != 2 {
+				t.Fatalf("GetByContentHash len=%d want 2", len(byHash))
+			}
+			ids := map[string]bool{ins2.ID: true, ins3.ID: true}
+			for _, r := range byHash {
+				if !ids[r.ID] {
+					t.Fatalf("GetByContentHash returned unexpected ID %q", r.ID)
+				}
+				if !bytes.Equal(r.ContentHash, hashBytes) {
+					t.Fatalf("GetByContentHash content_hash mismatch")
+				}
+			}
+
+			// --- 5. SetContentHash transitions NULL → set ---
+			// ListPendingHash should return the file we inserted without a hash.
+			pending, err := fr.ListPendingHash(ctx, 10)
+			if err != nil {
+				t.Fatalf("ListPendingHash: %v", err)
+			}
+			// inserted (f) has NULL hash; f2 and f3 already have one.
+			if len(pending) != 1 {
+				t.Fatalf("ListPendingHash len=%d want 1", len(pending))
+			}
+			if pending[0].ID != inserted.ID {
+				t.Fatalf("ListPendingHash returned wrong file ID %q", pending[0].ID)
+			}
+
+			newHash := sha256.Sum256([]byte("new content"))
+			newMtime := now.Add(time.Second)
+			if err := fr.SetContentHash(ctx, inserted.ID, newHash[:], 2048, newMtime); err != nil {
+				t.Fatalf("SetContentHash: %v", err)
+			}
+			// Confirm hash is now set.
+			updated, err := fr.GetByLocation(ctx, lib.ID, "subdir/book.epub")
+			if err != nil {
+				t.Fatalf("GetByLocation after SetContentHash: %v", err)
+			}
+			if !bytes.Equal(updated.ContentHash, newHash[:]) {
+				t.Fatalf("ContentHash mismatch after SetContentHash")
+			}
+			if updated.Size != 2048 {
+				t.Fatalf("Size=%d want 2048", updated.Size)
+			}
+
+			// --- 6. ListPendingHash respects batch size ---
+			// Insert 3 more files without a hash.
+			for i := 0; i < 3; i++ {
+				_, err := fr.Insert(ctx, model.File{
+					LibraryID:   lib.ID,
+					Location:    "batch/file" + string(rune('a'+i)) + ".epub",
+					Size:        10,
+					Mtime:       now,
+					Format:      "EPUB",
+					LastScanned: now,
+				})
+				if err != nil {
+					t.Fatalf("Insert batch[%d]: %v", i, err)
+				}
+			}
+			limited, err := fr.ListPendingHash(ctx, 2)
+			if err != nil {
+				t.Fatalf("ListPendingHash batchSize=2: %v", err)
+			}
+			if len(limited) != 2 {
+				t.Fatalf("ListPendingHash batch limit=%d want 2", len(limited))
+			}
+
+			// --- 7. MarkScanned updates last_scanned ---
+			if err := fr.MarkScanned(ctx, inserted.ID); err != nil {
+				t.Fatalf("MarkScanned: %v", err)
+			}
+			// We can't assert the exact timestamp but we can confirm no error was returned.
+
+			// --- 8. Insert collision → ErrFileLocationTaken ---
+			_, err = fr.Insert(ctx, model.File{
+				LibraryID:   lib.ID,
+				Location:    "subdir/book.epub", // same as inserted
+				Size:        1,
+				Mtime:       now,
+				Format:      "EPUB",
+				LastScanned: now,
+			})
+			if !errors.Is(err, repo.ErrFileLocationTaken) {
+				t.Fatalf("dup insert: got %v, want ErrFileLocationTaken", err)
+			}
+		})
+	}
+}

--- a/internal/repo/library.go
+++ b/internal/repo/library.go
@@ -1016,3 +1016,33 @@ func (r *LibraryRepo) SearchSuggestLibraries(ctx context.Context, q string, limi
 	}
 	return out, rows.Err()
 }
+
+// SetBackendID wires a library to a storage backend by writing the
+// backend_id FK column. Pass an empty string to clear the association.
+// Used by StorageBackendRepo tests and the library-update handler.
+func (r *LibraryRepo) SetBackendID(ctx context.Context, libraryID, backendID string) error {
+	const qPG = `UPDATE libraries SET backend_id = $2 WHERE id = $1`
+	const qSQLite = `UPDATE libraries SET backend_id = ? WHERE id = ?`
+	var nilableBackend any
+	if backendID != "" {
+		nilableBackend = backendID
+	}
+	var res sql.Result
+	var err error
+	if r.db.Dialect == db.DialectSQLite {
+		res, err = r.db.SQL.ExecContext(ctx, qSQLite, nilableBackend, libraryID)
+	} else {
+		res, err = r.db.SQL.ExecContext(ctx, qPG, libraryID, nilableBackend)
+	}
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}

--- a/internal/repo/library.go
+++ b/internal/repo/library.go
@@ -35,7 +35,8 @@ const bookCols = `
 	b.isbn_locked, b.isbn10_locked, b.language_locked,
 	b.publish_date_locked, b.genres_locked, b.moods_locked,
 	b.tags_locked, b.pages_locked, b.cover_locked,
-	b.duration_seconds, b.narrator, b.chapters
+	b.duration_seconds, b.narrator, b.chapters,
+	b.uuid, b.folder_path
 `
 
 // bookFromPG is the FROM + LEFT JOIN clause for Postgres queries, where
@@ -90,7 +91,8 @@ const libCols = `
 		(SELECT COUNT(*) FROM books b
 		 WHERE b.library_id = l.id AND b.deleted_at IS NULL),
 		0
-	) AS book_count
+	) AS book_count,
+	l.backend_id, l.root, l.org_mode
 `
 
 // libColsReturning is the same projection for RETURNING clauses where
@@ -103,7 +105,8 @@ const libColsReturning = `
 		(SELECT COUNT(*) FROM books b
 		 WHERE b.library_id = libraries.id AND b.deleted_at IS NULL),
 		0
-	) AS book_count
+	) AS book_count,
+	backend_id, root, org_mode
 `
 
 // CreateLibrary inserts a new library row and returns the persisted
@@ -228,10 +231,12 @@ func (r *LibraryRepo) TouchScan(ctx context.Context, id string, fileCount, disco
 func (r *LibraryRepo) scanLibrary(s scanner) (model.Library, error) {
 	var l model.Library
 	var lastScannedAny, createdAny any
+	var backendID, root sql.NullString
 	err := s.Scan(
 		&l.ID, &l.Name, &l.Slug, &l.Path,
 		&lastScannedAny, &l.FileCount, &l.DiscoveredCount,
 		&l.FileNamingPattern, &createdAny, &l.BookCount,
+		&backendID, &root, &l.OrgMode,
 	)
 	if err != nil {
 		return l, err
@@ -241,6 +246,14 @@ func (r *LibraryRepo) scanLibrary(s scanner) (model.Library, error) {
 	}
 	if err := db.ScanTime(r.db.Dialect, createdAny, &l.CreatedAt); err != nil {
 		return l, fmt.Errorf("scan created_at: %w", err)
+	}
+	if backendID.Valid {
+		s := backendID.String
+		l.BackendID = &s
+	}
+	if root.Valid {
+		s := root.String
+		l.Root = &s
 	}
 	return l, nil
 }
@@ -479,7 +492,8 @@ func (r *LibraryRepo) Create(ctx context.Context, b model.Book) (model.Book, err
 		       b.isbn_locked, b.isbn10_locked, b.language_locked,
 		       b.publish_date_locked, b.genres_locked, b.moods_locked,
 		       b.tags_locked, b.pages_locked, b.cover_locked,
-		       b.duration_seconds, b.narrator, b.chapters
+		       b.duration_seconds, b.narrator, b.chapters,
+		       b.uuid, b.folder_path
 		FROM inserted b
 	`
 
@@ -514,7 +528,8 @@ func (r *LibraryRepo) Create(ctx context.Context, b model.Book) (model.Book, err
 		    isbn_locked, isbn10_locked, language_locked,
 		    publish_date_locked, genres_locked, moods_locked,
 		    tags_locked, pages_locked, cover_locked,
-		    duration_seconds, narrator, chapters
+		    duration_seconds, narrator, chapters,
+		    uuid, folder_path
 	`
 
 	row := r.db.SQL.QueryRowContext(ctx, db.SelectQ(r.db.Dialect, qPG, qSQLite), args...)
@@ -837,6 +852,7 @@ func scanBook(d db.Dialect, s scanner) (model.Book, error) {
 	var b model.Book
 	var genresAny, moodsAny, tagsAny, publishDateAny, createdAny any
 	var durationAny, chaptersAny any
+	var bookUUID, folderPath sql.NullString
 	err := s.Scan(
 		&b.ID, &b.LibraryID, &b.Title, &b.Subtitle, &b.Author, &b.Format, &b.Year,
 		&publishDateAny, &b.Language,
@@ -854,6 +870,7 @@ func scanBook(d db.Dialect, s scanner) (model.Book, error) {
 		&b.Locks.PublishDate, &b.Locks.Genres, &b.Locks.Moods,
 		&b.Locks.Tags, &b.Locks.Pages, &b.Locks.Cover,
 		&durationAny, &b.Narrator, &chaptersAny,
+		&bookUUID, &folderPath,
 	)
 	if err != nil {
 		return b, err
@@ -893,6 +910,14 @@ func scanBook(d db.Dialect, s scanner) (model.Book, error) {
 				b.Chapters = ch
 			}
 		}
+	}
+	if bookUUID.Valid {
+		s := bookUUID.String
+		b.UUID = &s
+	}
+	if folderPath.Valid {
+		s := folderPath.String
+		b.FolderPath = &s
 	}
 	return b, nil
 }
@@ -1015,6 +1040,52 @@ func (r *LibraryRepo) SearchSuggestLibraries(ctx context.Context, q string, limi
 		out = append(out, l)
 	}
 	return out, rows.Err()
+}
+
+// LibraryBackend returns the storage_backends row associated with the given
+// library by joining through the backend_id FK. Returns ErrNotFound when the
+// library either does not exist or has no backend_id set yet.
+func (r *LibraryRepo) LibraryBackend(ctx context.Context, libraryID string) (model.StorageBackend, error) {
+	const qPG = `
+		SELECT sb.id, sb.kind, sb.config, sb.created_at
+		FROM libraries l
+		JOIN storage_backends sb ON sb.id = l.backend_id
+		WHERE l.id = $1
+	`
+	const qSQLite = `
+		SELECT sb.id, sb.kind, sb.config, sb.created_at
+		FROM libraries l
+		JOIN storage_backends sb ON sb.id = l.backend_id
+		WHERE l.id = ?
+	`
+	row := r.db.SQL.QueryRowContext(ctx, db.SelectQ(r.db.Dialect, qPG, qSQLite), libraryID)
+
+	// Re-use the same scan logic as StorageBackendRepo to avoid duplication.
+	var b model.StorageBackend
+	var configRaw, createdAny any
+	if err := row.Scan(&b.ID, &b.Kind, &configRaw, &createdAny); err != nil {
+		if dberr.IsNotFound(err) {
+			return model.StorageBackend{}, ErrNotFound
+		}
+		return model.StorageBackend{}, err
+	}
+
+	var raw []byte
+	switch v := configRaw.(type) {
+	case []byte:
+		raw = v
+	case string:
+		raw = []byte(v)
+	default:
+		return model.StorageBackend{}, fmt.Errorf("unexpected type for config column: %T", configRaw)
+	}
+	if err := json.Unmarshal(raw, &b.Config); err != nil {
+		return model.StorageBackend{}, fmt.Errorf("decode config: %w", err)
+	}
+	if err := db.ScanTime(r.db.Dialect, createdAny, &b.CreatedAt); err != nil {
+		return model.StorageBackend{}, fmt.Errorf("scan created_at: %w", err)
+	}
+	return b, nil
 }
 
 // SetBackendID wires a library to a storage backend by writing the

--- a/internal/repo/library_test.go
+++ b/internal/repo/library_test.go
@@ -9,6 +9,70 @@ import (
 	"github.com/blackforge/embookshelf/internal/repo/repotest"
 )
 
+// TestLibraryRepo_backendFields verifies that the new storage_v2 columns
+// (backend_id, root, org_mode) round-trip through the repo layer and that
+// LibraryBackend joins through correctly.
+func TestLibraryRepo_backendFields(t *testing.T) {
+	for _, dialect := range []string{"sqlite", "postgres"} {
+		dialect := dialect
+		t.Run(dialect, func(t *testing.T) {
+			d := repotest.NewWithDialect(t, dialect)
+			lr := repo.NewLibraryRepo(d)
+			sbr := repo.NewStorageBackendRepo(d)
+			ctx := context.Background()
+
+			// 1. Fresh library has nil BackendID and nil Root; OrgMode defaults to 'book_per_folder'.
+			lib, err := lr.CreateLibrary(ctx, "Backend Test", "backend-test", "/tmp/bt")
+			if err != nil {
+				t.Fatalf("CreateLibrary: %v", err)
+			}
+			if lib.BackendID != nil {
+				t.Fatalf("BackendID should be nil on fresh library, got %v", lib.BackendID)
+			}
+			if lib.Root != nil {
+				t.Fatalf("Root should be nil on fresh library, got %v", lib.Root)
+			}
+			if lib.OrgMode != "book_per_folder" {
+				t.Fatalf("OrgMode=%q want book_per_folder", lib.OrgMode)
+			}
+
+			// 2. LibraryBackend returns ErrNotFound when no backend is set.
+			_, err = lr.LibraryBackend(ctx, lib.ID)
+			if !errors.Is(err, repo.ErrNotFound) {
+				t.Fatalf("LibraryBackend (no backend): got %v, want ErrNotFound", err)
+			}
+
+			// 3. Wire a backend and read the library back.
+			backend, err := sbr.Create(ctx, "local", map[string]any{"root": "/data"})
+			if err != nil {
+				t.Fatalf("Create backend: %v", err)
+			}
+			if err := lr.SetBackendID(ctx, lib.ID, backend.ID); err != nil {
+				t.Fatalf("SetBackendID: %v", err)
+			}
+			got, err := lr.GetByID(ctx, lib.ID)
+			if err != nil {
+				t.Fatalf("GetByID after SetBackendID: %v", err)
+			}
+			if got.BackendID == nil || *got.BackendID != backend.ID {
+				t.Fatalf("BackendID=%v want %q", got.BackendID, backend.ID)
+			}
+
+			// 4. LibraryBackend now returns the joined backend row.
+			sb, err := lr.LibraryBackend(ctx, lib.ID)
+			if err != nil {
+				t.Fatalf("LibraryBackend: %v", err)
+			}
+			if sb.ID != backend.ID {
+				t.Fatalf("LibraryBackend ID=%q want %q", sb.ID, backend.ID)
+			}
+			if sb.Kind != "local" {
+				t.Fatalf("LibraryBackend Kind=%q want local", sb.Kind)
+			}
+		})
+	}
+}
+
 // TestLibraryRepo_matrix runs a single end-to-end CRUD scenario against
 // both SQLite and Postgres. The Postgres subtest is skipped when
 // TEST_DATABASE_URL is unset (per repotest.NewWithDialect contract).

--- a/internal/repo/storage_backend.go
+++ b/internal/repo/storage_backend.go
@@ -1,0 +1,165 @@
+package repo
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/blackforge/embookshelf/internal/db"
+	"github.com/blackforge/embookshelf/internal/db/dberr"
+	"github.com/blackforge/embookshelf/internal/model"
+)
+
+// ErrStorageBackendInUse is returned by Delete when at least one library
+// still references the backend via its backend_id FK. The caller should
+// surface this as HTTP 409 with a message prompting the user to
+// re-home or delete those libraries first.
+var ErrStorageBackendInUse = errors.New("storage backend is still in use by one or more libraries")
+
+// StorageBackendRepo provides CRUD access to the storage_backends table.
+type StorageBackendRepo struct {
+	db *db.DB
+}
+
+// NewStorageBackendRepo constructs a StorageBackendRepo backed by d.
+func NewStorageBackendRepo(d *db.DB) *StorageBackendRepo {
+	return &StorageBackendRepo{db: d}
+}
+
+// Create inserts a new storage backend row and returns the persisted record.
+// The id is generated app-side so the same INSERT works on both PG (UUID col)
+// and SQLite (TEXT col).
+func (r *StorageBackendRepo) Create(ctx context.Context, kind string, config map[string]any) (model.StorageBackend, error) {
+	id := db.NewID()
+
+	cfgJSON, err := json.Marshal(config)
+	if err != nil {
+		return model.StorageBackend{}, fmt.Errorf("encode config: %w", err)
+	}
+
+	// On Postgres the config column is JSONB; we cast the parameter explicitly
+	// so the driver does not have to guess the target OID.
+	const qPG = `
+		INSERT INTO storage_backends (id, kind, config)
+		VALUES ($1, $2, $3::jsonb)
+		RETURNING id, kind, config, created_at
+	`
+	const qSQLite = `
+		INSERT INTO storage_backends (id, kind, config)
+		VALUES (?, ?, ?)
+		RETURNING id, kind, config, created_at
+	`
+
+	row := r.db.SQL.QueryRowContext(ctx,
+		db.SelectQ(r.db.Dialect, qPG, qSQLite),
+		id, kind, string(cfgJSON),
+	)
+	return r.scanBackend(row)
+}
+
+// Get returns the backend with the given id. Returns ErrNotFound when missing.
+func (r *StorageBackendRepo) Get(ctx context.Context, id string) (model.StorageBackend, error) {
+	const qPG = `
+		SELECT id, kind, config, created_at
+		FROM storage_backends
+		WHERE id = $1
+	`
+	const qSQLite = `
+		SELECT id, kind, config, created_at
+		FROM storage_backends
+		WHERE id = ?
+	`
+	row := r.db.SQL.QueryRowContext(ctx, db.SelectQ(r.db.Dialect, qPG, qSQLite), id)
+	b, err := r.scanBackend(row)
+	if err != nil {
+		if dberr.IsNotFound(err) {
+			return model.StorageBackend{}, ErrNotFound
+		}
+		return model.StorageBackend{}, err
+	}
+	return b, nil
+}
+
+// List returns all backends ordered by created_at ASC.
+func (r *StorageBackendRepo) List(ctx context.Context) ([]model.StorageBackend, error) {
+	rows, err := r.db.SQL.QueryContext(ctx, `
+		SELECT id, kind, config, created_at
+		FROM storage_backends
+		ORDER BY created_at ASC
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []model.StorageBackend
+	for rows.Next() {
+		b, err := r.scanBackend(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, b)
+	}
+	return out, rows.Err()
+}
+
+// Delete removes the backend. Returns ErrStorageBackendInUse when any
+// library still references it (FK ON DELETE RESTRICT).
+func (r *StorageBackendRepo) Delete(ctx context.Context, id string) error {
+	const qPG = `DELETE FROM storage_backends WHERE id = $1`
+	const qSQLite = `DELETE FROM storage_backends WHERE id = ?`
+	res, err := r.db.SQL.ExecContext(ctx, db.SelectQ(r.db.Dialect, qPG, qSQLite), id)
+	if err != nil {
+		if dberr.IsForeignKeyViolation(err) {
+			return ErrStorageBackendInUse
+		}
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// scanner is shared with library.go to avoid re-declaring it; it is
+// already declared in that file within the same package.
+
+func (r *StorageBackendRepo) scanBackend(s scanner) (model.StorageBackend, error) {
+	var b model.StorageBackend
+	var configRaw any
+	var createdAny any
+
+	err := s.Scan(&b.ID, &b.Kind, &configRaw, &createdAny)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return b, sql.ErrNoRows
+		}
+		return b, err
+	}
+
+	// Decode JSON config. Postgres JSONB arrives as []byte, SQLite TEXT arrives
+	// as string. Both are valid JSON.
+	var raw []byte
+	switch v := configRaw.(type) {
+	case []byte:
+		raw = v
+	case string:
+		raw = []byte(v)
+	default:
+		return b, fmt.Errorf("unexpected type for config column: %T", configRaw)
+	}
+	if err := json.Unmarshal(raw, &b.Config); err != nil {
+		return b, fmt.Errorf("decode config: %w", err)
+	}
+
+	if err := db.ScanTime(r.db.Dialect, createdAny, &b.CreatedAt); err != nil {
+		return b, fmt.Errorf("scan created_at: %w", err)
+	}
+	return b, nil
+}

--- a/internal/repo/storage_backend_test.go
+++ b/internal/repo/storage_backend_test.go
@@ -1,0 +1,99 @@
+package repo_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/blackforge/embookshelf/internal/repo"
+	"github.com/blackforge/embookshelf/internal/repo/repotest"
+)
+
+func TestStorageBackendRepo_matrix(t *testing.T) {
+	for _, dialect := range []string{"sqlite", "postgres"} {
+		dialect := dialect
+		t.Run(dialect, func(t *testing.T) {
+			d := repotest.NewWithDialect(t, dialect)
+			r := repo.NewStorageBackendRepo(d)
+			lr := repo.NewLibraryRepo(d)
+			ctx := context.Background()
+
+			// 1. Create + List
+			cfg := map[string]any{"root": "/tmp/books"}
+			b, err := r.Create(ctx, "local", cfg)
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			if b.ID == "" {
+				t.Fatal("Create returned empty ID")
+			}
+			if b.Kind != "local" {
+				t.Fatalf("Kind=%q want local", b.Kind)
+			}
+			if b.Config["root"] != "/tmp/books" {
+				t.Fatalf("Config root=%v want /tmp/books", b.Config["root"])
+			}
+			if b.CreatedAt.IsZero() {
+				t.Fatal("CreatedAt is zero")
+			}
+
+			list, err := r.List(ctx)
+			if err != nil {
+				t.Fatalf("List: %v", err)
+			}
+			if len(list) != 1 {
+				t.Fatalf("List len=%d want 1", len(list))
+			}
+			if list[0].ID != b.ID {
+				t.Fatalf("List[0].ID=%q want %q", list[0].ID, b.ID)
+			}
+
+			// 2. Get found
+			got, err := r.Get(ctx, b.ID)
+			if err != nil {
+				t.Fatalf("Get: %v", err)
+			}
+			if got.ID != b.ID || got.Kind != b.Kind {
+				t.Fatalf("Get round-trip mismatch: %+v", got)
+			}
+
+			// 3. Get not found
+			_, err = r.Get(ctx, "00000000-0000-0000-0000-000000000000")
+			if !errors.Is(err, repo.ErrNotFound) {
+				t.Fatalf("Get missing: got %v, want ErrNotFound", err)
+			}
+
+			// 4. Delete success (no libraries reference it yet)
+			if err := r.Delete(ctx, b.ID); err != nil {
+				t.Fatalf("Delete: %v", err)
+			}
+			// Confirm it's gone
+			if _, err := r.Get(ctx, b.ID); !errors.Is(err, repo.ErrNotFound) {
+				t.Fatalf("post-delete Get: got %v, want ErrNotFound", err)
+			}
+
+			// 5. Delete-while-library-references-it → ErrStorageBackendInUse
+			//
+			// Create a fresh backend, wire up a library to it, then try to
+			// delete the backend. The FK ON DELETE RESTRICT should fire.
+			b2, err := r.Create(ctx, "local", map[string]any{"root": "/tmp/ref"})
+			if err != nil {
+				t.Fatalf("Create b2: %v", err)
+			}
+			// Create a library that points at b2.
+			lib, err := lr.CreateLibrary(ctx, "Ref Library", "ref-library", "/tmp/ref")
+			if err != nil {
+				t.Fatalf("CreateLibrary: %v", err)
+			}
+			// Wire the library to b2 via backend_id.
+			if err := lr.SetBackendID(ctx, lib.ID, b2.ID); err != nil {
+				t.Fatalf("SetBackendID: %v", err)
+			}
+			// Now deleting b2 should fail.
+			err = r.Delete(ctx, b2.ID)
+			if !errors.Is(err, repo.ErrStorageBackendInUse) {
+				t.Fatalf("Delete in-use backend: got %v, want ErrStorageBackendInUse", err)
+			}
+		})
+	}
+}

--- a/internal/service/bookdrop.go
+++ b/internal/service/bookdrop.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/blackforge/embookshelf/internal/coverstore"
 	"github.com/blackforge/embookshelf/internal/fileproc"
@@ -29,6 +30,10 @@ type BookDropService struct {
 	settings *repo.AppSettingsRepo
 	covers   *coverstore.Store
 	hub      *sse.Hub
+	// files is the storage_v2 file repo. When non-nil, Approve writes a
+	// files row alongside the new book. nil disables the write so callers
+	// (e.g. tests) that don't need the row don't have to supply a repo.
+	files *repo.FileRepo
 }
 
 func NewBookDropService(
@@ -37,6 +42,7 @@ func NewBookDropService(
 	settings *repo.AppSettingsRepo,
 	covers *coverstore.Store,
 	hub *sse.Hub,
+	files *repo.FileRepo,
 ) *BookDropService {
 	return &BookDropService{
 		bdrop:    bdrop,
@@ -44,6 +50,7 @@ func NewBookDropService(
 		settings: settings,
 		covers:   covers,
 		hub:      hub,
+		files:    files,
 	}
 }
 
@@ -167,6 +174,38 @@ func (s *BookDropService) Approve(ctx context.Context, id, libraryID string) (mo
 	created, err := s.libs.Create(ctx, book)
 	if err != nil {
 		return created, err
+	}
+
+	// Persist the storage_v2 files row alongside the book. content_hash
+	// was computed at ingest (Task 9); fall back to nil if it's missing,
+	// the boot worker will fill it on next start.
+	if s.files != nil {
+		location := relativizeBookLocation(ctx, s.libs, libraryID, book.Path)
+		size := int64(0)
+		var mtime time.Time
+		if st, statErr := os.Stat(book.Path); statErr == nil {
+			size = st.Size()
+			mtime = st.ModTime()
+		} else {
+			mtime = time.Now()
+		}
+		f := model.File{
+			LibraryID:   libraryID,
+			BookID:      created.ID,
+			Location:    location,
+			Size:        size,
+			Mtime:       mtime,
+			ContentHash: item.ContentHash,
+			Format:      created.Format,
+			LastScanned: time.Now(),
+		}
+		if _, err := s.files.Insert(ctx, f); err != nil {
+			// Duplicate location is benign — a re-import of an existing
+			// path. Other errors are logged but don't fail the approve.
+			if !errors.Is(err, repo.ErrFileLocationTaken) {
+				slog.Warn("approve: insert files row", "book_id", created.ID, "err", err)
+			}
+		}
 	}
 
 	// Best-effort: move the pre-approval cover into the book namespace.
@@ -438,4 +477,32 @@ func fallback(s, def string) string {
 		return def
 	}
 	return s
+}
+
+// relativizeBookLocation strips the library root from abs, returning the
+// path the files table stores. Falls back to abs on any lookup failure or
+// when the path doesn't sit under the library root.
+func relativizeBookLocation(ctx context.Context, libs *repo.LibraryRepo, libraryID, abs string) string {
+	lib, err := libs.GetByID(ctx, libraryID)
+	if err != nil {
+		return abs
+	}
+	root := ""
+	if lib.Root != nil {
+		root = *lib.Root
+	}
+	if root == "" {
+		root = lib.Path
+	}
+	if root == "" {
+		return abs
+	}
+	prefix := root
+	if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+	if strings.HasPrefix(abs, prefix) {
+		return abs[len(prefix):]
+	}
+	return abs
 }

--- a/internal/service/bookdrop.go
+++ b/internal/service/bookdrop.go
@@ -103,6 +103,12 @@ func (s *BookDropService) RecordMetadata(
 	return nil
 }
 
+// SetContentHash persists the sha256 computed by the ingest worker.
+// Plan B Task 9 / 11.
+func (s *BookDropService) SetContentHash(ctx context.Context, id string, hash []byte) error {
+	return s.bdrop.SetContentHash(ctx, id, hash)
+}
+
 func (s *BookDropService) Fail(ctx context.Context, id string, err error) error {
 	msg := err.Error()
 	if len(msg) > 500 {

--- a/internal/task/bookdrop.go
+++ b/internal/task/bookdrop.go
@@ -6,8 +6,11 @@ package task
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
+	"io"
 	"log/slog"
+	"os"
 
 	"github.com/riverqueue/river"
 
@@ -43,6 +46,24 @@ func BookDropIngest(ctx context.Context, args BookDropIngestArgs, deps BookDropD
 	if err := deps.Svc.BeginProcessing(ctx, itemID); err != nil {
 		return err
 	}
+
+	// Compute the content hash from a dedicated read pass. EPUB/PDF/CBZ
+	// need random access for metadata extraction, so we don't share the
+	// stream with the processor — one extra full read is cheap relative
+	// to the metadata work itself.
+	if hash, err := hashFile(ctx, item.Path); err != nil {
+		slog.Warn("bookdrop hash failed", "item_id", itemID, "path", item.Path, "err", err)
+		// Non-fatal: missing or unreadable file → mark as failed and stop.
+		_ = deps.Svc.Fail(ctx, itemID, err)
+		return nil
+	} else {
+		if err := deps.Svc.SetContentHash(ctx, itemID, hash); err != nil {
+			slog.Warn("bookdrop set hash failed", "item_id", itemID, "err", err)
+			// Persistence failures retry-eligible — return the error.
+			return err
+		}
+	}
+
 	proc, format, err := fileproc.Dispatch(item.Path)
 	if err != nil {
 		if errors.Is(err, fileproc.ErrUnsupportedFormat) {
@@ -65,6 +86,24 @@ func BookDropIngest(ctx context.Context, args BookDropIngestArgs, deps BookDropD
 		meta.Title, meta.Author, meta.Description, meta.Language,
 		meta.CoverBytes, meta.CoverMime,
 	)
+}
+
+// hashFile streams item.Path through sha256 and returns the digest.
+// Used during bookdrop ingest so the hash is recorded alongside the
+// approval-time metadata, well before the file is moved into the
+// library tree.
+func hashFile(_ context.Context, path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return nil, err
+	}
+	return h.Sum(nil), nil
 }
 
 // BookDropWorker is the River adapter for BookDropIngest. River

--- a/internal/task/files_backfill.go
+++ b/internal/task/files_backfill.go
@@ -1,0 +1,140 @@
+package task
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/blackforge/embookshelf/internal/hashing"
+	"github.com/blackforge/embookshelf/internal/repo"
+	"github.com/blackforge/embookshelf/internal/storage"
+)
+
+// FilesBackfillDeps groups the dependencies the boot-time hashing
+// pass needs. The Storage map is keyed by storage_backend.ID so the
+// worker can resolve a file's storage when the project grows beyond
+// a single backend (Plan F).
+type FilesBackfillDeps struct {
+	Files     *repo.FileRepo
+	Libraries *repo.LibraryRepo
+	Backends  *repo.StorageBackendRepo
+	// Storage is the single LocalFS backend constructed in main.go
+	// today. Plan F replaces this with a per-backend resolver.
+	Storage   storage.Storage
+	BatchSize int           // 0 → 100
+	Sleep     time.Duration // pause between batches; 0 → no pause
+}
+
+// RunFilesBackfill drains files.content_hash IS NULL by streaming
+// each file through sha256 and updating the row. Idempotent: missing
+// files (Storage.Get → ErrNotFound) are skipped and logged; the row
+// stays NULL so a future run retries when the file reappears.
+//
+// Returns nil when no rows remain pending. Caller is expected to
+// invoke this once at startup; rerunning is safe.
+func RunFilesBackfill(ctx context.Context, deps FilesBackfillDeps) error {
+	if deps.Storage == nil || deps.Files == nil {
+		return nil // not yet wired
+	}
+	batchSize := deps.BatchSize
+	if batchSize <= 0 {
+		batchSize = 100
+	}
+
+	total := 0
+	// skipped tracks IDs that failed in this run so we don't re-fetch them
+	// from ListPendingHash on the next iteration (they stay NULL until a
+	// future boot).
+	skipped := make(map[string]bool)
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		batch, err := deps.Files.ListPendingHash(ctx, batchSize+len(skipped))
+		if err != nil {
+			return err
+		}
+
+		// Filter out rows we already attempted this run.
+		pending := batch[:0]
+		for _, f := range batch {
+			if !skipped[f.ID] {
+				pending = append(pending, f)
+			}
+		}
+		// Limit to batchSize after filtering.
+		if len(pending) > batchSize {
+			pending = pending[:batchSize]
+		}
+
+		if len(pending) == 0 {
+			if total > 0 {
+				slog.Info("files backfill complete", "hashed", total)
+			}
+			return nil
+		}
+		for _, f := range pending {
+			// Resolve key: <library.root>/<location>
+			lib, err := deps.Libraries.GetByID(ctx, f.LibraryID)
+			if err != nil {
+				slog.Warn("files backfill: library lookup failed",
+					"file_id", f.ID, "library_id", f.LibraryID, "err", err)
+				skipped[f.ID] = true
+				continue
+			}
+			root := ""
+			if lib.Root != nil {
+				root = *lib.Root
+			}
+			if root == "" && lib.Path != "" {
+				root = lib.Path // fall back during transition (Plan B keeps Path)
+			}
+			key := joinKey(root, f.Location)
+
+			hash, size, err := hashing.HashFile(ctx, deps.Storage, key)
+			if err != nil {
+				slog.Warn("files backfill: hash failed",
+					"file_id", f.ID, "key", key, "err", err)
+				skipped[f.ID] = true
+				continue
+			}
+			info, headErr := deps.Storage.Head(ctx, key)
+			mtime := time.Now()
+			if headErr == nil {
+				mtime = info.ModTime
+			}
+
+			if err := deps.Files.SetContentHash(ctx, f.ID, hash, size, mtime); err != nil {
+				slog.Warn("files backfill: set hash failed",
+					"file_id", f.ID, "err", err)
+				skipped[f.ID] = true
+				continue
+			}
+			total++
+		}
+		if deps.Sleep > 0 {
+			select {
+			case <-time.After(deps.Sleep):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	}
+}
+
+// joinKey concatenates a backend root with a file location into a
+// single slash-separated key. Strips trailing slashes from root so
+// "<root>" + "/" + "<loc>" never produces a double slash.
+func joinKey(root, loc string) string {
+	root = strings.TrimRight(root, "/")
+	loc = strings.TrimLeft(loc, "/")
+	if root == "" {
+		return loc
+	}
+	if loc == "" {
+		return root
+	}
+	return root + "/" + loc
+}

--- a/internal/task/files_backfill_test.go
+++ b/internal/task/files_backfill_test.go
@@ -1,0 +1,251 @@
+package task_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/blackforge/embookshelf/internal/model"
+	"github.com/blackforge/embookshelf/internal/repo"
+	"github.com/blackforge/embookshelf/internal/repo/repotest"
+	"github.com/blackforge/embookshelf/internal/storage/local"
+	"github.com/blackforge/embookshelf/internal/task"
+)
+
+// newTestDeps creates a FilesBackfillDeps wired to a fresh SQLite DB and a
+// LocalFS rooted at "/" (matching the production main.go configuration).
+// File keys are therefore absolute paths like "<tmpDir>/<name>".
+func newTestDeps(t *testing.T) (task.FilesBackfillDeps, *repo.LibraryRepo) {
+	t.Helper()
+	d := repotest.NewWithDialect(t, "sqlite")
+	// Root the storage at "/" — same as production. joinKey will build
+	// keys like "/tmp/.../filename.epub" which LocalFS resolves correctly.
+	fs, err := local.New("/")
+	if err != nil {
+		t.Fatalf("local.New: %v", err)
+	}
+	lr := repo.NewLibraryRepo(d)
+	deps := task.FilesBackfillDeps{
+		Files:     repo.NewFileRepo(d),
+		Libraries: lr,
+		Backends:  repo.NewStorageBackendRepo(d),
+		Storage:   fs,
+	}
+	return deps, lr
+}
+
+// seedLibrary creates a library whose Path equals tmpDir so joinKey resolves
+// file locations against that directory.
+func seedLibrary(t *testing.T, lr *repo.LibraryRepo, tmpDir string) model.Library {
+	t.Helper()
+	lib, err := lr.CreateLibrary(context.Background(), "Test Library", "test-lib", tmpDir)
+	if err != nil {
+		t.Fatalf("CreateLibrary: %v", err)
+	}
+	return lib
+}
+
+// writeFile creates a file at <tmpDir>/<name> with the given content.
+func writeFile(t *testing.T, tmpDir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(tmpDir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("writeFile %q: %v", name, err)
+	}
+}
+
+// insertFile inserts a files row with content_hash = NULL (no hash yet).
+func insertFile(t *testing.T, fr *repo.FileRepo, libID, location string) model.File {
+	t.Helper()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	f, err := fr.Insert(context.Background(), model.File{
+		LibraryID:   libID,
+		Location:    location,
+		Size:        0,
+		Mtime:       now,
+		Format:      "EPUB",
+		LastScanned: now,
+	})
+	if err != nil {
+		t.Fatalf("Insert %q: %v", location, err)
+	}
+	return f
+}
+
+// TestRunFilesBackfill_nilDeps verifies that nil Storage or Files returns nil
+// immediately (guards against incomplete wiring at startup).
+func TestRunFilesBackfill_nilDeps(t *testing.T) {
+	ctx := context.Background()
+
+	// nil Storage
+	if err := task.RunFilesBackfill(ctx, task.FilesBackfillDeps{
+		Files:   repo.NewFileRepo(nil),
+		Storage: nil,
+	}); err != nil {
+		t.Fatalf("nil Storage: got %v, want nil", err)
+	}
+
+	// nil Files
+	d := repotest.NewWithDialect(t, "sqlite")
+	fs, _ := local.New("/")
+	if err := task.RunFilesBackfill(ctx, task.FilesBackfillDeps{
+		Files:    nil,
+		Storage:  fs,
+		Backends: repo.NewStorageBackendRepo(d),
+	}); err != nil {
+		t.Fatalf("nil Files: got %v, want nil", err)
+	}
+}
+
+// TestRunFilesBackfill_noPendingRows verifies that an empty pending set
+// returns nil without logging anything disruptive.
+func TestRunFilesBackfill_noPendingRows(t *testing.T) {
+	tmpDir := t.TempDir()
+	deps, lr := newTestDeps(t)
+	_ = seedLibrary(t, lr, tmpDir)
+
+	// No files inserted → nothing pending.
+	if err := task.RunFilesBackfill(context.Background(), deps); err != nil {
+		t.Fatalf("empty pending: got %v, want nil", err)
+	}
+}
+
+// TestRunFilesBackfill_hashesThreeFiles exercises the happy path:
+// three files with NULL hash are all hashed correctly.
+func TestRunFilesBackfill_hashesThreeFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	deps, lr := newTestDeps(t)
+	lib := seedLibrary(t, lr, tmpDir)
+
+	contents := []string{"alpha content", "beta content", "gamma content"}
+	names := []string{"alpha.epub", "beta.epub", "gamma.epub"}
+
+	for i, name := range names {
+		writeFile(t, tmpDir, name, contents[i])
+		insertFile(t, deps.Files, lib.ID, name)
+	}
+
+	ctx := context.Background()
+	if err := task.RunFilesBackfill(ctx, deps); err != nil {
+		t.Fatalf("RunFilesBackfill: %v", err)
+	}
+
+	// All three should now have a content_hash.
+	pending, err := deps.Files.ListPendingHash(ctx, 100)
+	if err != nil {
+		t.Fatalf("ListPendingHash: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("still %d pending rows after backfill; want 0", len(pending))
+	}
+
+	// Verify the hashes match the actual file content.
+	for i, name := range names {
+		expected := sha256.Sum256([]byte(contents[i]))
+		got, err := deps.Files.GetByLocation(ctx, lib.ID, name)
+		if err != nil {
+			t.Fatalf("GetByLocation %q: %v", name, err)
+		}
+		if got.ContentHash == nil {
+			t.Fatalf("file %q: ContentHash is nil after backfill", name)
+		}
+		if !bytes.Equal(got.ContentHash, expected[:]) {
+			t.Fatalf("file %q: ContentHash mismatch\n  got  %x\n  want %x",
+				name, got.ContentHash, expected)
+		}
+	}
+}
+
+// TestRunFilesBackfill_missingFileSkipped verifies that a row pointing to a
+// file that doesn't exist on disk stays NULL while the other rows are filled.
+func TestRunFilesBackfill_missingFileSkipped(t *testing.T) {
+	tmpDir := t.TempDir()
+	deps, lr := newTestDeps(t)
+	lib := seedLibrary(t, lr, tmpDir)
+
+	// Write two real files, leave the third missing.
+	writeFile(t, tmpDir, "present1.epub", "present content 1")
+	writeFile(t, tmpDir, "present2.epub", "present content 2")
+	// "missing.epub" is intentionally not created on disk.
+
+	present1 := insertFile(t, deps.Files, lib.ID, "present1.epub")
+	missingRow := insertFile(t, deps.Files, lib.ID, "missing.epub")
+	present2 := insertFile(t, deps.Files, lib.ID, "present2.epub")
+
+	ctx := context.Background()
+	if err := task.RunFilesBackfill(ctx, deps); err != nil {
+		t.Fatalf("RunFilesBackfill: %v", err)
+	}
+
+	// present1 and present2 should have hashes.
+	f1, err := deps.Files.GetByLocation(ctx, lib.ID, "present1.epub")
+	if err != nil {
+		t.Fatalf("GetByLocation present1: %v", err)
+	}
+	if f1.ContentHash == nil {
+		t.Fatalf("present1.epub: ContentHash should be set, got nil")
+	}
+	_ = present1
+
+	f2, err := deps.Files.GetByLocation(ctx, lib.ID, "present2.epub")
+	if err != nil {
+		t.Fatalf("GetByLocation present2: %v", err)
+	}
+	if f2.ContentHash == nil {
+		t.Fatalf("present2.epub: ContentHash should be set, got nil")
+	}
+	_ = present2
+
+	// The missing file row should still have NULL hash.
+	pending, err := deps.Files.ListPendingHash(ctx, 10)
+	if err != nil {
+		t.Fatalf("ListPendingHash: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("pending count=%d want 1 (the missing file)", len(pending))
+	}
+	if pending[0].ID != missingRow.ID {
+		t.Fatalf("pending row ID=%q want %q", pending[0].ID, missingRow.ID)
+	}
+}
+
+// TestRunFilesBackfill_idempotent verifies that running the backfill a second
+// time is a no-op — rows with hashes are not re-processed.
+func TestRunFilesBackfill_idempotent(t *testing.T) {
+	tmpDir := t.TempDir()
+	deps, lr := newTestDeps(t)
+	lib := seedLibrary(t, lr, tmpDir)
+
+	writeFile(t, tmpDir, "book.epub", "stable content")
+	insertFile(t, deps.Files, lib.ID, "book.epub")
+
+	ctx := context.Background()
+
+	// First run hashes the file.
+	if err := task.RunFilesBackfill(ctx, deps); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	f, err := deps.Files.GetByLocation(ctx, lib.ID, "book.epub")
+	if err != nil {
+		t.Fatalf("GetByLocation after first run: %v", err)
+	}
+	hashAfterFirst := make([]byte, len(f.ContentHash))
+	copy(hashAfterFirst, f.ContentHash)
+
+	// Second run: no pending rows → returns immediately.
+	if err := task.RunFilesBackfill(ctx, deps); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+
+	// Hash unchanged.
+	f2, err := deps.Files.GetByLocation(ctx, lib.ID, "book.epub")
+	if err != nil {
+		t.Fatalf("GetByLocation after second run: %v", err)
+	}
+	if !bytes.Equal(f2.ContentHash, hashAfterFirst) {
+		t.Fatalf("second run changed hash: got %x want %x", f2.ContentHash, hashAfterFirst)
+	}
+}

--- a/internal/task/library_scan.go
+++ b/internal/task/library_scan.go
@@ -6,10 +6,13 @@ import (
 	"io"
 	"log/slog"
 	"path/filepath"
+	"strings"
 
 	"github.com/riverqueue/river"
 
 	"github.com/blackforge/embookshelf/internal/fileproc"
+	"github.com/blackforge/embookshelf/internal/model"
+	"github.com/blackforge/embookshelf/internal/repo"
 	"github.com/blackforge/embookshelf/internal/service"
 	"github.com/blackforge/embookshelf/internal/storage"
 )
@@ -42,6 +45,11 @@ type LibraryScanDeps struct {
 	// the walk. Plan A only uses List; future plans use Get/Head for
 	// content-hash computation and metadata extraction.
 	Storage storage.Storage
+	// Files is the storage_v2 file repo. When non-nil the scan loop
+	// checks files.ExistsByLocation before falling through to the
+	// legacy BookExistsByPath check. nil disables the new check so
+	// libraries that haven't been backfilled yet still de-dupe by path.
+	Files *repo.FileRepo
 }
 
 // LibraryScan walks a library's filesystem root and stages every
@@ -94,6 +102,18 @@ func LibraryScan(ctx context.Context, args LibraryScanArgs, deps LibraryScanDeps
 		}
 		fileCount++
 
+		relLoc := relativizeLocation(lib, p)
+
+		if deps.Files != nil {
+			exists, err := deps.Files.ExistsByLocation(ctx, lib.ID, relLoc)
+			if err != nil {
+				slog.Warn("library scan: files exists check", "lib", lib.ID, "loc", relLoc, "err", err)
+				// fall through to legacy check
+			} else if exists {
+				continue
+			}
+		}
+
 		already, err := deps.Lib.BookExistsByPath(ctx, p)
 		if err != nil {
 			slog.Warn("library scan: book exists check", "path", p, "err", err)
@@ -136,4 +156,28 @@ type LibraryScanWorker struct {
 
 func (w *LibraryScanWorker) Work(ctx context.Context, job *river.Job[LibraryScanArgs]) error {
 	return LibraryScan(ctx, job.Args, w.Deps)
+}
+
+// relativizeLocation strips the library root from abs, returning the
+// path the files table stores. If abs doesn't fall under the library
+// root (a corner case Plan B's backfill stores verbatim), return abs.
+func relativizeLocation(lib model.Library, abs string) string {
+	root := ""
+	if lib.Root != nil {
+		root = *lib.Root
+	}
+	if root == "" {
+		root = lib.Path
+	}
+	if root == "" {
+		return abs
+	}
+	prefix := root
+	if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+	if strings.HasPrefix(abs, prefix) {
+		return abs[len(prefix):]
+	}
+	return abs
 }


### PR DESCRIPTION
## Summary

Implements Plan B of 8 of the storage refactor — content-hash identity and the schema reshape that supports it. Behavior remains backward-compatible: existing books still browse, scan, and serve via \`books.path\`; new code writes to the new \`files\`/\`storage_backends\` tables in parallel.

### What changed

- **New tables**: \`storage_backends\` (id, kind='local'|'s3', config JSONB, created_at), \`files\` (id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned). Both PG and SQLite parallel.
- **New columns**: \`libraries\` gains \`backend_id\`, \`root\`, \`org_mode\`. \`books\` gains \`uuid\`, \`folder_path\`. \`bookdrop_items\` gains \`content_hash\`.
- **Idempotent Go-level backfill** (\`migrator.BackfillStorageV2\`): seeds storage_backends from distinct \`libraries.path\` values, wires \`libraries.backend_id\`+\`root\`, assigns \`uuid\` to every book, copies \`books.path\` → \`files.location\` (content_hash NULL until the boot worker fills it). Sentinel: \`app_settings.storage_v2_backfilled\`.
- **New repos**: \`StorageBackendRepo\`, \`FileRepo\`. \`BookDropRepo\` gains \`SetContentHash\`. \`LibraryRepo\` exposes \`Root\`/\`BackendID\` on the model and adds \`LibraryBackend(libID)\` join helper.
- **\`internal/hashing.HashFile(ctx, store, key)\`**: streams sha256 from any \`storage.Storage\`.
- **Boot-time \`task.RunFilesBackfill\`**: drains \`files.content_hash IS NULL\` by streaming each file via \`storage.Storage\`. Idempotent; missing files stay NULL.
- **Bookdrop ingest** computes sha256 between \`BeginProcessing\` and metadata extraction; stores it on \`bookdrop_items.content_hash\`.
- **\`Approve\`** inserts a \`files\` row tying the new book to its physical artifact (library-relative location, size+mtime from \`os.Stat\`, content_hash from the bookdrop item).
- **Library scan** short-circuits on \`files.ExistsByLocation\` before the legacy \`BookExistsByPath\` check, so already-known files skip the bookdrop enqueue.

### Scope deviation from the plan doc

The original Plan B doc proposed splitting all book metadata (title, author, description, isbn, etc.) into a separate \`metadata\` table per spec §4.1. After surveying the live schema (30+ columns including FTS \`tsv\`, 15 \`*_locked\` flags, audiobook \`chapters JSONB\`, \`subtitle\`, \`series\`, \`genres\`, \`moods\`, \`age_rating\`, …), that split would touch the entire edit-metadata UI surface and produce hundreds more lines of diff with no incremental benefit for the storage identity work this plan exists to land.

**Deferred to Plan B2**: \`metadata\` table split, \`MetadataRepo\`, the handler-side \`books JOIN metadata\` queries. Scope: 0 lines of metadata-table code in this PR. Spec §4.1 alignment is a future work item.

\`books.path\`, \`books.format\`, and \`libraries.path\` are likewise **kept** in this PR. Plan B2 drops them once API consumers and the file-naming pattern resolver have moved to \`files.location\` + \`libraries.root\`.

## Plan
\`docs/superpowers/plans/2026-04-29-storage-plan-b-schema.md\` (Plan B of 8).
Spec: \`docs/spec/storage.spec.md\`.

## Migration safety

- Migration 000025 is **additive only** — no DROPs, all ADDs. The down migration removes the new tables/columns cleanly.
- Backfill runs after \`migrate.Up\` succeeds, idempotent via the sentinel. Re-running is a no-op.
- Boot-time hashing is asynchronous (1-hour timeout, 100-row batches). The app responds to traffic immediately; \`files.content_hash\` fills in the background.
- Tested round-trip: \`make migrate\` → backfill seeds backends + files → \`make migrate-down\` → \`make migrate\` cleanly re-applies.

## Test plan
- [x] \`make ci-local\` green (lint + ui-lint + ui-typecheck + test).
- [x] \`go test ./...\` — 25/25 packages pass on SQLite (PG via \`TEST_DATABASE_URL\` would extend coverage; CI does this).
- [x] Migration roundtrip in dev (PG via Docker compose).
- [ ] Manual smoke after merge: seed → boot → backfill log line → library scan still discovers new files → bookdrop approve still imports.

## Commits (11)

\`\`\`
2a324d2 feat(db): storage_v2 schema migrations (PG + SQLite)
bbeb6e1 feat(migrator): storage_v2 idempotent backfill
c0c8856 feat(repo): StorageBackendRepo
ea423b0 feat(repo): FileRepo
72f2dd5 feat(hashing): sha256 helper over storage.Storage
c15c38c feat(repo): expose backend_id, root, org_mode on Library
0b76151 feat(repo): bookdrop_items.content_hash
98bf9de feat(task): boot-time files_backfill worker
2e878f1 feat(task): bookdrop ingest computes sha256
8e2798e feat(task): library scan checks files table for identity
c8959eb feat(service): Approve inserts files row
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)