### PR TITLE
feat(scan): two-phase scan + reconciliation (Plan C of 8)

### DIFF
--- a/cmd/embookshelf/main.go
+++ b/cmd/embookshelf/main.go
@@ -250,6 +250,10 @@ func main() {
 		}
 	}()
 
+	// Missing-files purge sweeper: deletes files rows whose missing_since
+	// is older than 24h. Runs hourly until the application shuts down.
+	go task.LoopMissingPurge(ctx, fileRepo, time.Hour)
+
 	// File watcher goroutine.
 	watcher := &ingest.Watcher{
 		Path:     cfg.BookDropPath,

--- a/docs/superpowers/plans/2026-04-29-storage-plan-c-scan.md
+++ b/docs/superpowers/plans/2026-04-29-storage-plan-c-scan.md
@@ -1,0 +1,660 @@
+# Two-Phase Scan & Reconciliation — Implementation Plan (Plan C of 8)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rewrite the library scan worker as a two-phase walk + diff + ingest, using the `files` table from Plan B as authoritative state. Cheap mode skips re-hashing files whose `(size, mtime)` match the DB row; the expensive ingest path runs only for new or changed files. Missing files are soft-deleted with a 24-hour TTL. A `(library_id, content_hash)` reattach lets the scanner detect renames by hash and migrate the existing book to the new location instead of creating a duplicate.
+
+**Architecture:** Two new packages. `internal/scan/walker.go` produces a stream of `WalkEntry{Location, Size, Mtime, ETag}` from any `storage.Storage`. `internal/scan/differ.go` consumes that stream plus a `[]model.File` snapshot from the DB and emits a `Changeset{Unchanged, Changed, New, Missing}`. The scan worker orchestrates: read DB rows → walk → diff → for `New`, enqueue bookdrop (existing pipeline); for `Changed`, re-hash and update the row in place; for `Missing`, set `missing_since=now()` so a separate sweeper purges 24h later. Hash-based reattach is a fast post-processing step inside the differ: after a Changed entry's new hash is computed, if the hash already exists on another `files` row of the same library, the entry is reclassified as a Rename (update old row's location to the new one, keep the book_id, mark the duplicate row missing).
+
+**Tech Stack:** Go 1.25 stdlib (`io`, `sort`, `time`). Reuses Plan B's `repo.FileRepo`, `internal/hashing`, and Plan A's `storage.Storage`. No new third-party deps.
+
+**Companion spec:** [`docs/spec/storage.spec.md`](../../spec/storage.spec.md). Sections 5.3 (two-phase scan), 5.1 (hash-based identity), and the missing-row 24h grace mentioned at the end of 5.3 drive this plan.
+
+**Locked decisions:**
+- 24-hour TTL for missing files (per spec).
+- Soft-delete via `files.missing_since TIMESTAMPTZ NULL`. NULL = present, non-NULL = absent since that time.
+- Periodic purge runs hourly via a goroutine timer in `main.go` — not a River job in this plan; can promote to a queue job later if it grows.
+- The (size, mtime) fast-path skip is per-row on the `files` table. ETag is reserved for Plan F (S3) and ignored for local.
+- Reattach is in-scope: when a file is renamed locally, the next scan reattaches the existing book row to the new location.
+- The bookdrop pipeline for `New` entries is unchanged. `Changed` files do NOT go through bookdrop — they update the existing files row directly.
+
+**Depends on:** Plan B merged. Specifically the `files` table, `FileRepo`, `BookDropRepo.SetContentHash`, `internal/hashing.HashFile`, and the `storage.Storage` walker from Plan A.
+
+**Out of scope:**
+- Sidecar files (Plan D).
+- Cover storage migration (Plan E).
+- S3 backend, S3 events, presigned URLs, lifecycle (Plans F–H).
+- Dropping `books.path` / `libraries.path` (deferred to Plan B2 / Plan G when the handler stops reading them).
+- A separate cron framework — the periodic purge is a stdlib `time.Ticker` in main.go.
+- Concurrent scans across libraries — the existing River queue serializes per library; the changes here don't widen that.
+
+---
+
+## File Structure
+
+### Files created
+
+| Path | Responsibility |
+|---|---|
+| `internal/migrator/migrations/postgres/000026_files_missing_since.up.sql` | ADD `files.missing_since TIMESTAMPTZ`. |
+| `internal/migrator/migrations/postgres/000026_files_missing_since.down.sql` | DROP the column. |
+| `internal/migrator/migrations/sqlite/000026_files_missing_since.up.sql` | SQLite parallel. |
+| `internal/migrator/migrations/sqlite/000026_files_missing_since.down.sql` | SQLite parallel. |
+| `internal/scan/walker.go` | `WalkEntry`, `Walk(ctx, store storage.Storage, root string) (<-chan WalkEntry, <-chan error)`. |
+| `internal/scan/walker_test.go` | LocalFS-backed test. |
+| `internal/scan/differ.go` | `Changeset`, `Diff(walked []WalkEntry, dbFiles []model.File) Changeset`. Pure function, table-test friendly. |
+| `internal/scan/differ_test.go` | Exhaustive case table. |
+| `internal/scan/reattach.go` | `MaybeReattach(ctx, files repo.FileRepo, libraryID string, hash []byte, newLocation string) (bool, error)`. |
+| `internal/scan/reattach_test.go` | Cover the rename detection path. |
+| `internal/task/missing_purge.go` | `RunMissingPurge(ctx, files *repo.FileRepo, ttl time.Duration)` — single pass. |
+| `internal/task/missing_purge_test.go` | Asserts the >TTL row is deleted, the <TTL row is kept. |
+
+### Files modified
+
+| Path | Change |
+|---|---|
+| `internal/repo/file.go` | Add `MarkMissing(fileID, when)`, `ClearMissing(fileID)`, `DeleteMissingOlderThan(ctx, ttl) (int64, error)`, `ListByLibrary(ctx, libraryID) ([]model.File, error)`, `UpdateLocation(ctx, fileID, location string)`. Update `bdCols`-equivalent if needed. |
+| `internal/model/file.go` | Add `MissingSince *time.Time`. |
+| `internal/task/library_scan.go` | Replace the body with: load `dbFiles := files.ListByLibrary(libID)`, `walked := walker.Walk(...)`, `cs := differ.Diff(walked, dbFiles)`, then act per category. Hash-based reattach lives in the Changed branch via `reattach.MaybeReattach`. |
+| `cmd/embookshelf/main.go` | Launch `task.RunMissingPurge` in a goroutine on a 1-hour ticker after queue setup. |
+| `internal/queue/queue.go`, `internal/queue/sqlite.go` | If `LibraryScanDeps` adds new fields, plumb them through. (Likely just `Hashing` if the scan worker needs to compute hashes inline; alternatively the scan worker calls `hashing.HashFile` directly with the storage already in deps.) |
+
+### Files NOT touched
+
+- `internal/handler/files.go` — still reads `book.path`. Plan B2 / G when API consumers cut over.
+- `internal/coverstore/` — Plan E.
+- `internal/fileproc/` — extractor signatures unchanged.
+- `internal/service/bookdrop.go` Approve path — still creates the books + files rows for genuinely new imports.
+
+---
+
+## Phase 1 — Schema
+
+### Task 1: `files.missing_since` migration (PG + SQLite)
+
+**Files:**
+- Create: `internal/migrator/migrations/postgres/000026_files_missing_since.{up,down}.sql`
+- Create: `internal/migrator/migrations/sqlite/000026_files_missing_since.{up,down}.sql`
+
+PG up:
+
+```sql
+ALTER TABLE files ADD COLUMN IF NOT EXISTS missing_since TIMESTAMPTZ;
+CREATE INDEX IF NOT EXISTS idx_files_missing_since ON files(missing_since) WHERE missing_since IS NOT NULL;
+```
+
+PG down:
+
+```sql
+DROP INDEX IF EXISTS idx_files_missing_since;
+ALTER TABLE files DROP COLUMN IF EXISTS missing_since;
+```
+
+SQLite up:
+
+```sql
+ALTER TABLE files ADD COLUMN missing_since TEXT;
+CREATE INDEX IF NOT EXISTS idx_files_missing_since ON files(missing_since) WHERE missing_since IS NOT NULL;
+```
+
+(SQLite has no `IF NOT EXISTS` on `ADD COLUMN`. modernc.org/sqlite errors on that syntax — this was hit in Plan B Task 1.)
+
+SQLite down:
+
+```sql
+DROP INDEX IF EXISTS idx_files_missing_since;
+-- SQLite cannot DROP COLUMN before 3.35.0; modernc.org/sqlite supports it.
+ALTER TABLE files DROP COLUMN missing_since;
+```
+
+If the modernc driver doesn't support `DROP COLUMN`, fall back to the rename-create-copy-drop dance. Verify by reading the driver version and a recent SQLite migration that drops a column (none in this codebase yet — modernc.org/sqlite has supported DROP COLUMN since 1.20.0; the project pins a newer version).
+
+- [ ] Commit:
+
+```bash
+git add internal/migrator/migrations/postgres/000026_files_missing_since.{up,down}.sql internal/migrator/migrations/sqlite/000026_files_missing_since.{up,down}.sql
+git commit -m "feat(db): add files.missing_since for scan reconciliation"
+```
+
+---
+
+## Phase 2 — Repo Extensions
+
+### Task 2: FileRepo extensions
+
+**Files:**
+- Modify: `internal/repo/file.go`
+- Modify: `internal/repo/file_test.go`
+- Modify: `internal/model/file.go` (add `MissingSince *time.Time`)
+
+Add `missing_since` to the `fileCols`-equivalent constant and to the `scanFile` helper.
+
+New methods:
+
+```go
+// MarkMissing records that the file is no longer present in storage.
+// Idempotent: calling twice with the same `when` is a no-op.
+func (r *FileRepo) MarkMissing(ctx context.Context, fileID string, when time.Time) error
+
+// ClearMissing flips missing_since back to NULL when a previously
+// missing file reappears.
+func (r *FileRepo) ClearMissing(ctx context.Context, fileID string) error
+
+// DeleteMissingOlderThan purges rows whose missing_since is more
+// than ttl ago. Returns the count deleted.
+func (r *FileRepo) DeleteMissingOlderThan(ctx context.Context, ttl time.Duration) (int64, error)
+
+// ListByLibrary returns every files row for libraryID (including
+// missing). Used by the scan worker to diff against the live walk.
+func (r *FileRepo) ListByLibrary(ctx context.Context, libraryID string) ([]model.File, error)
+
+// UpdateLocation moves a row to a new (library_id, location). Used
+// by hash-based reattach when a file is renamed within the same
+// library. Returns ErrFileLocationTaken on conflict.
+func (r *FileRepo) UpdateLocation(ctx context.Context, fileID, newLocation string) error
+```
+
+Tests cover: each method's happy path, NULL handling on read, conflict on UpdateLocation, batch correctness on DeleteMissingOlderThan (rows ≤ ttl preserved).
+
+- [ ] Commit:
+
+```bash
+git commit -m "feat(repo): file missing-since lifecycle + ListByLibrary"
+```
+
+---
+
+## Phase 3 — Walker + Differ
+
+### Task 3: `internal/scan/walker.go`
+
+**Files:**
+- Create: `internal/scan/walker.go`
+- Create: `internal/scan/walker_test.go`
+
+```go
+// Package scan orchestrates the two-phase library scan: walk, diff,
+// then act on the changeset. The walker yields entries via a
+// channel so the iterator API of storage.Storage doesn't leak into
+// the differ.
+package scan
+
+import (
+    "context"
+    "errors"
+    "io"
+    "time"
+
+    "github.com/blackforge/embookshelf/internal/storage"
+)
+
+// WalkEntry is one observation from a storage backend during the
+// cheap walk phase. Hashes are NOT computed here.
+type WalkEntry struct {
+    Location string
+    Size     int64
+    Mtime    time.Time
+    ETag     string
+}
+
+// Walk lists every object under root in store and forwards each as a
+// WalkEntry. Errors during iteration go to errc; the caller MUST
+// consume both channels to completion.
+func Walk(ctx context.Context, store storage.Storage, root string) (<-chan WalkEntry, <-chan error) {
+    out := make(chan WalkEntry, 64)
+    errc := make(chan error, 1)
+    go func() {
+        defer close(out)
+        defer close(errc)
+        it, err := store.List(ctx, root)
+        if err != nil {
+            errc <- err
+            return
+        }
+        defer func() { _ = it.Close() }()
+        for {
+            obj, err := it.Next(ctx)
+            if errors.Is(err, io.EOF) {
+                return
+            }
+            if err != nil {
+                errc <- err
+                return
+            }
+            entry := WalkEntry{
+                Location: obj.Key,
+                Size:     obj.Size,
+                Mtime:    obj.ModTime,
+                ETag:     obj.ETag,
+            }
+            select {
+            case out <- entry:
+            case <-ctx.Done():
+                errc <- ctx.Err()
+                return
+            }
+        }
+    }()
+    return out, errc
+}
+```
+
+Tests with `local.LocalFS` rooted at `t.TempDir()`:
+- Empty dir → no entries.
+- 3 files → 3 entries with non-zero sizes and mtimes.
+- Cancellation: cancel ctx mid-walk; expect ctx.Err() on errc.
+
+- [ ] Commit:
+
+```bash
+git commit -m "feat(scan): walker streams WalkEntry from storage.Storage"
+```
+
+---
+
+### Task 4: `internal/scan/differ.go`
+
+**Files:**
+- Create: `internal/scan/differ.go`
+- Create: `internal/scan/differ_test.go`
+
+```go
+package scan
+
+import (
+    "github.com/blackforge/embookshelf/internal/model"
+)
+
+// Changeset is the output of Diff. Each slice holds the WalkEntry +
+// the matching DB row (for Changed and Missing) or just the
+// WalkEntry (for New) / just the model.File (for Missing).
+type Changeset struct {
+    // Unchanged: row exists, size+mtime match. No work needed.
+    Unchanged []model.File
+    // Changed: row exists but size or mtime differ — re-hash + update.
+    Changed []ChangedEntry
+    // New: walked but not in DB — enqueue ingest.
+    New []WalkEntry
+    // Missing: in DB but not walked — mark missing_since.
+    Missing []model.File
+}
+
+// ChangedEntry pairs the live observation with the stale DB row.
+type ChangedEntry struct {
+    Walk WalkEntry
+    DB   model.File
+}
+
+// Diff computes the changeset comparing walked entries against the
+// current DB rows for one library. Both slices may be in any order;
+// Diff sorts internally by Location.
+func Diff(walked []WalkEntry, dbFiles []model.File) Changeset {
+    // Build a map of DB rows by Location for O(1) lookup.
+    byLoc := make(map[string]model.File, len(dbFiles))
+    for _, f := range dbFiles {
+        byLoc[f.Location] = f
+    }
+
+    var cs Changeset
+    seen := make(map[string]bool, len(walked))
+    for _, w := range walked {
+        seen[w.Location] = true
+        f, ok := byLoc[w.Location]
+        if !ok {
+            cs.New = append(cs.New, w)
+            continue
+        }
+        // Compare size + mtime (truncated to whole seconds — local FS
+        // and S3 both report at ≥1s resolution). Float ETags would
+        // fail equality; we strip subsecond precision deliberately.
+        if w.Size == f.Size && sameSecond(w.Mtime, f.Mtime) {
+            cs.Unchanged = append(cs.Unchanged, f)
+            continue
+        }
+        cs.Changed = append(cs.Changed, ChangedEntry{Walk: w, DB: f})
+    }
+    for _, f := range dbFiles {
+        if !seen[f.Location] {
+            cs.Missing = append(cs.Missing, f)
+        }
+    }
+    return cs
+}
+
+func sameSecond(a, b time.Time) bool {
+    return a.Truncate(time.Second).Equal(b.Truncate(time.Second))
+}
+```
+
+Tests cover all 4 categories:
+- All unchanged
+- One new
+- One changed (size differs / mtime differs)
+- One missing
+- Mixed: 2 unchanged + 1 changed + 1 new + 1 missing
+- Empty dbFiles + walked → all New
+- Empty walked + dbFiles → all Missing
+- Walked entry where DB row has missing_since set: still classified as Unchanged or Changed by size+mtime; the caller is responsible for ClearMissing.
+
+- [ ] Commit:
+
+```bash
+git commit -m "feat(scan): differ classifies walk vs DB into Unchanged/Changed/New/Missing"
+```
+
+---
+
+### Task 5: `internal/scan/reattach.go`
+
+**Files:**
+- Create: `internal/scan/reattach.go`
+- Create: `internal/scan/reattach_test.go`
+
+```go
+// MaybeReattach handles the rename case. After a Changed entry has
+// been re-hashed, if the new hash matches another files row in the
+// same library, the file was probably renamed: update that row's
+// location instead of orphaning the old row. Returns (true, nil)
+// when a reattach happened.
+//
+// The caller passes:
+//   - the freshly computed hash for the moved file,
+//   - the new location it now lives at,
+//   - the OLD row's id (the row that was at the previous location).
+//
+// On reattach: the OTHER row (the one whose hash matches) takes
+// over the new location, and the OLD row is marked missing so the
+// purge sweeper deletes it after the TTL. This preserves book_id
+// continuity when the user renames a file outside the app.
+func MaybeReattach(ctx context.Context, files *repo.FileRepo, libraryID string, hash []byte, newLocation string, oldRowID string) (bool, error) {
+    if len(hash) == 0 { return false, nil }
+    matches, err := files.GetByContentHash(ctx, hash)
+    if err != nil { return false, err }
+    for _, m := range matches {
+        if m.LibraryID != libraryID { continue }
+        if m.ID == oldRowID { continue }
+        // Reattach: m takes over newLocation; old row goes missing.
+        if err := files.UpdateLocation(ctx, m.ID, newLocation); err != nil {
+            return false, err
+        }
+        if err := files.MarkMissing(ctx, oldRowID, time.Now()); err != nil {
+            return false, err
+        }
+        return true, nil
+    }
+    return false, nil
+}
+```
+
+Tests: classic rename scenario — file A.epub renamed to B.epub locally; the row's hash already exists; reattach swaps location and marks the stale row missing.
+
+- [ ] Commit:
+
+```bash
+git commit -m "feat(scan): hash-based rename reattach"
+```
+
+---
+
+## Phase 4 — Library Scan Worker Rewrite
+
+### Task 6: Rewrite `internal/task/library_scan.go`
+
+**Files:**
+- Modify: `internal/task/library_scan.go`
+
+Replace the body of `LibraryScan` with the orchestration logic:
+
+```go
+func LibraryScan(ctx context.Context, args LibraryScanArgs, deps LibraryScanDeps) error {
+    lib, err := deps.Lib.GetByID(ctx, args.LibraryID)
+    if err != nil { return err }
+    root := lib.Path
+    if lib.Root != nil && *lib.Root != "" { root = *lib.Root }
+    if root == "" {
+        slog.Warn("library scan: empty root, skipping", "library_id", lib.ID)
+        return nil
+    }
+    if deps.Storage == nil || deps.Files == nil {
+        slog.Warn("library scan: missing deps, falling back", "library_id", lib.ID)
+        return legacyScan(ctx, lib, deps) // keeps the old BookExistsByPath path
+    }
+
+    dbFiles, err := deps.Files.ListByLibrary(ctx, lib.ID)
+    if err != nil {
+        return fmt.Errorf("list db files: %w", err)
+    }
+
+    // Phase 1: walk
+    var walked []scan.WalkEntry
+    entries, errc := scan.Walk(ctx, deps.Storage, root)
+    for e := range entries {
+        // Convert from absolute key (LocalFS rooted at /) to library-
+        // relative location consistent with the DB.
+        e.Location = relativizeLocation(lib, "/"+e.Location)
+        walked = append(walked, e)
+    }
+    if err := <-errc; err != nil && !errors.Is(err, context.Canceled) {
+        slog.Warn("library scan: walk error", "library_id", lib.ID, "err", err)
+    }
+
+    cs := scan.Diff(walked, dbFiles)
+
+    // Phase 2: act
+    fileCount := len(walked)
+    discovered := 0
+
+    for _, f := range cs.Unchanged {
+        if f.MissingSince != nil {
+            // File reappeared after going missing; clear the flag.
+            _ = deps.Files.ClearMissing(ctx, f.ID)
+        }
+    }
+
+    for _, ce := range cs.Changed {
+        // Re-hash + update the row in place.
+        key := joinKey(root, ce.Walk.Location)
+        hash, size, herr := hashing.HashFile(ctx, deps.Storage, key)
+        if herr != nil {
+            slog.Warn("library scan: rehash failed", "loc", ce.Walk.Location, "err", herr)
+            continue
+        }
+        // Reattach: if the new hash matches a different row in this
+        // library, swap their locations.
+        if reattached, rerr := scan.MaybeReattach(ctx, deps.Files, lib.ID, hash, ce.Walk.Location, ce.DB.ID); rerr != nil {
+            slog.Warn("library scan: reattach failed", "loc", ce.Walk.Location, "err", rerr)
+        } else if reattached {
+            continue
+        }
+        if err := deps.Files.SetContentHash(ctx, ce.DB.ID, hash, size, ce.Walk.Mtime); err != nil {
+            slog.Warn("library scan: update changed row", "id", ce.DB.ID, "err", err)
+        }
+    }
+
+    for _, w := range cs.New {
+        if !fileproc.IsSupported("/" + w.Location) { continue }
+        format := fileproc.FormatForExt(filepath.Ext(w.Location))
+        absPath := joinKey(root, w.Location) // bookdrop still wants the absolute path
+        item, created, err := deps.BookDrop.Enqueue(ctx, "/"+absPath, format, w.Size)
+        if err != nil {
+            slog.Warn("library scan: enqueue", "path", absPath, "err", err)
+            continue
+        }
+        if !created { continue }
+        if deps.Queue != nil {
+            if err := deps.Queue.EnqueueBookDrop(ctx, item.ID); err != nil {
+                slog.Warn("library scan: enqueue queue job", "id", item.ID, "err", err)
+            }
+        }
+        discovered++
+    }
+
+    for _, f := range cs.Missing {
+        if f.MissingSince != nil { continue } // already marked
+        if err := deps.Files.MarkMissing(ctx, f.ID, time.Now()); err != nil {
+            slog.Warn("library scan: mark missing", "id", f.ID, "err", err)
+        }
+    }
+
+    if err := deps.Lib.TouchScan(ctx, lib.ID, fileCount, discovered); err != nil {
+        slog.Warn("library scan: touch", "id", lib.ID, "err", err)
+    }
+    slog.Info("library scan done",
+        "library", lib.ID, "root", root,
+        "files", fileCount, "discovered", discovered,
+        "changed", len(cs.Changed), "missing", len(cs.Missing),
+    )
+    return nil
+}
+
+// joinKey is the same helper as in task/files_backfill.go; consider
+// promoting to internal/scan or a shared util.
+func joinKey(root, loc string) string {
+    root = strings.TrimRight(root, "/")
+    loc = strings.TrimLeft(loc, "/")
+    if root == "" { return loc }
+    if loc == "" { return root }
+    return root + "/" + loc
+}
+```
+
+`legacyScan` is the previous implementation kept verbatim as a fallback when `deps.Files` or `deps.Storage` is nil. This protects the SQLite-test code paths that pass nil today.
+
+- [ ] Commit:
+
+```bash
+git commit -m "refactor(task): library scan = walk + diff + ingest
+
+Replaces the linear walk-then-check loop with a structured
+two-phase pipeline. Files with matching size+mtime skip the
+re-hash entirely; changed files re-hash and update in place;
+missing files are soft-flagged for the 24h purge sweeper.
+Hash-based reattach keeps book_id continuity across renames."
+```
+
+---
+
+## Phase 5 — Missing Purge Sweeper
+
+### Task 7: `internal/task/missing_purge.go`
+
+**Files:**
+- Create: `internal/task/missing_purge.go`
+- Create: `internal/task/missing_purge_test.go`
+
+```go
+package task
+
+import (
+    "context"
+    "log/slog"
+    "time"
+
+    "github.com/blackforge/embookshelf/internal/repo"
+)
+
+// MissingTTL is the grace period before missing files are purged.
+// Spec §5.3 sets this at 24h to ride out unmounted drives, S3 region
+// blips, and IAM hiccups.
+const MissingTTL = 24 * time.Hour
+
+// RunMissingPurge deletes files rows whose missing_since is older
+// than MissingTTL. Returns the count purged.
+func RunMissingPurge(ctx context.Context, files *repo.FileRepo) (int64, error) {
+    return files.DeleteMissingOlderThan(ctx, MissingTTL)
+}
+
+// LoopMissingPurge runs RunMissingPurge on a ticker until ctx is
+// cancelled. Errors are logged but do not stop the loop.
+func LoopMissingPurge(ctx context.Context, files *repo.FileRepo, every time.Duration) {
+    if every <= 0 { every = time.Hour }
+    t := time.NewTicker(every)
+    defer t.Stop()
+    for {
+        select {
+        case <-ctx.Done(): return
+        case <-t.C:
+            n, err := RunMissingPurge(ctx, files)
+            if err != nil {
+                slog.Warn("missing purge", "err", err)
+                continue
+            }
+            if n > 0 {
+                slog.Info("missing purge", "deleted", n)
+            }
+        }
+    }
+}
+```
+
+Tests:
+- 0 missing rows → returns (0, nil).
+- 1 missing row, missing_since < TTL → not deleted.
+- 1 missing row, missing_since > TTL → deleted, returns 1.
+- Loop test with a tight ticker + cancellable ctx exits cleanly.
+
+`main.go` change:
+
+```go
+go task.LoopMissingPurge(ctx, fileRepo, time.Hour)
+```
+
+Place after the existing `RunFilesBackfill` goroutine.
+
+- [ ] Commit:
+
+```bash
+git commit -m "feat(task): missing-files purge sweeper (24h TTL)"
+```
+
+---
+
+## Phase 6 — Verification & PR
+
+### Task 8: Final pass
+
+- [ ] `make ci-local` green.
+- [ ] `git diff --stat origin/main..HEAD` confirms only the listed files changed.
+- [ ] Migration roundtrip if dev DB available.
+- [ ] Manual smoke if Docker available: rename a file in a library; trigger a scan; verify the renamed row keeps its book_id (look at `files.book_id` before/after).
+- [ ] Push, open PR.
+
+```bash
+gh pr create --base main --title "feat(scan): two-phase scan + reconciliation (Plan C of 8)" --body-file <(cat <<'EOF'
+## Summary
+- Library scan rewritten as walk → diff → ingest (Plan C of 8).
+- Files with matching size + mtime skip re-hash entirely.
+- Missing files are soft-deleted with a 24-hour TTL via files.missing_since.
+- Hash-based reattach keeps book_id continuity when files are renamed locally.
+- New packages: internal/scan (walker, differ, reattach) and internal/task/missing_purge.
+
+## Plan
+docs/superpowers/plans/2026-04-29-storage-plan-c-scan.md.
+Spec: docs/spec/storage.spec.md §5.3.
+
+## Test plan
+- [x] make ci-local green.
+- [x] go test ./internal/scan/... ./internal/repo/... ./internal/task/...
+- [ ] Manual smoke: rename a file in a library; next scan reattaches the row.
+EOF
+)
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §5.3 two-phase scan → covered (walk/diff/act).
+- §5.3 missing 24h TTL → covered (missing_since + purge sweeper).
+- §5.1 hash-based identity → reinforced by reattach.
+- §5.2 ETag advisory → ETag plumbed through WalkEntry; ignored on local; useful in Plan F.
+- §5.4 change notification (inotify, S3 events) → still deferred; the periodic full walk every 6h is implicit in the scan worker's existing schedule.
+
+**Risks:**
+- Differ comparing mtime at 1-second resolution: filesystem write within the same second of a previous scan + size unchanged would be misclassified Unchanged. Acceptable trade-off; the next scan catches it once mtime advances.
+- Walking very large libraries: the channel buffer (64) plus ListByLibrary's full-table read are O(n) memory. For a library with millions of files we'd switch to a streaming differ. Today's deployments are well below that.
+- Reattach across libraries is intentionally NOT supported: a file moved between libraries gets a fresh row in the destination and the old row goes missing.
+- Backward compat: `legacyScan` fallback keeps existing scan tests green when deps.Files is nil.
+
+**Type consistency:** `WalkEntry`, `Changeset{Unchanged, Changed, New, Missing}`, `ChangedEntry`, `MaybeReattach`, `LoopMissingPurge`, `RunMissingPurge`, `MissingTTL` referenced consistently across tasks.

--- a/internal/migrator/migrations/postgres/000026_files_missing_since.down.sql
+++ b/internal/migrator/migrations/postgres/000026_files_missing_since.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_files_missing_since;
+ALTER TABLE files DROP COLUMN IF EXISTS missing_since;

--- a/internal/migrator/migrations/postgres/000026_files_missing_since.up.sql
+++ b/internal/migrator/migrations/postgres/000026_files_missing_since.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE files ADD COLUMN IF NOT EXISTS missing_since TIMESTAMPTZ;
+CREATE INDEX IF NOT EXISTS idx_files_missing_since ON files(missing_since) WHERE missing_since IS NOT NULL;

--- a/internal/migrator/migrations/sqlite/000026_files_missing_since.down.sql
+++ b/internal/migrator/migrations/sqlite/000026_files_missing_since.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_files_missing_since;
+ALTER TABLE files DROP COLUMN missing_since;

--- a/internal/migrator/migrations/sqlite/000026_files_missing_since.up.sql
+++ b/internal/migrator/migrations/sqlite/000026_files_missing_since.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE files ADD COLUMN missing_since TEXT;
+CREATE INDEX IF NOT EXISTS idx_files_missing_since ON files(missing_since) WHERE missing_since IS NOT NULL;

--- a/internal/model/file.go
+++ b/internal/model/file.go
@@ -16,4 +16,8 @@ type File struct {
 	ContentHash []byte // nil until hashed
 	Format      string // canonical: "EPUB" | "PDF" | "CBZ" | "MP3" | "M4B"
 	LastScanned time.Time
+	// MissingSince is set when a scan can't find the file in storage.
+	// Files stay flagged for the missing TTL (24h) before purge; nil
+	// means "present (or never observed missing)".
+	MissingSince *time.Time
 }

--- a/internal/repo/file.go
+++ b/internal/repo/file.go
@@ -51,12 +51,12 @@ func (r *FileRepo) Insert(ctx context.Context, f model.File) (model.File, error)
 	const qPG = `
 		INSERT INTO files (id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-		RETURNING id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned
+		RETURNING id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned, missing_since
 	`
 	const qSQLite = `
 		INSERT INTO files (id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		RETURNING id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned
+		RETURNING id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned, missing_since
 	`
 
 	// mtime and last_scanned: pass as time.Time on PG (pgx handles TIMESTAMPTZ),
@@ -89,12 +89,12 @@ func (r *FileRepo) Insert(ctx context.Context, f model.File) (model.File, error)
 // ErrNotFound when missing.
 func (r *FileRepo) GetByLocation(ctx context.Context, libraryID, location string) (model.File, error) {
 	const qPG = `
-		SELECT id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned
+		SELECT id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned, missing_since
 		FROM files
 		WHERE library_id = $1 AND location = $2
 	`
 	const qSQLite = `
-		SELECT id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned
+		SELECT id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned, missing_since
 		FROM files
 		WHERE library_id = ? AND location = ?
 	`
@@ -114,12 +114,12 @@ func (r *FileRepo) GetByLocation(ctx context.Context, libraryID, location string
 // returned when no rows match.
 func (r *FileRepo) GetByContentHash(ctx context.Context, hash []byte) ([]model.File, error) {
 	const qPG = `
-		SELECT id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned
+		SELECT id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned, missing_since
 		FROM files
 		WHERE content_hash = $1
 	`
 	const qSQLite = `
-		SELECT id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned
+		SELECT id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned, missing_since
 		FROM files
 		WHERE content_hash = ?
 	`
@@ -202,14 +202,14 @@ func (r *FileRepo) SetContentHash(ctx context.Context, fileID string, hash []byt
 // still NULL. Used by the backfill worker to drain the queue.
 func (r *FileRepo) ListPendingHash(ctx context.Context, batchSize int) ([]model.File, error) {
 	const qPG = `
-		SELECT id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned
+		SELECT id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned, missing_since
 		FROM files
 		WHERE content_hash IS NULL
 		ORDER BY id
 		LIMIT $1
 	`
 	const qSQLite = `
-		SELECT id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned
+		SELECT id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned, missing_since
 		FROM files
 		WHERE content_hash IS NULL
 		ORDER BY id
@@ -251,6 +251,149 @@ func (r *FileRepo) MarkScanned(ctx context.Context, fileID string) error {
 	return nil
 }
 
+// MarkMissing records that the file is no longer present in storage.
+// Idempotent: re-marking with a later 'when' is allowed (overwrite);
+// re-marking with the same 'when' is a no-op.
+func (r *FileRepo) MarkMissing(ctx context.Context, fileID string, when time.Time) error {
+	const qPG = `UPDATE files SET missing_since = $2 WHERE id = $1`
+	const qSQLite = `UPDATE files SET missing_since = ? WHERE id = ?`
+
+	var whenVal any
+	if r.db.Dialect == db.DialectSQLite {
+		whenVal = when.UTC().Format(time.RFC3339Nano)
+	} else {
+		whenVal = when
+	}
+
+	var res sql.Result
+	var err error
+	if r.db.Dialect == db.DialectSQLite {
+		res, err = r.db.SQL.ExecContext(ctx, qSQLite, whenVal, fileID)
+	} else {
+		res, err = r.db.SQL.ExecContext(ctx, qPG, fileID, whenVal)
+	}
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ClearMissing flips missing_since back to NULL when a previously
+// missing file reappears.
+func (r *FileRepo) ClearMissing(ctx context.Context, fileID string) error {
+	const qPG = `UPDATE files SET missing_since = NULL WHERE id = $1`
+	const qSQLite = `UPDATE files SET missing_since = NULL WHERE id = ?`
+
+	res, err := r.db.SQL.ExecContext(ctx, db.SelectQ(r.db.Dialect, qPG, qSQLite), fileID)
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// DeleteMissingOlderThan purges rows whose missing_since is more
+// than ttl ago. Returns the count deleted. Rows where missing_since
+// IS NULL are not affected.
+func (r *FileRepo) DeleteMissingOlderThan(ctx context.Context, ttl time.Duration) (int64, error) {
+	cutoff := time.Now().Add(-ttl)
+
+	const qPG = `DELETE FROM files WHERE missing_since IS NOT NULL AND missing_since < $1`
+	const qSQLite = `DELETE FROM files WHERE missing_since IS NOT NULL AND missing_since < ?`
+
+	var cutoffVal any
+	if r.db.Dialect == db.DialectSQLite {
+		cutoffVal = cutoff.UTC().Format(time.RFC3339Nano)
+	} else {
+		cutoffVal = cutoff
+	}
+
+	res, err := r.db.SQL.ExecContext(ctx, db.SelectQ(r.db.Dialect, qPG, qSQLite), cutoffVal)
+	if err != nil {
+		return 0, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("rows affected: %w", err)
+	}
+	return n, nil
+}
+
+// ListByLibrary returns every files row for libraryID (including
+// missing ones). Used by the scan worker to diff against the live walk.
+func (r *FileRepo) ListByLibrary(ctx context.Context, libraryID string) ([]model.File, error) {
+	const qPG = `
+		SELECT id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned, missing_since
+		FROM files
+		WHERE library_id = $1
+		ORDER BY location
+	`
+	const qSQLite = `
+		SELECT id, library_id, book_id, location, size, mtime, etag, content_hash, format, last_scanned, missing_since
+		FROM files
+		WHERE library_id = ?
+		ORDER BY location
+	`
+	rows, err := r.db.SQL.QueryContext(ctx, db.SelectQ(r.db.Dialect, qPG, qSQLite), libraryID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []model.File
+	for rows.Next() {
+		f, err := r.scanFile(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, f)
+	}
+	return out, rows.Err()
+}
+
+// UpdateLocation moves a row to a new location within the same
+// library. Used by hash-based reattach when a file is renamed.
+// Returns ErrFileLocationTaken on (library_id, location) conflict.
+func (r *FileRepo) UpdateLocation(ctx context.Context, fileID, newLocation string) error {
+	const qPG = `UPDATE files SET location = $2 WHERE id = $1`
+	const qSQLite = `UPDATE files SET location = ? WHERE id = ?`
+
+	var res sql.Result
+	var err error
+	if r.db.Dialect == db.DialectSQLite {
+		res, err = r.db.SQL.ExecContext(ctx, qSQLite, newLocation, fileID)
+	} else {
+		res, err = r.db.SQL.ExecContext(ctx, qPG, fileID, newLocation)
+	}
+	if err != nil {
+		if ok, _ := dberr.IsUniqueViolation(err); ok {
+			return ErrFileLocationTaken
+		}
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 // scanFile scans a files row into a model.File. s may be a *sql.Row or
 // *sql.Rows — both implement the scanner interface.
 func (r *FileRepo) scanFile(s scanner) (model.File, error) {
@@ -260,11 +403,12 @@ func (r *FileRepo) scanFile(s scanner) (model.File, error) {
 	var contentHashAny any
 	var mtimeAny any
 	var lastScannedAny any
+	var missingSinceAny any
 
 	err := s.Scan(
 		&f.ID, &f.LibraryID, &bookIDAny, &f.Location,
 		&f.Size, &mtimeAny, &etagAny, &contentHashAny,
-		&f.Format, &lastScannedAny,
+		&f.Format, &lastScannedAny, &missingSinceAny,
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -311,6 +455,11 @@ func (r *FileRepo) scanFile(s scanner) (model.File, error) {
 	// last_scanned: non-nullable
 	if err := db.ScanTime(r.db.Dialect, lastScannedAny, &f.LastScanned); err != nil {
 		return f, fmt.Errorf("scan last_scanned: %w", err)
+	}
+
+	// missing_since: nullable
+	if err := db.ScanNullTime(r.db.Dialect, missingSinceAny, &f.MissingSince); err != nil {
+		return f, fmt.Errorf("scan missing_since: %w", err)
 	}
 
 	return f, nil

--- a/internal/repo/file_test.go
+++ b/internal/repo/file_test.go
@@ -208,6 +208,182 @@ func TestFileRepo_matrix(t *testing.T) {
 			if !errors.Is(err, repo.ErrFileLocationTaken) {
 				t.Fatalf("dup insert: got %v, want ErrFileLocationTaken", err)
 			}
+
+			// --- 9. MarkMissing round-trip ---
+			markFile, err := fr.Insert(ctx, model.File{
+				LibraryID:   lib.ID,
+				Location:    "missing/book.epub",
+				Size:        512,
+				Mtime:       now,
+				Format:      "EPUB",
+				LastScanned: now,
+			})
+			if err != nil {
+				t.Fatalf("Insert markFile: %v", err)
+			}
+			if markFile.MissingSince != nil {
+				t.Fatal("MissingSince should be nil on fresh insert")
+			}
+			markTime := time.Now().UTC().Truncate(time.Second)
+			if err := fr.MarkMissing(ctx, markFile.ID, markTime); err != nil {
+				t.Fatalf("MarkMissing: %v", err)
+			}
+			byLib, err := fr.ListByLibrary(ctx, lib.ID)
+			if err != nil {
+				t.Fatalf("ListByLibrary after MarkMissing: %v", err)
+			}
+			var found *model.File
+			for i := range byLib {
+				if byLib[i].ID == markFile.ID {
+					found = &byLib[i]
+					break
+				}
+			}
+			if found == nil {
+				t.Fatal("ListByLibrary: markFile not found")
+			}
+			if found.MissingSince == nil {
+				t.Fatal("MissingSince should be non-nil after MarkMissing")
+			}
+			if !found.MissingSince.Truncate(time.Second).Equal(markTime) {
+				t.Fatalf("MissingSince=%v want ~%v", found.MissingSince, markTime)
+			}
+
+			// --- 10. ClearMissing ---
+			if err := fr.ClearMissing(ctx, markFile.ID); err != nil {
+				t.Fatalf("ClearMissing: %v", err)
+			}
+			afterClear, err := fr.GetByLocation(ctx, lib.ID, "missing/book.epub")
+			if err != nil {
+				t.Fatalf("GetByLocation after ClearMissing: %v", err)
+			}
+			if afterClear.MissingSince != nil {
+				t.Fatalf("MissingSince should be nil after ClearMissing, got %v", afterClear.MissingSince)
+			}
+
+			// --- 11. DeleteMissingOlderThan ---
+			// Insert a file that went missing 25h ago (should be deleted).
+			old := time.Now().Add(-25 * time.Hour)
+			oldFile, err := fr.Insert(ctx, model.File{
+				LibraryID:   lib.ID,
+				Location:    "old/missing.epub",
+				Size:        100,
+				Mtime:       now,
+				Format:      "EPUB",
+				LastScanned: now,
+			})
+			if err != nil {
+				t.Fatalf("Insert oldFile: %v", err)
+			}
+			if err := fr.MarkMissing(ctx, oldFile.ID, old); err != nil {
+				t.Fatalf("MarkMissing oldFile: %v", err)
+			}
+			// Insert a file that went missing 1h ago (should survive 24h TTL).
+			recent := time.Now().Add(-1 * time.Hour)
+			recentFile, err := fr.Insert(ctx, model.File{
+				LibraryID:   lib.ID,
+				Location:    "recent/missing.epub",
+				Size:        100,
+				Mtime:       now,
+				Format:      "EPUB",
+				LastScanned: now,
+			})
+			if err != nil {
+				t.Fatalf("Insert recentFile: %v", err)
+			}
+			if err := fr.MarkMissing(ctx, recentFile.ID, recent); err != nil {
+				t.Fatalf("MarkMissing recentFile: %v", err)
+			}
+			deleted, err := fr.DeleteMissingOlderThan(ctx, 24*time.Hour)
+			if err != nil {
+				t.Fatalf("DeleteMissingOlderThan: %v", err)
+			}
+			if deleted != 1 {
+				t.Fatalf("DeleteMissingOlderThan count=%d want 1", deleted)
+			}
+			// recentFile should still exist.
+			_, err = fr.GetByLocation(ctx, lib.ID, "recent/missing.epub")
+			if err != nil {
+				t.Fatalf("recentFile should survive TTL: %v", err)
+			}
+			// oldFile should be gone.
+			_, err = fr.GetByLocation(ctx, lib.ID, "old/missing.epub")
+			if !errors.Is(err, repo.ErrNotFound) {
+				t.Fatalf("oldFile should be purged, got %v", err)
+			}
+
+			// --- 12. ListByLibrary isolation ---
+			lib2, err := lr.CreateLibrary(ctx, "Other Library", "other-library", "/tmp/other")
+			if err != nil {
+				t.Fatalf("CreateLibrary lib2: %v", err)
+			}
+			_, err = fr.Insert(ctx, model.File{
+				LibraryID:   lib2.ID,
+				Location:    "other/book.epub",
+				Size:        10,
+				Mtime:       now,
+				Format:      "EPUB",
+				LastScanned: now,
+			})
+			if err != nil {
+				t.Fatalf("Insert lib2 file: %v", err)
+			}
+			lib1Files, err := fr.ListByLibrary(ctx, lib.ID)
+			if err != nil {
+				t.Fatalf("ListByLibrary lib: %v", err)
+			}
+			for _, f := range lib1Files {
+				if f.LibraryID != lib.ID {
+					t.Fatalf("ListByLibrary returned file from wrong library: %q", f.LibraryID)
+				}
+			}
+			lib2Files, err := fr.ListByLibrary(ctx, lib2.ID)
+			if err != nil {
+				t.Fatalf("ListByLibrary lib2: %v", err)
+			}
+			if len(lib2Files) != 1 {
+				t.Fatalf("ListByLibrary lib2 count=%d want 1", len(lib2Files))
+			}
+
+			// --- 13. UpdateLocation happy path + conflict ---
+			moveFile, err := fr.Insert(ctx, model.File{
+				LibraryID:   lib.ID,
+				Location:    "move/source.epub",
+				Size:        200,
+				Mtime:       now,
+				Format:      "EPUB",
+				LastScanned: now,
+			})
+			if err != nil {
+				t.Fatalf("Insert moveFile: %v", err)
+			}
+			if err := fr.UpdateLocation(ctx, moveFile.ID, "move/dest.epub"); err != nil {
+				t.Fatalf("UpdateLocation: %v", err)
+			}
+			_, err = fr.GetByLocation(ctx, lib.ID, "move/dest.epub")
+			if err != nil {
+				t.Fatalf("GetByLocation after UpdateLocation: %v", err)
+			}
+			_, err = fr.GetByLocation(ctx, lib.ID, "move/source.epub")
+			if !errors.Is(err, repo.ErrNotFound) {
+				t.Fatalf("old location should be gone after UpdateLocation, got %v", err)
+			}
+			// Conflict: try to move to an existing location.
+			conflictTarget, err := fr.Insert(ctx, model.File{
+				LibraryID:   lib.ID,
+				Location:    "move/conflict.epub",
+				Size:        10,
+				Mtime:       now,
+				Format:      "EPUB",
+				LastScanned: now,
+			})
+			if err != nil {
+				t.Fatalf("Insert conflictTarget: %v", err)
+			}
+			err = fr.UpdateLocation(ctx, conflictTarget.ID, "move/dest.epub")
+			if !errors.Is(err, repo.ErrFileLocationTaken) {
+				t.Fatalf("UpdateLocation conflict: got %v, want ErrFileLocationTaken", err)
+			}
 		})
 	}
 }

--- a/internal/scan/differ.go
+++ b/internal/scan/differ.go
@@ -1,0 +1,71 @@
+package scan
+
+import (
+	"time"
+
+	"github.com/blackforge/embookshelf/internal/model"
+)
+
+// Changeset is the output of Diff. Each slice holds the WalkEntry +
+// the matching DB row (for Changed and Missing) or just the
+// WalkEntry (for New) / just the model.File (for Missing).
+type Changeset struct {
+	// Unchanged: row exists, size+mtime match. No work needed.
+	Unchanged []model.File
+	// Changed: row exists but size or mtime differ — re-hash + update.
+	Changed []ChangedEntry
+	// New: walked but not in DB — enqueue ingest.
+	New []WalkEntry
+	// Missing: in DB but not walked — mark missing_since.
+	Missing []model.File
+}
+
+// ChangedEntry pairs the live observation with the stale DB row.
+type ChangedEntry struct {
+	Walk WalkEntry
+	DB   model.File
+}
+
+// Diff computes the changeset comparing walked entries against the
+// current DB rows for one library. Both slices may be in any order;
+// Diff sorts internally by Location.
+func Diff(walked []WalkEntry, dbFiles []model.File) Changeset {
+	// Build a map of DB rows by Location for O(1) lookup.
+	byLoc := make(map[string]model.File, len(dbFiles))
+	for _, f := range dbFiles {
+		byLoc[f.Location] = f
+	}
+
+	var cs Changeset
+	seen := make(map[string]bool, len(walked))
+	for _, w := range walked {
+		seen[w.Location] = true
+		f, ok := byLoc[w.Location]
+		if !ok {
+			cs.New = append(cs.New, w)
+			continue
+		}
+		// Compare size + mtime (truncated to whole seconds — local FS
+		// and S3 both report at ≥1s resolution). Float ETags would
+		// fail equality; we strip subsecond precision deliberately.
+		if w.Size == f.Size && sameSecond(w.Mtime, f.Mtime) {
+			cs.Unchanged = append(cs.Unchanged, f)
+			continue
+		}
+		cs.Changed = append(cs.Changed, ChangedEntry{Walk: w, DB: f})
+	}
+	for _, f := range dbFiles {
+		if !seen[f.Location] {
+			cs.Missing = append(cs.Missing, f)
+		}
+	}
+	return cs
+}
+
+// sameSecond returns true when a and b are equal after truncating both
+// to whole-second precision. This guards against sub-second drift
+// between reading mtime from the local FS and reading it back from the
+// DB as an ISO-8601 string.
+func sameSecond(a, b time.Time) bool {
+	return a.Truncate(time.Second).Equal(b.Truncate(time.Second))
+}

--- a/internal/scan/differ_test.go
+++ b/internal/scan/differ_test.go
@@ -1,0 +1,279 @@
+package scan_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/blackforge/embookshelf/internal/model"
+	"github.com/blackforge/embookshelf/internal/scan"
+)
+
+// baseTime is a fixed reference time used across subtests.
+var baseTime = time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+
+func makeFile(id, loc string, size int64, mtime time.Time) model.File {
+	return model.File{
+		ID:        id,
+		LibraryID: "lib1",
+		Location:  loc,
+		Size:      size,
+		Mtime:     mtime,
+		Format:    "EPUB",
+	}
+}
+
+func makeEntry(loc string, size int64, mtime time.Time) scan.WalkEntry {
+	return scan.WalkEntry{
+		Location: loc,
+		Size:     size,
+		Mtime:    mtime,
+	}
+}
+
+func TestDiff_BothEmpty(t *testing.T) {
+	cs := scan.Diff(nil, nil)
+	if len(cs.Unchanged) != 0 {
+		t.Errorf("Unchanged: want 0, got %d", len(cs.Unchanged))
+	}
+	if len(cs.Changed) != 0 {
+		t.Errorf("Changed: want 0, got %d", len(cs.Changed))
+	}
+	if len(cs.New) != 0 {
+		t.Errorf("New: want 0, got %d", len(cs.New))
+	}
+	if len(cs.Missing) != 0 {
+		t.Errorf("Missing: want 0, got %d", len(cs.Missing))
+	}
+}
+
+func TestDiff_AllMatching(t *testing.T) {
+	mtime := baseTime
+	walked := []scan.WalkEntry{
+		makeEntry("a.epub", 100, mtime),
+		makeEntry("b.epub", 200, mtime),
+	}
+	dbFiles := []model.File{
+		makeFile("id1", "a.epub", 100, mtime),
+		makeFile("id2", "b.epub", 200, mtime),
+	}
+
+	cs := scan.Diff(walked, dbFiles)
+
+	if len(cs.Unchanged) != 2 {
+		t.Errorf("Unchanged: want 2, got %d", len(cs.Unchanged))
+	}
+	if len(cs.Changed) != 0 {
+		t.Errorf("Changed: want 0, got %d", len(cs.Changed))
+	}
+	if len(cs.New) != 0 {
+		t.Errorf("New: want 0, got %d", len(cs.New))
+	}
+	if len(cs.Missing) != 0 {
+		t.Errorf("Missing: want 0, got %d", len(cs.Missing))
+	}
+}
+
+func TestDiff_OneNew(t *testing.T) {
+	walked := []scan.WalkEntry{
+		makeEntry("new.epub", 500, baseTime),
+	}
+	var dbFiles []model.File
+
+	cs := scan.Diff(walked, dbFiles)
+
+	if len(cs.New) != 1 {
+		t.Fatalf("New: want 1, got %d", len(cs.New))
+	}
+	if cs.New[0].Location != "new.epub" {
+		t.Errorf("New[0].Location = %q, want new.epub", cs.New[0].Location)
+	}
+	if len(cs.Unchanged) != 0 || len(cs.Changed) != 0 || len(cs.Missing) != 0 {
+		t.Errorf("expected only New entries, got Unchanged=%d Changed=%d Missing=%d",
+			len(cs.Unchanged), len(cs.Changed), len(cs.Missing))
+	}
+}
+
+func TestDiff_OneMissing(t *testing.T) {
+	var walked []scan.WalkEntry
+	dbFiles := []model.File{
+		makeFile("id1", "gone.epub", 300, baseTime),
+	}
+
+	cs := scan.Diff(walked, dbFiles)
+
+	if len(cs.Missing) != 1 {
+		t.Fatalf("Missing: want 1, got %d", len(cs.Missing))
+	}
+	if cs.Missing[0].Location != "gone.epub" {
+		t.Errorf("Missing[0].Location = %q, want gone.epub", cs.Missing[0].Location)
+	}
+	if len(cs.Unchanged) != 0 || len(cs.Changed) != 0 || len(cs.New) != 0 {
+		t.Errorf("expected only Missing entries, got Unchanged=%d Changed=%d New=%d",
+			len(cs.Unchanged), len(cs.Changed), len(cs.New))
+	}
+}
+
+func TestDiff_ChangedBySize(t *testing.T) {
+	mtime := baseTime
+	walked := []scan.WalkEntry{
+		makeEntry("book.epub", 999, mtime), // size differs from DB
+	}
+	dbFiles := []model.File{
+		makeFile("id1", "book.epub", 100, mtime),
+	}
+
+	cs := scan.Diff(walked, dbFiles)
+
+	if len(cs.Changed) != 1 {
+		t.Fatalf("Changed: want 1, got %d", len(cs.Changed))
+	}
+	if cs.Changed[0].Walk.Location != "book.epub" {
+		t.Errorf("Changed[0].Walk.Location = %q, want book.epub", cs.Changed[0].Walk.Location)
+	}
+	if cs.Changed[0].DB.ID != "id1" {
+		t.Errorf("Changed[0].DB.ID = %q, want id1", cs.Changed[0].DB.ID)
+	}
+	if len(cs.Unchanged) != 0 || len(cs.New) != 0 || len(cs.Missing) != 0 {
+		t.Errorf("expected only Changed entries")
+	}
+}
+
+func TestDiff_ChangedByMtimeMoreThanOneSecond(t *testing.T) {
+	walked := []scan.WalkEntry{
+		makeEntry("book.epub", 100, baseTime.Add(2*time.Second)),
+	}
+	dbFiles := []model.File{
+		makeFile("id1", "book.epub", 100, baseTime),
+	}
+
+	cs := scan.Diff(walked, dbFiles)
+
+	if len(cs.Changed) != 1 {
+		t.Fatalf("Changed: want 1 (mtime >1s apart), got %d", len(cs.Changed))
+	}
+	if len(cs.Unchanged) != 0 {
+		t.Errorf("Unchanged: want 0, got %d", len(cs.Unchanged))
+	}
+}
+
+func TestDiff_UnchangedByMtimeLessThanOneSecond(t *testing.T) {
+	// Two timestamps that differ by only 500ms should be considered the same
+	// after truncation to the second.
+	t1 := baseTime
+	t2 := baseTime.Add(500 * time.Millisecond)
+
+	walked := []scan.WalkEntry{
+		makeEntry("book.epub", 100, t2),
+	}
+	dbFiles := []model.File{
+		makeFile("id1", "book.epub", 100, t1),
+	}
+
+	cs := scan.Diff(walked, dbFiles)
+
+	if len(cs.Unchanged) != 1 {
+		t.Fatalf("Unchanged: want 1 (mtime <1s apart), got %d", len(cs.Unchanged))
+	}
+	if len(cs.Changed) != 0 {
+		t.Errorf("Changed: want 0 (sub-second diff should be ignored), got %d", len(cs.Changed))
+	}
+}
+
+func TestDiff_Mixed(t *testing.T) {
+	mtime := baseTime
+
+	// Walked: a (match), b (size changed), c (new), d is absent (missing)
+	walked := []scan.WalkEntry{
+		makeEntry("a.epub", 100, mtime),  // unchanged
+		makeEntry("b.epub", 9999, mtime), // changed: size differs
+		makeEntry("e.epub", 100, mtime),  // unchanged second
+		makeEntry("c.epub", 400, mtime),  // new
+	}
+	dbFiles := []model.File{
+		makeFile("id-a", "a.epub", 100, mtime), // unchanged
+		makeFile("id-b", "b.epub", 100, mtime), // changed
+		makeFile("id-e", "e.epub", 100, mtime), // unchanged second
+		makeFile("id-d", "d.epub", 300, mtime), // missing
+	}
+
+	cs := scan.Diff(walked, dbFiles)
+
+	if len(cs.Unchanged) != 2 {
+		t.Errorf("Unchanged: want 2, got %d", len(cs.Unchanged))
+	}
+	if len(cs.Changed) != 1 {
+		t.Errorf("Changed: want 1, got %d", len(cs.Changed))
+	}
+	if len(cs.New) != 1 {
+		t.Errorf("New: want 1, got %d", len(cs.New))
+	}
+	if len(cs.Missing) != 1 {
+		t.Errorf("Missing: want 1, got %d", len(cs.Missing))
+	}
+
+	if cs.Changed[0].DB.ID != "id-b" {
+		t.Errorf("Changed entry should be id-b, got %q", cs.Changed[0].DB.ID)
+	}
+	if cs.New[0].Location != "c.epub" {
+		t.Errorf("New entry should be c.epub, got %q", cs.New[0].Location)
+	}
+	if cs.Missing[0].ID != "id-d" {
+		t.Errorf("Missing entry should be id-d, got %q", cs.Missing[0].ID)
+	}
+}
+
+func TestDiff_AllNew(t *testing.T) {
+	walked := []scan.WalkEntry{
+		makeEntry("x.epub", 100, baseTime),
+		makeEntry("y.epub", 200, baseTime),
+	}
+
+	cs := scan.Diff(walked, nil)
+
+	if len(cs.New) != 2 {
+		t.Errorf("New: want 2, got %d", len(cs.New))
+	}
+	if len(cs.Unchanged) != 0 || len(cs.Changed) != 0 || len(cs.Missing) != 0 {
+		t.Errorf("expected only New entries")
+	}
+}
+
+func TestDiff_AllMissing(t *testing.T) {
+	dbFiles := []model.File{
+		makeFile("id1", "x.epub", 100, baseTime),
+		makeFile("id2", "y.epub", 200, baseTime),
+	}
+
+	cs := scan.Diff(nil, dbFiles)
+
+	if len(cs.Missing) != 2 {
+		t.Errorf("Missing: want 2, got %d", len(cs.Missing))
+	}
+	if len(cs.Unchanged) != 0 || len(cs.Changed) != 0 || len(cs.New) != 0 {
+		t.Errorf("expected only Missing entries")
+	}
+}
+
+func TestDiff_MissingRowWithMissingSinceSet(t *testing.T) {
+	// A DB row that already has MissingSince set but reappears in the walk
+	// should be classified as Unchanged (if size+mtime match) — the caller
+	// is responsible for calling ClearMissing.
+	mtime := baseTime
+	missingSince := mtime.Add(-time.Hour)
+	f := makeFile("id1", "reappeared.epub", 100, mtime)
+	f.MissingSince = &missingSince
+
+	walked := []scan.WalkEntry{
+		makeEntry("reappeared.epub", 100, mtime),
+	}
+	dbFiles := []model.File{f}
+
+	cs := scan.Diff(walked, dbFiles)
+
+	if len(cs.Unchanged) != 1 {
+		t.Fatalf("Unchanged: want 1 (reappeared file with matching size+mtime), got %d", len(cs.Unchanged))
+	}
+	if len(cs.Changed) != 0 || len(cs.New) != 0 || len(cs.Missing) != 0 {
+		t.Errorf("expected only Unchanged")
+	}
+}

--- a/internal/scan/reattach.go
+++ b/internal/scan/reattach.go
@@ -1,0 +1,54 @@
+package scan
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/blackforge/embookshelf/internal/repo"
+)
+
+// MaybeReattach handles the rename case. After a Changed entry has
+// been re-hashed, if the new hash matches another files row in the
+// same library, the file was probably renamed: update that row's
+// location instead of orphaning the old row. Returns (true, nil)
+// when a reattach happened.
+//
+// The caller passes:
+//   - the freshly computed hash for the moved file,
+//   - the new location it now lives at,
+//   - the OLD row's id (the row that was at the previous location).
+//
+// On reattach: the OTHER row (the one whose hash matches) takes
+// over the new location, and the OLD row is marked missing so the
+// purge sweeper deletes it after the TTL. This preserves book_id
+// continuity when the user renames a file outside the app.
+func MaybeReattach(ctx context.Context, files *repo.FileRepo, libraryID string, hash []byte, newLocation string, oldRowID string) (bool, error) {
+	if len(hash) == 0 {
+		return false, nil
+	}
+	matches, err := files.GetByContentHash(ctx, hash)
+	if err != nil {
+		return false, err
+	}
+	for _, m := range matches {
+		if m.LibraryID != libraryID {
+			continue
+		}
+		if m.ID == oldRowID {
+			continue
+		}
+		// Reattach: m takes over newLocation; old row goes missing.
+		if err := files.UpdateLocation(ctx, m.ID, newLocation); err != nil {
+			if errors.Is(err, repo.ErrFileLocationTaken) {
+				return false, err
+			}
+			return false, err
+		}
+		if err := files.MarkMissing(ctx, oldRowID, time.Now()); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	return false, nil
+}

--- a/internal/scan/reattach_test.go
+++ b/internal/scan/reattach_test.go
@@ -1,0 +1,219 @@
+package scan_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/blackforge/embookshelf/internal/model"
+	"github.com/blackforge/embookshelf/internal/repo"
+	"github.com/blackforge/embookshelf/internal/repo/repotest"
+	"github.com/blackforge/embookshelf/internal/scan"
+)
+
+// setupReattach creates a fully-migrated DB and seeds two libraries.
+// Returns (fileRepo, lib1ID, lib2ID).
+func setupReattach(t *testing.T) (*repo.FileRepo, string, string) {
+	t.Helper()
+	d := repotest.New(t)
+	fr := repo.NewFileRepo(d)
+	lr := repo.NewLibraryRepo(d)
+	ctx := context.Background()
+
+	lib1, err := lr.CreateLibrary(ctx, "Library One", "lib-one", "/tmp/lib1")
+	if err != nil {
+		t.Fatalf("CreateLibrary lib1: %v", err)
+	}
+	lib2, err := lr.CreateLibrary(ctx, "Library Two", "lib-two", "/tmp/lib2")
+	if err != nil {
+		t.Fatalf("CreateLibrary lib2: %v", err)
+	}
+	return fr, lib1.ID, lib2.ID
+}
+
+func insertTestFile(t *testing.T, fr *repo.FileRepo, libraryID, location string, hash []byte) model.File {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	f := model.File{
+		LibraryID:   libraryID,
+		Location:    location,
+		Size:        100,
+		Mtime:       now,
+		Format:      "EPUB",
+		LastScanned: now,
+		ContentHash: hash,
+	}
+	inserted, err := fr.Insert(ctx, f)
+	if err != nil {
+		t.Fatalf("Insert(%q): %v", location, err)
+	}
+	return inserted
+}
+
+func TestMaybeReattach_NoHashMatches(t *testing.T) {
+	fr, lib1ID, _ := setupReattach(t)
+	ctx := context.Background()
+
+	// Insert an old row with no matching hash anywhere.
+	h := sha256.Sum256([]byte("unique-content"))
+	oldRow := insertTestFile(t, fr, lib1ID, "old.epub", nil)
+
+	reattached, err := scan.MaybeReattach(ctx, fr, lib1ID, h[:], "new.epub", oldRow.ID)
+	if err != nil {
+		t.Fatalf("MaybeReattach unexpected error: %v", err)
+	}
+	if reattached {
+		t.Fatalf("expected (false, nil), got reattached=true")
+	}
+
+	// Old row should be unmodified.
+	got, err := fr.GetByLocation(ctx, lib1ID, "old.epub")
+	if err != nil {
+		t.Fatalf("GetByLocation old.epub: %v", err)
+	}
+	if got.MissingSince != nil {
+		t.Errorf("old row MissingSince should be nil, got %v", got.MissingSince)
+	}
+}
+
+func TestMaybeReattach_EmptyHash(t *testing.T) {
+	fr, lib1ID, _ := setupReattach(t)
+	ctx := context.Background()
+
+	oldRow := insertTestFile(t, fr, lib1ID, "old.epub", nil)
+
+	reattached, err := scan.MaybeReattach(ctx, fr, lib1ID, nil, "new.epub", oldRow.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if reattached {
+		t.Fatalf("expected (false, nil) for empty hash")
+	}
+}
+
+func TestMaybeReattach_HashMatchInDifferentLibrary(t *testing.T) {
+	fr, lib1ID, lib2ID := setupReattach(t)
+	ctx := context.Background()
+
+	h := sha256.Sum256([]byte("shared-content"))
+
+	// The matching row lives in lib2, not lib1.
+	insertTestFile(t, fr, lib2ID, "lib2/file.epub", h[:])
+
+	oldRow := insertTestFile(t, fr, lib1ID, "old.epub", nil)
+
+	reattached, err := scan.MaybeReattach(ctx, fr, lib1ID, h[:], "new.epub", oldRow.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if reattached {
+		t.Fatalf("expected (false, nil) for match in different library")
+	}
+
+	// old row must be untouched.
+	got, err := fr.GetByLocation(ctx, lib1ID, "old.epub")
+	if err != nil {
+		t.Fatalf("GetByLocation: %v", err)
+	}
+	if got.MissingSince != nil {
+		t.Errorf("old row should not be marked missing")
+	}
+}
+
+func TestMaybeReattach_HashMatchesOldRowOnly(t *testing.T) {
+	fr, lib1ID, _ := setupReattach(t)
+	ctx := context.Background()
+
+	h := sha256.Sum256([]byte("self-match"))
+
+	// The only row with this hash IS the old row itself.
+	oldRow := insertTestFile(t, fr, lib1ID, "old.epub", h[:])
+
+	reattached, err := scan.MaybeReattach(ctx, fr, lib1ID, h[:], "new.epub", oldRow.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if reattached {
+		t.Fatalf("expected (false, nil) when hash only matches oldRowID")
+	}
+}
+
+func TestMaybeReattach_Rename(t *testing.T) {
+	fr, lib1ID, _ := setupReattach(t)
+	ctx := context.Background()
+
+	h := sha256.Sum256([]byte("book-content"))
+
+	// The "canonical" row already exists at a.epub with the hash.
+	canonRow := insertTestFile(t, fr, lib1ID, "a.epub", h[:])
+
+	// The "stale" row — the previous location that is now being re-scanned.
+	oldRow := insertTestFile(t, fr, lib1ID, "b_old.epub", nil)
+
+	// Simulate: file was renamed from b_old.epub to b_new.epub.
+	// The re-hash of b_new.epub matches canonRow's hash.
+	reattached, err := scan.MaybeReattach(ctx, fr, lib1ID, h[:], "b_new.epub", oldRow.ID)
+	if err != nil {
+		t.Fatalf("MaybeReattach: %v", err)
+	}
+	if !reattached {
+		t.Fatalf("expected reattached=true for rename scenario")
+	}
+
+	// canonRow should now live at b_new.epub.
+	updated, err := fr.GetByLocation(ctx, lib1ID, "b_new.epub")
+	if err != nil {
+		t.Fatalf("GetByLocation b_new.epub: %v", err)
+	}
+	if updated.ID != canonRow.ID {
+		t.Errorf("expected canonRow ID %q at b_new.epub, got %q", canonRow.ID, updated.ID)
+	}
+
+	// old row should be marked missing.
+	allFiles, err := fr.ListByLibrary(ctx, lib1ID)
+	if err != nil {
+		t.Fatalf("ListByLibrary: %v", err)
+	}
+	var oldFound *model.File
+	for i := range allFiles {
+		if allFiles[i].ID == oldRow.ID {
+			oldFound = &allFiles[i]
+			break
+		}
+	}
+	if oldFound == nil {
+		t.Fatal("old row not found in ListByLibrary")
+	}
+	if oldFound.MissingSince == nil {
+		t.Errorf("old row should have MissingSince set after reattach")
+	}
+}
+
+func TestMaybeReattach_NewLocationTaken(t *testing.T) {
+	fr, lib1ID, _ := setupReattach(t)
+	ctx := context.Background()
+
+	h := sha256.Sum256([]byte("taken-content"))
+
+	// The row whose hash matches (the one that would be reattached).
+	insertTestFile(t, fr, lib1ID, "match.epub", h[:])
+
+	// A third row already sitting at the target location.
+	insertTestFile(t, fr, lib1ID, "target.epub", nil)
+
+	// The stale row.
+	oldRow := insertTestFile(t, fr, lib1ID, "stale.epub", nil)
+
+	// Reattach would try to move match.epub → target.epub, but target.epub
+	// is already taken by a third row.
+	_, err := scan.MaybeReattach(ctx, fr, lib1ID, h[:], "target.epub", oldRow.ID)
+	if err == nil {
+		t.Fatal("expected error when new location is already taken")
+	}
+	if !errors.Is(err, repo.ErrFileLocationTaken) {
+		t.Fatalf("expected ErrFileLocationTaken, got %v", err)
+	}
+}

--- a/internal/scan/walker.go
+++ b/internal/scan/walker.go
@@ -1,0 +1,64 @@
+// Package scan orchestrates the two-phase library scan: walk, diff,
+// then act on the changeset. The walker yields entries via a
+// channel so the iterator API of storage.Storage doesn't leak into
+// the differ.
+package scan
+
+import (
+	"context"
+	"errors"
+	"io"
+	"time"
+
+	"github.com/blackforge/embookshelf/internal/storage"
+)
+
+// WalkEntry is one observation from a storage backend during the
+// cheap walk phase. Hashes are NOT computed here.
+type WalkEntry struct {
+	Location string
+	Size     int64
+	Mtime    time.Time
+	ETag     string
+}
+
+// Walk lists every object under root in store and forwards each as a
+// WalkEntry. Errors during iteration go to errc; the caller MUST
+// consume both channels to completion.
+func Walk(ctx context.Context, store storage.Storage, root string) (<-chan WalkEntry, <-chan error) {
+	out := make(chan WalkEntry, 64)
+	errc := make(chan error, 1)
+	go func() {
+		defer close(out)
+		defer close(errc)
+		it, err := store.List(ctx, root)
+		if err != nil {
+			errc <- err
+			return
+		}
+		defer func() { _ = it.Close() }()
+		for {
+			obj, err := it.Next(ctx)
+			if errors.Is(err, io.EOF) {
+				return
+			}
+			if err != nil {
+				errc <- err
+				return
+			}
+			entry := WalkEntry{
+				Location: obj.Key,
+				Size:     obj.Size,
+				Mtime:    obj.ModTime,
+				ETag:     obj.ETag,
+			}
+			select {
+			case out <- entry:
+			case <-ctx.Done():
+				errc <- ctx.Err()
+				return
+			}
+		}
+	}()
+	return out, errc
+}

--- a/internal/scan/walker_test.go
+++ b/internal/scan/walker_test.go
@@ -1,0 +1,135 @@
+package scan_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/blackforge/embookshelf/internal/scan"
+	"github.com/blackforge/embookshelf/internal/storage/local"
+)
+
+func TestWalk_EmptyDir(t *testing.T) {
+	root := t.TempDir()
+	store, err := local.New(root)
+	if err != nil {
+		t.Fatalf("local.New: %v", err)
+	}
+	ctx := context.Background()
+	out, errc := scan.Walk(ctx, store, "")
+
+	var entries []scan.WalkEntry
+	for e := range out {
+		entries = append(entries, e)
+	}
+	if err := <-errc; err != nil {
+		t.Fatalf("unexpected error from empty dir walk: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected 0 entries, got %d", len(entries))
+	}
+}
+
+func TestWalk_ThreeFiles(t *testing.T) {
+	root := t.TempDir()
+	store, err := local.New(root)
+	if err != nil {
+		t.Fatalf("local.New: %v", err)
+	}
+
+	// Create 3 known files with distinct content (and thus distinct sizes).
+	files := map[string]string{
+		"a.epub":        "content of a",
+		"subdir/b.epub": "content of b — slightly longer",
+		"c.pdf":         "c",
+	}
+	for rel, content := range files {
+		abs := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+			t.Fatalf("WriteFile %q: %v", rel, err)
+		}
+	}
+
+	ctx := context.Background()
+	out, errc := scan.Walk(ctx, store, "")
+
+	var entries []scan.WalkEntry
+	for e := range out {
+		entries = append(entries, e)
+	}
+	if err := <-errc; err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(entries))
+	}
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Location < entries[j].Location })
+
+	for _, e := range entries {
+		if e.Size <= 0 {
+			t.Errorf("entry %q has non-positive Size %d", e.Location, e.Size)
+		}
+		if e.Mtime.IsZero() {
+			t.Errorf("entry %q has zero Mtime", e.Location)
+		}
+	}
+
+	// Verify the locations we expect are present.
+	locs := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		locs[e.Location] = true
+	}
+	for rel := range files {
+		if !locs[rel] {
+			t.Errorf("expected location %q not found in walk entries", rel)
+		}
+	}
+}
+
+func TestWalk_CancelledContext(t *testing.T) {
+	root := t.TempDir()
+	store, err := local.New(root)
+	if err != nil {
+		t.Fatalf("local.New: %v", err)
+	}
+
+	// Create a file so the walk has something to iterate over.
+	abs := filepath.Join(root, "book.epub")
+	if err := os.WriteFile(abs, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	out, errc := scan.Walk(ctx, store, "")
+
+	// Drain both channels; at least one should reflect cancellation.
+	var entries []scan.WalkEntry
+	for e := range out {
+		entries = append(entries, e)
+	}
+	walkErr := <-errc
+
+	// A pre-cancelled context must surface ctx.Err() on errc OR result in
+	// zero entries (the iterator itself may short-circuit before sending).
+	if walkErr != nil {
+		if walkErr != context.Canceled {
+			t.Fatalf("expected context.Canceled, got %v", walkErr)
+		}
+		// Good — error path surfaced correctly.
+		return
+	}
+	// If no error was sent, the walk must have returned 0 entries (the
+	// context was cancelled before any select could send).
+	if len(entries) != 0 {
+		t.Fatalf("with cancelled ctx expected 0 entries or ctx.Canceled error, got %d entries and nil err", len(entries))
+	}
+}

--- a/internal/task/library_scan.go
+++ b/internal/task/library_scan.go
@@ -7,12 +7,15 @@ import (
 	"log/slog"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/riverqueue/river"
 
 	"github.com/blackforge/embookshelf/internal/fileproc"
+	"github.com/blackforge/embookshelf/internal/hashing"
 	"github.com/blackforge/embookshelf/internal/model"
 	"github.com/blackforge/embookshelf/internal/repo"
+	"github.com/blackforge/embookshelf/internal/scan"
 	"github.com/blackforge/embookshelf/internal/service"
 	"github.com/blackforge/embookshelf/internal/storage"
 )
@@ -45,10 +48,9 @@ type LibraryScanDeps struct {
 	// the walk. Plan A only uses List; future plans use Get/Head for
 	// content-hash computation and metadata extraction.
 	Storage storage.Storage
-	// Files is the storage_v2 file repo. When non-nil the scan loop
-	// checks files.ExistsByLocation before falling through to the
-	// legacy BookExistsByPath check. nil disables the new check so
-	// libraries that haven't been backfilled yet still de-dupe by path.
+	// Files is the storage_v2 file repo. When non-nil the scan uses the
+	// two-phase walk+diff pipeline. nil disables the new pipeline and
+	// falls back to the legacy BookExistsByPath check.
 	Files *repo.FileRepo
 }
 
@@ -64,9 +66,129 @@ func LibraryScan(ctx context.Context, args LibraryScanArgs, deps LibraryScanDeps
 		return err
 	}
 	root := lib.Path
+	if lib.Root != nil && *lib.Root != "" {
+		root = *lib.Root
+	}
 	if root == "" {
-		slog.Warn("library scan: empty path, skipping", "library_id", lib.ID)
+		slog.Warn("library scan: empty root, skipping", "library_id", lib.ID)
 		return nil
+	}
+
+	// Fall back to legacy implementation when deps are missing (e.g. in
+	// the SQLite queue tests that pass nil for both).
+	if deps.Storage == nil || deps.Files == nil {
+		return legacyScan(ctx, lib, deps)
+	}
+
+	// Phase 1: read DB state.
+	dbFiles, err := deps.Files.ListByLibrary(ctx, lib.ID)
+	if err != nil {
+		return errors.New("list db files: " + err.Error())
+	}
+
+	// Phase 2: walk storage and collect WalkEntry slice.
+	var walked []scan.WalkEntry
+	entries, errc := scan.Walk(ctx, deps.Storage, root)
+	for e := range entries {
+		// Convert the absolute key (LocalFS rooted at "/") to library-
+		// relative location so it matches what the DB stores.
+		e.Location = relativizeLocation(lib, "/"+e.Location)
+		walked = append(walked, e)
+	}
+	if walkErr := <-errc; walkErr != nil && !errors.Is(walkErr, context.Canceled) {
+		slog.Warn("library scan: walk error", "library_id", lib.ID, "err", walkErr)
+	}
+
+	// Phase 3: diff.
+	cs := scan.Diff(walked, dbFiles)
+
+	// Phase 4: act on each category.
+	fileCount := len(walked)
+	discovered := 0
+
+	// Unchanged: clear missing flag if file reappeared.
+	for _, f := range cs.Unchanged {
+		if f.MissingSince != nil {
+			if err := deps.Files.ClearMissing(ctx, f.ID); err != nil {
+				slog.Warn("library scan: clear missing", "id", f.ID, "err", err)
+			}
+		}
+	}
+
+	// Changed: re-hash and update the row in place (or reattach on rename).
+	for _, ce := range cs.Changed {
+		key := joinKey(root, ce.Walk.Location)
+		hash, size, herr := hashing.HashFile(ctx, deps.Storage, key)
+		if herr != nil {
+			slog.Warn("library scan: rehash failed", "loc", ce.Walk.Location, "err", herr)
+			continue
+		}
+		reattached, rerr := scan.MaybeReattach(ctx, deps.Files, lib.ID, hash, ce.Walk.Location, ce.DB.ID)
+		if rerr != nil {
+			slog.Warn("library scan: reattach failed", "loc", ce.Walk.Location, "err", rerr)
+		} else if reattached {
+			continue
+		}
+		if err := deps.Files.SetContentHash(ctx, ce.DB.ID, hash, size, ce.Walk.Mtime); err != nil {
+			slog.Warn("library scan: update changed row", "id", ce.DB.ID, "err", err)
+		}
+	}
+
+	// New: enqueue supported files through the bookdrop pipeline.
+	for _, w := range cs.New {
+		absPath := joinKey(root, w.Location)
+		// fileproc.IsSupported expects a slash-prefixed path.
+		if !fileproc.IsSupported("/" + absPath) {
+			continue
+		}
+		format := fileproc.FormatForExt(filepath.Ext(w.Location))
+		// Bookdrop still wants the absolute path with leading slash.
+		fullPath := "/" + absPath
+		item, created, err := deps.BookDrop.Enqueue(ctx, fullPath, format, w.Size)
+		if err != nil {
+			slog.Warn("library scan: enqueue", "path", fullPath, "err", err)
+			continue
+		}
+		if !created {
+			continue
+		}
+		if deps.Queue != nil {
+			if err := deps.Queue.EnqueueBookDrop(ctx, item.ID); err != nil {
+				slog.Warn("library scan: enqueue queue job", "id", item.ID, "err", err)
+			}
+		}
+		discovered++
+	}
+
+	// Missing: soft-flag files for the 24h purge sweeper.
+	for _, f := range cs.Missing {
+		if f.MissingSince != nil {
+			continue // already marked
+		}
+		if err := deps.Files.MarkMissing(ctx, f.ID, time.Now()); err != nil {
+			slog.Warn("library scan: mark missing", "id", f.ID, "err", err)
+		}
+	}
+
+	if err := deps.Lib.TouchScan(ctx, lib.ID, fileCount, discovered); err != nil {
+		slog.Warn("library scan: touch", "id", lib.ID, "err", err)
+	}
+	slog.Info("library scan done",
+		"library", lib.ID, "root", root,
+		"files", fileCount, "discovered", discovered,
+		"changed", len(cs.Changed), "missing", len(cs.Missing),
+	)
+	return nil
+}
+
+// legacyScan is the pre-Plan-C implementation kept as a fallback for
+// code paths where deps.Files or deps.Storage is nil (e.g. the SQLite
+// queue test that passes nil for both). It walks storage directly and
+// de-dupes by BookExistsByPath.
+func legacyScan(ctx context.Context, lib model.Library, deps LibraryScanDeps) error {
+	root := lib.Path
+	if lib.Root != nil && *lib.Root != "" {
+		root = *lib.Root
 	}
 
 	var fileCount, discovered int

--- a/internal/task/missing_purge.go
+++ b/internal/task/missing_purge.go
@@ -1,0 +1,51 @@
+package task
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/blackforge/embookshelf/internal/repo"
+)
+
+// MissingTTL is the grace period before missing files are purged.
+// Spec §5.3 sets this at 24h to ride out unmounted drives, S3 region
+// blips, and IAM hiccups.
+const MissingTTL = 24 * time.Hour
+
+// RunMissingPurge deletes files rows whose missing_since is older
+// than MissingTTL. Returns the count purged.
+func RunMissingPurge(ctx context.Context, files *repo.FileRepo) (int64, error) {
+	if files == nil {
+		return 0, nil
+	}
+	return files.DeleteMissingOlderThan(ctx, MissingTTL)
+}
+
+// LoopMissingPurge runs RunMissingPurge on a ticker until ctx is
+// cancelled. Errors are logged but do not stop the loop.
+func LoopMissingPurge(ctx context.Context, files *repo.FileRepo, every time.Duration) {
+	if every <= 0 {
+		every = time.Hour
+	}
+	if files == nil {
+		return
+	}
+	t := time.NewTicker(every)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			n, err := RunMissingPurge(ctx, files)
+			if err != nil {
+				slog.Warn("missing purge", "err", err)
+				continue
+			}
+			if n > 0 {
+				slog.Info("missing purge", "deleted", n)
+			}
+		}
+	}
+}

--- a/internal/task/missing_purge_test.go
+++ b/internal/task/missing_purge_test.go
@@ -1,0 +1,223 @@
+package task_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/blackforge/embookshelf/internal/model"
+	"github.com/blackforge/embookshelf/internal/repo"
+	"github.com/blackforge/embookshelf/internal/repo/repotest"
+	"github.com/blackforge/embookshelf/internal/task"
+)
+
+// newPurgeTestRepo creates a FileRepo wired to a fresh SQLite DB (migrated).
+func newPurgeTestRepo(t *testing.T) (*repo.FileRepo, *repo.LibraryRepo) {
+	t.Helper()
+	d := repotest.NewWithDialect(t, "sqlite")
+	return repo.NewFileRepo(d), repo.NewLibraryRepo(d)
+}
+
+// insertMissingFile inserts a file row with missing_since set to `when`.
+func insertMissingFile(t *testing.T, fr *repo.FileRepo, libID string, when time.Time) model.File {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	f, err := fr.Insert(ctx, model.File{
+		LibraryID:   libID,
+		Location:    "book-" + when.Format("20060102150405.999999999") + ".epub",
+		Size:        100,
+		Mtime:       now,
+		Format:      "EPUB",
+		LastScanned: now,
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	if err := fr.MarkMissing(ctx, f.ID, when); err != nil {
+		t.Fatalf("MarkMissing: %v", err)
+	}
+	return f
+}
+
+// TestRunMissingPurge_nilFiles ensures nil FileRepo returns (0, nil).
+func TestRunMissingPurge_nilFiles(t *testing.T) {
+	n, err := task.RunMissingPurge(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("nil files: got err %v, want nil", err)
+	}
+	if n != 0 {
+		t.Fatalf("nil files: got n=%d, want 0", n)
+	}
+}
+
+// TestRunMissingPurge_noMissingRows returns (0, nil) when no rows are missing.
+func TestRunMissingPurge_noMissingRows(t *testing.T) {
+	fr, lr := newPurgeTestRepo(t)
+	ctx := context.Background()
+	lib, err := lr.CreateLibrary(ctx, "Purge Test", "purge-test", "/tmp/purge")
+	if err != nil {
+		t.Fatalf("CreateLibrary: %v", err)
+	}
+
+	// Insert a normal (non-missing) file.
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	_, err = fr.Insert(ctx, model.File{
+		LibraryID:   lib.ID,
+		Location:    "present.epub",
+		Size:        100,
+		Mtime:       now,
+		Format:      "EPUB",
+		LastScanned: now,
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	n, err := task.RunMissingPurge(ctx, fr)
+	if err != nil {
+		t.Fatalf("got err %v, want nil", err)
+	}
+	if n != 0 {
+		t.Fatalf("got n=%d, want 0 (no missing rows)", n)
+	}
+}
+
+// TestRunMissingPurge_withinTTL verifies a row missing < 24h is not deleted.
+func TestRunMissingPurge_withinTTL(t *testing.T) {
+	fr, lr := newPurgeTestRepo(t)
+	ctx := context.Background()
+	lib, err := lr.CreateLibrary(ctx, "Purge Test TTL", "purge-ttl", "/tmp/purge-ttl")
+	if err != nil {
+		t.Fatalf("CreateLibrary: %v", err)
+	}
+
+	// Mark missing 1 hour ago — well within the 24h TTL.
+	insertMissingFile(t, fr, lib.ID, time.Now().Add(-1*time.Hour))
+
+	n, err := task.RunMissingPurge(ctx, fr)
+	if err != nil {
+		t.Fatalf("got err %v, want nil", err)
+	}
+	if n != 0 {
+		t.Fatalf("got n=%d, want 0 (row within TTL should be kept)", n)
+	}
+
+	// Row should still exist.
+	rows, err := fr.ListByLibrary(ctx, lib.ID)
+	if err != nil {
+		t.Fatalf("ListByLibrary: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1 (row kept)", len(rows))
+	}
+}
+
+// TestRunMissingPurge_beyondTTL verifies a row missing > 24h is deleted.
+func TestRunMissingPurge_beyondTTL(t *testing.T) {
+	fr, lr := newPurgeTestRepo(t)
+	ctx := context.Background()
+	lib, err := lr.CreateLibrary(ctx, "Purge Test Old", "purge-old", "/tmp/purge-old")
+	if err != nil {
+		t.Fatalf("CreateLibrary: %v", err)
+	}
+
+	// Mark missing 25 hours ago — past the 24h TTL.
+	insertMissingFile(t, fr, lib.ID, time.Now().Add(-25*time.Hour))
+
+	n, err := task.RunMissingPurge(ctx, fr)
+	if err != nil {
+		t.Fatalf("got err %v, want nil", err)
+	}
+	if n != 1 {
+		t.Fatalf("got n=%d, want 1 (row past TTL should be deleted)", n)
+	}
+
+	// Row should be gone.
+	rows, err := fr.ListByLibrary(ctx, lib.ID)
+	if err != nil {
+		t.Fatalf("ListByLibrary: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("got %d rows, want 0 (row deleted)", len(rows))
+	}
+}
+
+// TestRunMissingPurge_mixed verifies only rows past TTL are deleted while
+// rows within TTL are preserved.
+func TestRunMissingPurge_mixed(t *testing.T) {
+	fr, lr := newPurgeTestRepo(t)
+	ctx := context.Background()
+	lib, err := lr.CreateLibrary(ctx, "Purge Test Mix", "purge-mix", "/tmp/purge-mix")
+	if err != nil {
+		t.Fatalf("CreateLibrary: %v", err)
+	}
+
+	// One row within TTL, one beyond.
+	insertMissingFile(t, fr, lib.ID, time.Now().Add(-1*time.Hour))  // keep
+	insertMissingFile(t, fr, lib.ID, time.Now().Add(-25*time.Hour)) // delete
+
+	n, err := task.RunMissingPurge(ctx, fr)
+	if err != nil {
+		t.Fatalf("got err %v, want nil", err)
+	}
+	if n != 1 {
+		t.Fatalf("got n=%d, want 1 (only the old row deleted)", n)
+	}
+
+	rows, err := fr.ListByLibrary(ctx, lib.ID)
+	if err != nil {
+		t.Fatalf("ListByLibrary: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1 (new-missing row kept)", len(rows))
+	}
+}
+
+// TestLoopMissingPurge_nilFiles returns immediately when files is nil.
+func TestLoopMissingPurge_nilFiles(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		task.LoopMissingPurge(ctx, nil, 50*time.Millisecond)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Expected: nil files → immediate return.
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("LoopMissingPurge with nil files did not return promptly")
+	}
+}
+
+// TestLoopMissingPurge_cancellation verifies the loop exits cleanly when
+// ctx is cancelled, without leaking goroutines.
+func TestLoopMissingPurge_cancellation(t *testing.T) {
+	fr, lr := newPurgeTestRepo(t)
+	ctx := context.Background()
+	lib, err := lr.CreateLibrary(ctx, "Loop Test", "loop-test", "/tmp/loop-test")
+	if err != nil {
+		t.Fatalf("CreateLibrary: %v", err)
+	}
+	// Insert a row past TTL so the loop has work to do on its ticks.
+	insertMissingFile(t, fr, lib.ID, time.Now().Add(-25*time.Hour))
+
+	loopCtx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		task.LoopMissingPurge(loopCtx, fr, 50*time.Millisecond)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Loop exited after cancellation — clean.
+	case <-time.After(1 * time.Second):
+		t.Fatal("LoopMissingPurge did not exit after context cancellation")
+	}
+}


### PR DESCRIPTION
## Summary

Plan C of 8 — library scan rewritten as walk → diff → ingest, with hash-based rename reattach and a 24-hour TTL for missing files.

### What changed

- **Migration 000026**: \`files.missing_since TIMESTAMPTZ\` + partial index (PG + SQLite parallel).
- **\`internal/scan\`** (new package):
  - \`walker.go\` — streams \`WalkEntry{Location, Size, Mtime, ETag}\` from any \`storage.Storage\`.
  - \`differ.go\` — pure function; classifies walk × DB rows into \`Changeset{Unchanged, Changed, New, Missing}\` using \`(size, second-truncated mtime)\` as the fast-path skip.
  - \`reattach.go\` — hash-based rename detection; when a Changed file's new sha256 matches another row in the same library, swap the canonical row's location and mark the stale row missing.
- **\`FileRepo\`** gains \`MarkMissing\`, \`ClearMissing\`, \`DeleteMissingOlderThan\`, \`ListByLibrary\`, \`UpdateLocation\`.
- **\`task.LibraryScan\`** rewritten as walk + diff + act. Files matching size+mtime skip the re-hash entirely. Reattach preserves \`book_id\` continuity across local renames. \`legacyScan\` fallback for nil-deps cases keeps the queue tests green.
- **\`task.RunMissingPurge\` / \`LoopMissingPurge\`**: hourly sweeper deletes \`files\` rows whose \`missing_since\` is older than 24h. Wired into \`main.go\`.

### Behavior delta

Before: every scan walked the filesystem, called \`BookExistsByPath\` (or \`FileRepo.ExistsByLocation\` after Plan B) per entry, enqueued unseen files. No detection of changed/missing/renamed files.

After: scan loads DB state once, walks the filesystem once, classifies in O(n+m). Files unchanged since last scan skip *all* expensive work. Local renames are detected by hash match and reattached without orphaning the book. Files that disappear are soft-deleted with a 24h grace window.

### Test plan
- [x] \`make ci-local\` green
- [x] \`go test ./...\` — 29 packages, 0 failures
- [x] queue tests with nil deps still pass (legacyScan fallback verified)
- [ ] Manual smoke: rename a file in a library; trigger a scan; confirm \`files.book_id\` is preserved on the renamed row

## Plan
docs/superpowers/plans/2026-04-29-storage-plan-c-scan.md.
Spec: docs/spec/storage.spec.md §5.3 (two-phase scan), §5.1 (content identity).

## Commits (8)
\`\`\`
49030ca docs(plan): two-phase scan + reconciliation (Plan C of 8)
9a8f375 feat(db): add files.missing_since
7c501d3 feat(repo): file missing-since lifecycle + ListByLibrary
9f6a023 feat(scan): walker streams WalkEntry
a6e508a feat(scan): differ classifies walk vs DB
a25feb1 feat(scan): hash-based rename reattach
6c2cfb9 refactor(task): library scan = walk + diff + ingest
84aaaee feat(task): missing-files purge sweeper (24h TTL)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)