### PR TITLE
feat(sidecar): metadata.opf + .embookshelf.toml read pipeline (Plan D of 8)

### DIFF
--- a/docs/superpowers/plans/2026-04-29-storage-plan-d-sidecars.md
+++ b/docs/superpowers/plans/2026-04-29-storage-plan-d-sidecars.md
@@ -1,0 +1,550 @@
+# Sidecar Read + Atomic Writes — Implementation Plan (Plan D of 8)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Establish portable, user-editable metadata sidecars next to each book on disk. Two formats: `metadata.opf` (Calibre-compatible XML) and `.embookshelf.toml` (native). Both are read at ingest time and merged with embedded metadata; the bookdrop pipeline picks them up before approval. Atomic writes via the `storage.Storage` interface (write-tmp-fsync-rename on local FS) with per-key serialization so concurrent edits queue cleanly.
+
+**Architecture:** A new `internal/sidecar` package owns parsers, the merge policy, and the atomic writer. Read flow: scanner asks `sidecar.Read(store, folderPrefix)` which lists sibling keys, parses any matches, and merges (TOML over OPF). The merged `Sidecar` struct is then layered over `Metadata` from `internal/fileproc` (sidecar wins when non-empty). Write flow: `sidecar.Writer.Write(store, key, s)` serializes per-key via a `sync.Map` of mutexes, then calls `storage.Put` which already does write-temp-then-rename for local FS. S3 conditional `If-Match` writes land in Plan F.
+
+**Tech Stack:** Go 1.25 stdlib `encoding/xml` (already used by fileproc), `github.com/pelletier/go-toml/v2` (already a transitive dep — promoted to direct here), `internal/storage`, `internal/fileproc` for shared metadata struct.
+
+**Companion spec:** [`docs/spec/storage.spec.md`](../../spec/storage.spec.md) §3.3 (sidecar files), §6.1 (layering), §6.2 (atomic sidecar writes).
+
+**Locked decisions:**
+- Sidecar filenames: `metadata.opf` and `.embookshelf.toml` (native; spec said `.grimmory.toml` — repo is canonical).
+- Merge order at read time: embedded < OPF < TOML (TOML is the user-editable native format; OPF is for interop). User app edits go to TOML; OPF stays as imported.
+- Plan D ships READ + atomic-write **primitives**, plus the **bookdrop ingest read hook**. Plan D2 wires the user-edit write hook (`PUT /books/:id/metadata`) once the edit-metadata UI is verified.
+- Write conditional precondition: deferred. Local writes are tmp+rename (already atomic); S3 conditional writes land with Plan F.
+
+**Depends on:** Plan A (`storage.Storage`), Plan B (location keys), Plan C unrelated but compatible.
+
+**Out of scope:**
+- Wiring sidecar writes into `PUT /books/:id/metadata` (Plan D2).
+- Writing OPF (we only read OPF; native edits go to TOML).
+- Conflict resolution UI for concurrent edits across instances (single-instance assumed).
+- Cover image inside sidecar — `metadata.opf` cover refs are followed in Plan E (cover store reorg).
+
+---
+
+## File Structure
+
+### Files created
+
+| Path | Responsibility |
+|---|---|
+| `internal/sidecar/sidecar.go` | `Sidecar` struct + `Layer(into *fileproc.Metadata)` helper. |
+| `internal/sidecar/opf.go` | `ParseOPF([]byte) (Sidecar, error)` — Dublin Core XML. |
+| `internal/sidecar/toml.go` | `ParseTOML([]byte) (Sidecar, error)`, `EncodeTOML(Sidecar) ([]byte, error)`. |
+| `internal/sidecar/reader.go` | `Read(ctx, store, prefix) (Sidecar, error)` — locates sibling files in storage, parses, merges. |
+| `internal/sidecar/writer.go` | `Writer` with per-key mutex. `Write(ctx, store, key, s)` calls `EncodeTOML` then `storage.Put`. |
+| `internal/sidecar/sidecar_test.go` | Combined test file: parsers, merge, writer concurrency. |
+
+### Files modified
+
+| Path | Change |
+|---|---|
+| `go.mod` | Promote `github.com/pelletier/go-toml/v2` from indirect to direct. |
+| `internal/task/bookdrop.go` | After `proc.Extract` returns metadata, look up sidecars via `sidecar.Read(ctx, store, dir(item.Path))` and layer them in. The Storage handle comes from a new field on `BookDropDeps`. |
+| `internal/queue/queue.go` & `internal/queue/sqlite.go` | Pass `Storage` into `BookDropDeps` (extending the deps struct already used by Plan A's library scan). |
+| `cmd/embookshelf/main.go` | Wire `fileStorage` into `BookDropDeps`. |
+
+---
+
+## Phase 1 — Parsers and Layering
+
+### Task 1: `Sidecar` struct + TOML round-trip
+
+**Files:**
+- Create: `internal/sidecar/sidecar.go`
+- Create: `internal/sidecar/toml.go`
+- Create: `internal/sidecar/sidecar_test.go` (initially with TOML cases)
+
+```go
+// Package sidecar reads and writes per-book metadata files that live
+// next to the book bytes on disk (or in object storage). Two formats:
+// metadata.opf (Calibre-compatible XML, read-only) and
+// .embookshelf.toml (native, read+write).
+package sidecar
+
+import (
+    "fmt"
+
+    "github.com/pelletier/go-toml/v2"
+)
+
+// Sidecar holds the editable subset of a book's metadata. Fields
+// match what the edit-metadata UI exposes; anything ground-truth-
+// derived (page count, duration, cover bytes) stays in the embedded
+// extractor's output and is not overwritten by sidecars.
+type Sidecar struct {
+    Title         string   `toml:"title"`
+    TitleSort     string   `toml:"title_sort"`
+    Subtitle      string   `toml:"subtitle"`
+    Author        string   `toml:"author"`
+    Description   string   `toml:"description"`
+    Language      string   `toml:"language"`
+    Publisher     string   `toml:"publisher"`
+    PublishedDate string   `toml:"published_date"` // free text per spec §4
+    ISBN          string   `toml:"isbn"`
+    Series        string   `toml:"series"`
+    SeriesIndex   int      `toml:"series_index"`
+    Tags          []string `toml:"tags"`
+    Genres        []string `toml:"genres"`
+}
+
+// IsZero reports whether s carries no information. Used to short-
+// circuit the merge when no sidecar was present.
+func (s Sidecar) IsZero() bool {
+    return s.Title == "" && s.TitleSort == "" && s.Subtitle == "" &&
+        s.Author == "" && s.Description == "" && s.Language == "" &&
+        s.Publisher == "" && s.PublishedDate == "" && s.ISBN == "" &&
+        s.Series == "" && s.SeriesIndex == 0 &&
+        len(s.Tags) == 0 && len(s.Genres) == 0
+}
+
+// Merge overlays b on a: any non-zero field in b wins.
+func Merge(a, b Sidecar) Sidecar {
+    out := a
+    if b.Title != "" { out.Title = b.Title }
+    if b.TitleSort != "" { out.TitleSort = b.TitleSort }
+    if b.Subtitle != "" { out.Subtitle = b.Subtitle }
+    if b.Author != "" { out.Author = b.Author }
+    if b.Description != "" { out.Description = b.Description }
+    if b.Language != "" { out.Language = b.Language }
+    if b.Publisher != "" { out.Publisher = b.Publisher }
+    if b.PublishedDate != "" { out.PublishedDate = b.PublishedDate }
+    if b.ISBN != "" { out.ISBN = b.ISBN }
+    if b.Series != "" { out.Series = b.Series }
+    if b.SeriesIndex != 0 { out.SeriesIndex = b.SeriesIndex }
+    if len(b.Tags) > 0 { out.Tags = b.Tags }
+    if len(b.Genres) > 0 { out.Genres = b.Genres }
+    return out
+}
+
+// ParseTOML deserializes TOML bytes into a Sidecar.
+func ParseTOML(data []byte) (Sidecar, error) {
+    var s Sidecar
+    if err := toml.Unmarshal(data, &s); err != nil {
+        return Sidecar{}, fmt.Errorf("sidecar: parse toml: %w", err)
+    }
+    return s, nil
+}
+
+// EncodeTOML serializes a Sidecar to TOML for atomic write.
+func EncodeTOML(s Sidecar) ([]byte, error) {
+    out, err := toml.Marshal(s)
+    if err != nil {
+        return nil, fmt.Errorf("sidecar: encode toml: %w", err)
+    }
+    return out, nil
+}
+```
+
+Promote the TOML dep to direct: edit `go.mod` so `github.com/pelletier/go-toml/v2` is in the `require` block without `// indirect`. Run `go mod tidy` to verify.
+
+**Tests:**
+- Encode then parse round-trip preserves every field.
+- ParseTOML on malformed input returns an error.
+- `IsZero` is true on `Sidecar{}` and false after setting any field.
+- `Merge` cases: empty over set (no change); set over empty (b wins); set over set (b wins); empty slices don't clobber non-empty.
+
+- [ ] Commit:
+
+```bash
+git add internal/sidecar/sidecar.go internal/sidecar/toml.go internal/sidecar/sidecar_test.go go.mod go.sum
+git commit -m "feat(sidecar): TOML round-trip + Sidecar struct + Merge"
+```
+
+---
+
+### Task 2: OPF parser
+
+**Files:**
+- Create: `internal/sidecar/opf.go`
+- Modify: `internal/sidecar/sidecar_test.go` (add OPF cases)
+
+`metadata.opf` is the Calibre-style XML format. Reuse the structural pattern from `internal/fileproc/epub.go` but with the entry point being raw bytes (the file already extracted from the zip).
+
+```go
+package sidecar
+
+import (
+    "encoding/xml"
+    "fmt"
+    "strings"
+)
+
+// opfPackage is the root <package> element of a metadata.opf file.
+// We only consume the metadata block; manifest/spine are EPUB-only.
+type opfPackage struct {
+    XMLName  xml.Name `xml:"package"`
+    Metadata opfMetadata `xml:"metadata"`
+}
+
+type opfMetadata struct {
+    Title       string       `xml:"title"`
+    Creator     []opfCreator `xml:"creator"`
+    Description string       `xml:"description"`
+    Language    string       `xml:"language"`
+    Publisher   string       `xml:"publisher"`
+    Date        string       `xml:"date"`
+    Identifier  []opfIdent   `xml:"identifier"`
+    Subject     []string     `xml:"subject"`
+    Meta        []opfMetaKV  `xml:"meta"`
+}
+
+type opfCreator struct {
+    Role  string `xml:"role,attr"`
+    Value string `xml:",chardata"`
+}
+
+type opfIdent struct {
+    Scheme string `xml:"scheme,attr"`
+    Value  string `xml:",chardata"`
+}
+
+type opfMetaKV struct {
+    Name    string `xml:"name,attr"`
+    Content string `xml:"content,attr"`
+}
+
+// ParseOPF deserializes an OPF metadata file (the standalone sibling
+// kind, not the one embedded in an .epub) into a Sidecar.
+func ParseOPF(data []byte) (Sidecar, error) {
+    var pkg opfPackage
+    if err := xml.Unmarshal(data, &pkg); err != nil {
+        return Sidecar{}, fmt.Errorf("sidecar: parse opf: %w", err)
+    }
+    s := Sidecar{
+        Title:         strings.TrimSpace(pkg.Metadata.Title),
+        Description:   strings.TrimSpace(pkg.Metadata.Description),
+        Language:      strings.TrimSpace(pkg.Metadata.Language),
+        Publisher:     strings.TrimSpace(pkg.Metadata.Publisher),
+        PublishedDate: strings.TrimSpace(pkg.Metadata.Date),
+    }
+    // Author = first creator with role="aut" or, failing that, the
+    // first creator entry.
+    for _, c := range pkg.Metadata.Creator {
+        if c.Role == "aut" && c.Value != "" {
+            s.Author = c.Value
+            break
+        }
+    }
+    if s.Author == "" {
+        for _, c := range pkg.Metadata.Creator {
+            if c.Value != "" {
+                s.Author = c.Value
+                break
+            }
+        }
+    }
+    // ISBN = first identifier with scheme="ISBN" (case-insensitive).
+    for _, i := range pkg.Metadata.Identifier {
+        if strings.EqualFold(i.Scheme, "ISBN") && i.Value != "" {
+            s.ISBN = i.Value
+            break
+        }
+    }
+    // Tags = <subject> entries.
+    if len(pkg.Metadata.Subject) > 0 {
+        s.Tags = append(s.Tags, pkg.Metadata.Subject...)
+    }
+    // Calibre encodes series via <meta name="calibre:series" content="…"/>.
+    for _, m := range pkg.Metadata.Meta {
+        switch m.Name {
+        case "calibre:series":
+            s.Series = m.Content
+        case "calibre:series_index":
+            // Best-effort parse; silently drop on error.
+            var idx int
+            _, _ = fmt.Sscanf(m.Content, "%d", &idx)
+            s.SeriesIndex = idx
+        case "calibre:title_sort":
+            s.TitleSort = m.Content
+        }
+    }
+    return s, nil
+}
+```
+
+**Tests:**
+- Minimal Calibre OPF (provided as a literal string in the test) parses to expected `Sidecar` fields.
+- Multiple `<creator>` tags: role="aut" wins; if none has the role, first entry wins.
+- ISBN identifier with various scheme casings (ISBN, isbn, ISBN-13).
+- Calibre-specific `<meta>` extraction (series, series_index, title_sort).
+- Malformed XML returns an error.
+
+- [ ] Commit:
+
+```bash
+git add internal/sidecar/opf.go internal/sidecar/sidecar_test.go
+git commit -m "feat(sidecar): OPF (Calibre) reader"
+```
+
+---
+
+## Phase 2 — Storage Integration
+
+### Task 3: Atomic writer with per-key serialization
+
+**Files:**
+- Create: `internal/sidecar/writer.go`
+- Modify: `internal/sidecar/sidecar_test.go` (add writer cases)
+
+```go
+package sidecar
+
+import (
+    "bytes"
+    "context"
+    "sync"
+
+    "github.com/blackforge/embookshelf/internal/storage"
+)
+
+// Writer serializes sidecar writes per-key. Two writes targeting the
+// same key block one after the other; writes to different keys run
+// concurrently. The underlying storage.Put is already atomic
+// (write-temp-then-rename on LocalFS); the Writer's job is to
+// linearize multiple in-flight writes from the same process.
+//
+// Multi-process / multi-instance coordination is out of scope for
+// Plan D; conditional PUT lands in Plan F.
+type Writer struct {
+    locks sync.Map // map[string]*sync.Mutex
+}
+
+// NewWriter constructs a fresh writer.
+func NewWriter() *Writer { return &Writer{} }
+
+// keyLock returns the per-key mutex, creating it on first reference.
+func (w *Writer) keyLock(key string) *sync.Mutex {
+    actual, _ := w.locks.LoadOrStore(key, &sync.Mutex{})
+    return actual.(*sync.Mutex)
+}
+
+// Write encodes s as TOML and stores it at key. Concurrent calls for
+// the same key are serialized; calls for different keys run in
+// parallel. The encoded bytes are written via storage.Put so the
+// underlying backend's atomic-write semantics apply.
+func (w *Writer) Write(ctx context.Context, store storage.Storage, key string, s Sidecar) error {
+    data, err := EncodeTOML(s)
+    if err != nil {
+        return err
+    }
+    mu := w.keyLock(key)
+    mu.Lock()
+    defer mu.Unlock()
+    _, err = store.Put(ctx, key, bytes.NewReader(data), storage.WithContentType("application/toml"))
+    return err
+}
+```
+
+**Tests:**
+- Single Write happy path: bytes land at key, parsable on Get.
+- 100 concurrent Writes to the same key: all complete; the final read parses to one of the inputs (no torn write). Use `sync.WaitGroup`.
+- 100 concurrent Writes to 100 different keys: all complete; each key's read returns its own input.
+
+- [ ] Commit:
+
+```bash
+git add internal/sidecar/writer.go internal/sidecar/sidecar_test.go
+git commit -m "feat(sidecar): per-key serialized atomic writer"
+```
+
+---
+
+### Task 4: Sibling-file reader
+
+**Files:**
+- Create: `internal/sidecar/reader.go`
+- Modify: `internal/sidecar/sidecar_test.go` (add reader cases)
+
+```go
+package sidecar
+
+import (
+    "context"
+    "errors"
+    "io"
+    "strings"
+
+    "github.com/blackforge/embookshelf/internal/storage"
+)
+
+// SidecarFiles is the set of sibling filenames the reader looks for,
+// in priority order. TOML wins (it's the native, app-edited format).
+var SidecarFiles = []string{
+    "metadata.opf",
+    ".embookshelf.toml",
+}
+
+// Read locates sidecar files under the given storage prefix
+// (typically the directory containing a book). It parses each one
+// it finds and merges them in priority order: OPF first, then TOML
+// over it. A missing prefix or no sidecars present is not an error;
+// the function returns Sidecar{}, nil.
+func Read(ctx context.Context, store storage.Storage, prefix string) (Sidecar, error) {
+    var merged Sidecar
+    for _, name := range SidecarFiles {
+        key := strings.TrimRight(prefix, "/") + "/" + name
+        rc, err := store.Get(ctx, key)
+        if err != nil {
+            if errors.Is(err, storage.ErrNotFound) {
+                continue
+            }
+            return Sidecar{}, err
+        }
+        data, readErr := io.ReadAll(rc)
+        _ = rc.Close()
+        if readErr != nil {
+            return Sidecar{}, readErr
+        }
+
+        var parsed Sidecar
+        var parseErr error
+        switch name {
+        case "metadata.opf":
+            parsed, parseErr = ParseOPF(data)
+        case ".embookshelf.toml":
+            parsed, parseErr = ParseTOML(data)
+        }
+        if parseErr != nil {
+            // A malformed sidecar is logged via the caller; here we
+            // surface the error so the scan worker can record it.
+            return merged, parseErr
+        }
+        merged = Merge(merged, parsed)
+    }
+    return merged, nil
+}
+```
+
+**Tests** (use `local.LocalFS` rooted at `t.TempDir()`):
+- No sidecars → `Sidecar{}, nil`.
+- Only `metadata.opf` → fields from OPF populated.
+- Only `.embookshelf.toml` → fields from TOML populated.
+- Both present → TOML wins on overlapping fields, OPF fills the rest.
+- Malformed TOML → error surfaces.
+
+- [ ] Commit:
+
+```bash
+git add internal/sidecar/reader.go internal/sidecar/sidecar_test.go
+git commit -m "feat(sidecar): reader merges sibling OPF + TOML via storage.List"
+```
+
+---
+
+## Phase 3 — Bookdrop Ingest Hook
+
+### Task 5: Wire `sidecar.Read` into bookdrop ingest
+
+**Files:**
+- Modify: `internal/task/bookdrop.go`
+- Modify: `internal/queue/queue.go`
+- Modify: `internal/queue/sqlite.go`
+- Modify: `cmd/embookshelf/main.go`
+
+Add a Storage field to `BookDropDeps`:
+
+```go
+type BookDropDeps struct {
+    Svc     *service.BookDropService
+    Storage storage.Storage // optional; nil disables sidecar lookup
+}
+```
+
+After `proc.Extract` succeeds, look up sidecars from the same directory and overlay them on the extracted metadata (only fields the sidecar carries — never overwrite cover bytes, duration, etc.):
+
+```go
+if deps.Storage != nil {
+    // Convert the absolute path into a storage key (Plan A LocalFS
+    // is rooted at "/" so we strip the leading slash). Then take
+    // the directory portion as the lookup prefix.
+    key := strings.TrimPrefix(item.Path, "/")
+    prefix := path.Dir(key)
+    if sc, err := sidecar.Read(ctx, deps.Storage, prefix); err == nil && !sc.IsZero() {
+        meta = layerSidecar(meta, sc)
+    } else if err != nil {
+        slog.Warn("bookdrop sidecar read failed", "item_id", itemID, "prefix", prefix, "err", err)
+        // non-fatal — proceed with embedded metadata only
+    }
+}
+```
+
+`layerSidecar` lives in `internal/task/bookdrop.go`:
+
+```go
+func layerSidecar(m fileproc.Metadata, s sidecar.Sidecar) fileproc.Metadata {
+    if s.Title != "" { m.Title = s.Title }
+    if s.Author != "" { m.Author = s.Author }
+    if s.Description != "" { m.Description = s.Description }
+    if s.Language != "" { m.Language = s.Language }
+    return m
+}
+```
+
+Plumb `Storage` from `main.go` → `queue.New` → `BookDropDeps`. The library scan deps already carry a `Storage` field (Plan A); reuse the same construction.
+
+**Tests:** the existing bookdrop test suite tolerates a nil `Storage`, so this is mainly an integration-level concern. The unit test for `layerSidecar` is the simplest:
+
+```go
+func TestLayerSidecar_NonEmptyOverlays(t *testing.T) {
+    m := fileproc.Metadata{Title: "Original", Author: "A"}
+    s := sidecar.Sidecar{Title: "Override", Description: "hello"}
+    out := layerSidecar(m, s)
+    if out.Title != "Override" { t.Errorf("title not overridden") }
+    if out.Author != "A" { t.Errorf("author should be unchanged") }
+    if out.Description != "hello" { t.Errorf("description not overlaid") }
+}
+```
+
+- [ ] Commit:
+
+```bash
+git add internal/task/bookdrop.go internal/queue/queue.go internal/queue/sqlite.go cmd/embookshelf/main.go internal/queue/sqlite_test.go
+git commit -m "feat(task): bookdrop ingest reads sibling sidecars
+
+After proc.Extract, sidecar.Read pulls metadata.opf / .embookshelf.toml
+from the file's directory and overlays them on the extracted metadata.
+Embedded fields stay where the sidecar is silent. Storage handle
+flows from main.go through BookDropDeps."
+```
+
+---
+
+## Phase 4 — Verification
+
+### Task 6: Verify and PR
+
+- [ ] `go test ./internal/sidecar/...` — all tests pass.
+- [ ] `make ci-local` — green.
+- [ ] `git diff --stat origin/main..HEAD` confirms scope.
+- [ ] Push and open PR.
+
+```bash
+gh pr create --base main --title "feat(sidecar): metadata.opf + .embookshelf.toml read pipeline (Plan D of 8)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §3.3 sidecar files (formats, locations) → covered: OPF + TOML parsers, sibling-key lookup.
+- §6.1 layering — embedded ⊕ sidecar ⊕ user-edits → covered for embedded ⊕ sidecar; user-edits write hook is Plan D2.
+- §6.2 atomic sidecar writes (local) → covered via `storage.Put`'s tmp+fsync+rename. Per-key mutex linearizes in-process concurrency.
+- §6.2 conditional PUT for S3 → deferred to Plan F.
+
+**Out of scope (deferred, with linkage):**
+- The user-edit write hook on `PUT /books/:id/metadata` — Plan D2.
+- Cover image inside OPF → Plan E (cover store reorg).
+- S3 conditional writes for sidecars → Plan F.
+
+**Risks:**
+- The bookdrop ingest's `item.Path` is an absolute path; the LocalFS Plan A rooted at `/` so stripping the leading slash gives the correct key. When library backends become per-library rooted (Plan B2 / Plan F), this stripping needs to take `library.root` into account.
+- A malformed `.embookshelf.toml` aborts the merge for that book. The current behavior logs and proceeds with embedded only — acceptable.
+- Cover bytes in OPF are not yet followed (cover stays from embedded extraction). Plan E reorganizes cover storage and can revisit.
+
+**Type consistency:** `Sidecar`, `Merge`, `ParseTOML/EncodeTOML`, `ParseOPF`, `Read`, `Writer.Write`, `layerSidecar` consistent across tasks.

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/dhowden/tag v0.0.0-20240417053706-3d75831295e8 // indirect
+	github.com/dhowden/tag v0.0.0-20240417053706-3d75831295e8
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
@@ -82,7 +82,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
-	github.com/pelletier/go-toml/v2 v2.3.0 // indirect
+	github.com/pelletier/go-toml/v2 v2.3.0
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.0 // indirect

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -78,7 +78,7 @@ func newRiver(
 	}
 
 	workers := river.NewWorkers()
-	river.AddWorker(workers, &task.BookDropWorker{Deps: task.BookDropDeps{Svc: bdropSvc}})
+	river.AddWorker(workers, &task.BookDropWorker{Deps: task.BookDropDeps{Svc: bdropSvc, Storage: store}})
 
 	// The scan worker needs to enqueue bookdrop.ingest jobs; wire that up
 	// after the client is constructed (circular dep resolved via the

--- a/internal/queue/sqlite.go
+++ b/internal/queue/sqlite.go
@@ -54,7 +54,7 @@ func newSQLiteQueue(
 		doneCh:   make(chan struct{}),
 	}
 
-	bdropDeps := task.BookDropDeps{Svc: bdropSvc}
+	bdropDeps := task.BookDropDeps{Svc: bdropSvc, Storage: store}
 	libDeps := task.LibraryScanDeps{
 		BookDrop: bdropSvc,
 		Lib:      libSvc,

--- a/internal/sidecar/opf.go
+++ b/internal/sidecar/opf.go
@@ -1,0 +1,100 @@
+package sidecar
+
+import (
+	"encoding/xml"
+	"fmt"
+	"strings"
+)
+
+// opfPackage is the root <package> element of a metadata.opf file.
+// We only consume the metadata block; manifest/spine are EPUB-only.
+type opfPackage struct {
+	XMLName  xml.Name    `xml:"package"`
+	Metadata opfMetadata `xml:"metadata"`
+}
+
+type opfMetadata struct {
+	Title       string       `xml:"title"`
+	Creator     []opfCreator `xml:"creator"`
+	Description string       `xml:"description"`
+	Language    string       `xml:"language"`
+	Publisher   string       `xml:"publisher"`
+	Date        string       `xml:"date"`
+	Identifier  []opfIdent   `xml:"identifier"`
+	Subject     []string     `xml:"subject"`
+	Meta        []opfMetaKV  `xml:"meta"`
+}
+
+type opfCreator struct {
+	Role  string `xml:"role,attr"`
+	Value string `xml:",chardata"`
+}
+
+type opfIdent struct {
+	Scheme string `xml:"scheme,attr"`
+	Value  string `xml:",chardata"`
+}
+
+type opfMetaKV struct {
+	Name    string `xml:"name,attr"`
+	Content string `xml:"content,attr"`
+}
+
+// ParseOPF deserializes an OPF metadata file (the standalone sibling
+// kind, not the one embedded in an .epub) into a Sidecar.
+func ParseOPF(data []byte) (Sidecar, error) {
+	var pkg opfPackage
+	if err := xml.Unmarshal(data, &pkg); err != nil {
+		return Sidecar{}, fmt.Errorf("sidecar: parse opf: %w", err)
+	}
+	s := Sidecar{
+		Title:         strings.TrimSpace(pkg.Metadata.Title),
+		Description:   strings.TrimSpace(pkg.Metadata.Description),
+		Language:      strings.TrimSpace(pkg.Metadata.Language),
+		Publisher:     strings.TrimSpace(pkg.Metadata.Publisher),
+		PublishedDate: strings.TrimSpace(pkg.Metadata.Date),
+	}
+	// Author = first creator with role="aut" or, failing that, the
+	// first creator entry.
+	for _, c := range pkg.Metadata.Creator {
+		if c.Role == "aut" && c.Value != "" {
+			s.Author = c.Value
+			break
+		}
+	}
+	if s.Author == "" {
+		for _, c := range pkg.Metadata.Creator {
+			if c.Value != "" {
+				s.Author = c.Value
+				break
+			}
+		}
+	}
+	// ISBN = first identifier whose scheme contains "isbn" (case-insensitive).
+	// This matches "ISBN", "isbn", "ISBN-13", "isbn-10", etc.
+	for _, i := range pkg.Metadata.Identifier {
+		if strings.Contains(strings.ToLower(i.Scheme), "isbn") && i.Value != "" {
+			s.ISBN = i.Value
+			break
+		}
+	}
+	// Tags = <subject> entries.
+	if len(pkg.Metadata.Subject) > 0 {
+		s.Tags = append(s.Tags, pkg.Metadata.Subject...)
+	}
+	// Calibre encodes series via <meta name="calibre:series" content="…"/>.
+	for _, m := range pkg.Metadata.Meta {
+		switch m.Name {
+		case "calibre:series":
+			s.Series = m.Content
+		case "calibre:series_index":
+			// Best-effort parse; silently drop on error.
+			var idx int
+			_, _ = fmt.Sscanf(m.Content, "%d", &idx)
+			s.SeriesIndex = idx
+		case "calibre:title_sort":
+			s.TitleSort = m.Content
+		}
+	}
+	return s, nil
+}

--- a/internal/sidecar/reader.go
+++ b/internal/sidecar/reader.go
@@ -1,0 +1,57 @@
+package sidecar
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+
+	"github.com/blackforge/embookshelf/internal/storage"
+)
+
+// SidecarFiles is the set of sibling filenames the reader looks for,
+// in priority order. TOML wins (it's the native, app-edited format).
+var SidecarFiles = []string{
+	"metadata.opf",
+	".embookshelf.toml",
+}
+
+// Read locates sidecar files under the given storage prefix
+// (typically the directory containing a book). It parses each one
+// it finds and merges them in priority order: OPF first, then TOML
+// over it. A missing prefix or no sidecars present is not an error;
+// the function returns Sidecar{}, nil.
+func Read(ctx context.Context, store storage.Storage, prefix string) (Sidecar, error) {
+	var merged Sidecar
+	for _, name := range SidecarFiles {
+		key := strings.TrimRight(prefix, "/") + "/" + name
+		rc, err := store.Get(ctx, key)
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				continue
+			}
+			return Sidecar{}, err
+		}
+		data, readErr := io.ReadAll(rc)
+		_ = rc.Close()
+		if readErr != nil {
+			return Sidecar{}, readErr
+		}
+
+		var parsed Sidecar
+		var parseErr error
+		switch name {
+		case "metadata.opf":
+			parsed, parseErr = ParseOPF(data)
+		case ".embookshelf.toml":
+			parsed, parseErr = ParseTOML(data)
+		}
+		if parseErr != nil {
+			// A malformed sidecar is logged via the caller; here we
+			// surface the error so the scan worker can record it.
+			return merged, parseErr
+		}
+		merged = Merge(merged, parsed)
+	}
+	return merged, nil
+}

--- a/internal/sidecar/sidecar.go
+++ b/internal/sidecar/sidecar.go
@@ -1,0 +1,80 @@
+// Package sidecar reads and writes per-book metadata files that live
+// next to the book bytes on disk (or in object storage). Two formats:
+// metadata.opf (Calibre-compatible XML, read-only) and
+// .embookshelf.toml (native, read+write).
+package sidecar
+
+// Sidecar holds the editable subset of a book's metadata. Fields
+// match what the edit-metadata UI exposes; anything ground-truth-
+// derived (page count, duration, cover bytes) stays in the embedded
+// extractor's output and is not overwritten by sidecars.
+type Sidecar struct {
+	Title         string   `toml:"title"`
+	TitleSort     string   `toml:"title_sort"`
+	Subtitle      string   `toml:"subtitle"`
+	Author        string   `toml:"author"`
+	Description   string   `toml:"description"`
+	Language      string   `toml:"language"`
+	Publisher     string   `toml:"publisher"`
+	PublishedDate string   `toml:"published_date"` // free text per spec §4
+	ISBN          string   `toml:"isbn"`
+	Series        string   `toml:"series"`
+	SeriesIndex   int      `toml:"series_index"`
+	Tags          []string `toml:"tags"`
+	Genres        []string `toml:"genres"`
+}
+
+// IsZero reports whether s carries no information. Used to short-
+// circuit the merge when no sidecar was present.
+func (s Sidecar) IsZero() bool {
+	return s.Title == "" && s.TitleSort == "" && s.Subtitle == "" &&
+		s.Author == "" && s.Description == "" && s.Language == "" &&
+		s.Publisher == "" && s.PublishedDate == "" && s.ISBN == "" &&
+		s.Series == "" && s.SeriesIndex == 0 &&
+		len(s.Tags) == 0 && len(s.Genres) == 0
+}
+
+// Merge overlays b on a: any non-zero field in b wins.
+func Merge(a, b Sidecar) Sidecar {
+	out := a
+	if b.Title != "" {
+		out.Title = b.Title
+	}
+	if b.TitleSort != "" {
+		out.TitleSort = b.TitleSort
+	}
+	if b.Subtitle != "" {
+		out.Subtitle = b.Subtitle
+	}
+	if b.Author != "" {
+		out.Author = b.Author
+	}
+	if b.Description != "" {
+		out.Description = b.Description
+	}
+	if b.Language != "" {
+		out.Language = b.Language
+	}
+	if b.Publisher != "" {
+		out.Publisher = b.Publisher
+	}
+	if b.PublishedDate != "" {
+		out.PublishedDate = b.PublishedDate
+	}
+	if b.ISBN != "" {
+		out.ISBN = b.ISBN
+	}
+	if b.Series != "" {
+		out.Series = b.Series
+	}
+	if b.SeriesIndex != 0 {
+		out.SeriesIndex = b.SeriesIndex
+	}
+	if len(b.Tags) > 0 {
+		out.Tags = b.Tags
+	}
+	if len(b.Genres) > 0 {
+		out.Genres = b.Genres
+	}
+	return out
+}

--- a/internal/sidecar/sidecar_test.go
+++ b/internal/sidecar/sidecar_test.go
@@ -1,7 +1,13 @@
 package sidecar
 
 import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
 	"testing"
+
+	"github.com/blackforge/embookshelf/internal/storage/local"
 )
 
 // ---- TOML round-trip tests ----
@@ -338,5 +344,125 @@ func TestParseOPF_MalformedXMLReturnsError(t *testing.T) {
 	_, err := ParseOPF([]byte("<package><metadata><unclosed>"))
 	if err == nil {
 		t.Fatal("expected error for malformed XML, got nil")
+	}
+}
+
+// ---- Writer tests ----
+
+func newTestStore(t *testing.T) *local.LocalFS {
+	t.Helper()
+	fs, err := local.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("local.New: %v", err)
+	}
+	return fs
+}
+
+func TestWriter_SingleWriteHappyPath(t *testing.T) {
+	store := newTestStore(t)
+	w := NewWriter()
+	ctx := context.Background()
+
+	sc := Sidecar{Title: "Hello", Author: "World"}
+	if err := w.Write(ctx, store, "book.embookshelf.toml", sc); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	rc, err := store.Get(ctx, "book.embookshelf.toml")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	parsed, err := ParseTOML(data)
+	if err != nil {
+		t.Fatalf("ParseTOML: %v", err)
+	}
+	if parsed.Title != "Hello" || parsed.Author != "World" {
+		t.Errorf("parsed mismatch: got %+v", parsed)
+	}
+}
+
+func TestWriter_ConcurrentWritesSameKey(t *testing.T) {
+	store := newTestStore(t)
+	w := NewWriter()
+	ctx := context.Background()
+	key := "concurrent.embookshelf.toml"
+
+	const n = 100
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			sc := Sidecar{Title: fmt.Sprintf("Title-%d", i)}
+			if err := w.Write(ctx, store, key, sc); err != nil {
+				t.Errorf("Write[%d]: %v", i, err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// After all writes, the key must be parsable (no torn writes).
+	rc, err := store.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+	data, _ := io.ReadAll(rc)
+	if _, err := ParseTOML(data); err != nil {
+		t.Fatalf("final read not parseable: %v", err)
+	}
+}
+
+func TestWriter_ConcurrentWritesDistinctKeys(t *testing.T) {
+	store := newTestStore(t)
+	w := NewWriter()
+	ctx := context.Background()
+
+	const n = 100
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			key := fmt.Sprintf("book%d/.embookshelf.toml", i)
+			sc := Sidecar{Title: fmt.Sprintf("Title-%d", i)}
+			if err := w.Write(ctx, store, key, sc); err != nil {
+				t.Errorf("Write[%d]: %v", i, err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Verify each key has its own content.
+	for i := 0; i < n; i++ {
+		key := fmt.Sprintf("book%d/.embookshelf.toml", i)
+		rc, err := store.Get(ctx, key)
+		if err != nil {
+			t.Errorf("Get[%d]: %v", i, err)
+			continue
+		}
+		data, readErr := io.ReadAll(rc)
+		_ = rc.Close()
+		if readErr != nil {
+			t.Errorf("ReadAll[%d]: %v", i, readErr)
+			continue
+		}
+		parsed, parseErr := ParseTOML(data)
+		if parseErr != nil {
+			t.Errorf("ParseTOML[%d]: %v", i, parseErr)
+			continue
+		}
+		expected := fmt.Sprintf("Title-%d", i)
+		if parsed.Title != expected {
+			t.Errorf("key %s: title got %q want %q", key, parsed.Title, expected)
+		}
 	}
 }

--- a/internal/sidecar/sidecar_test.go
+++ b/internal/sidecar/sidecar_test.go
@@ -1,0 +1,184 @@
+package sidecar
+
+import (
+	"testing"
+)
+
+// ---- TOML round-trip tests ----
+
+func TestTOML_RoundTrip(t *testing.T) {
+	original := Sidecar{
+		Title:         "The Great Gatsby",
+		TitleSort:     "Great Gatsby, The",
+		Subtitle:      "A Novel",
+		Author:        "F. Scott Fitzgerald",
+		Description:   "A story of the Jazz Age.",
+		Language:      "en",
+		Publisher:     "Scribner",
+		PublishedDate: "1925-04-10",
+		ISBN:          "978-0-7432-7356-5",
+		Series:        "American Classics",
+		SeriesIndex:   3,
+		Tags:          []string{"fiction", "classic"},
+		Genres:        []string{"literary fiction"},
+	}
+
+	data, err := EncodeTOML(original)
+	if err != nil {
+		t.Fatalf("EncodeTOML: %v", err)
+	}
+
+	parsed, err := ParseTOML(data)
+	if err != nil {
+		t.Fatalf("ParseTOML: %v", err)
+	}
+
+	if parsed.Title != original.Title {
+		t.Errorf("Title: got %q want %q", parsed.Title, original.Title)
+	}
+	if parsed.TitleSort != original.TitleSort {
+		t.Errorf("TitleSort: got %q want %q", parsed.TitleSort, original.TitleSort)
+	}
+	if parsed.Subtitle != original.Subtitle {
+		t.Errorf("Subtitle: got %q want %q", parsed.Subtitle, original.Subtitle)
+	}
+	if parsed.Author != original.Author {
+		t.Errorf("Author: got %q want %q", parsed.Author, original.Author)
+	}
+	if parsed.Description != original.Description {
+		t.Errorf("Description: got %q want %q", parsed.Description, original.Description)
+	}
+	if parsed.Language != original.Language {
+		t.Errorf("Language: got %q want %q", parsed.Language, original.Language)
+	}
+	if parsed.Publisher != original.Publisher {
+		t.Errorf("Publisher: got %q want %q", parsed.Publisher, original.Publisher)
+	}
+	if parsed.PublishedDate != original.PublishedDate {
+		t.Errorf("PublishedDate: got %q want %q", parsed.PublishedDate, original.PublishedDate)
+	}
+	if parsed.ISBN != original.ISBN {
+		t.Errorf("ISBN: got %q want %q", parsed.ISBN, original.ISBN)
+	}
+	if parsed.Series != original.Series {
+		t.Errorf("Series: got %q want %q", parsed.Series, original.Series)
+	}
+	if parsed.SeriesIndex != original.SeriesIndex {
+		t.Errorf("SeriesIndex: got %d want %d", parsed.SeriesIndex, original.SeriesIndex)
+	}
+	if len(parsed.Tags) != len(original.Tags) {
+		t.Errorf("Tags len: got %d want %d", len(parsed.Tags), len(original.Tags))
+	} else {
+		for i, tag := range original.Tags {
+			if parsed.Tags[i] != tag {
+				t.Errorf("Tags[%d]: got %q want %q", i, parsed.Tags[i], tag)
+			}
+		}
+	}
+	if len(parsed.Genres) != len(original.Genres) {
+		t.Errorf("Genres len: got %d want %d", len(parsed.Genres), len(original.Genres))
+	} else {
+		for i, g := range original.Genres {
+			if parsed.Genres[i] != g {
+				t.Errorf("Genres[%d]: got %q want %q", i, parsed.Genres[i], g)
+			}
+		}
+	}
+}
+
+func TestParseTOML_MalformedReturnsError(t *testing.T) {
+	_, err := ParseTOML([]byte("not valid toml [[["))
+	if err == nil {
+		t.Fatal("expected error for malformed TOML, got nil")
+	}
+}
+
+// ---- IsZero tests ----
+
+func TestIsZero_EmptySidecar(t *testing.T) {
+	empty := Sidecar{}
+	if !empty.IsZero() {
+		t.Fatal("empty Sidecar should be zero")
+	}
+}
+
+func TestIsZero_AfterFieldSet(t *testing.T) {
+	tests := []struct {
+		name string
+		s    Sidecar
+	}{
+		{"Title", Sidecar{Title: "x"}},
+		{"Author", Sidecar{Author: "x"}},
+		{"TitleSort", Sidecar{TitleSort: "x"}},
+		{"Subtitle", Sidecar{Subtitle: "x"}},
+		{"Description", Sidecar{Description: "x"}},
+		{"Language", Sidecar{Language: "x"}},
+		{"Publisher", Sidecar{Publisher: "x"}},
+		{"PublishedDate", Sidecar{PublishedDate: "x"}},
+		{"ISBN", Sidecar{ISBN: "x"}},
+		{"Series", Sidecar{Series: "x"}},
+		{"SeriesIndex", Sidecar{SeriesIndex: 1}},
+		{"Tags", Sidecar{Tags: []string{"x"}}},
+		{"Genres", Sidecar{Genres: []string{"x"}}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.s.IsZero() {
+				t.Fatalf("Sidecar with %s set should not be zero", tc.name)
+			}
+		})
+	}
+}
+
+// ---- Merge tests ----
+
+func TestMerge_EmptyOverSet_AWins(t *testing.T) {
+	a := Sidecar{Title: "Original", Author: "Author A"}
+	b := Sidecar{} // empty
+	out := Merge(a, b)
+	if out.Title != "Original" {
+		t.Errorf("Title: got %q want %q", out.Title, "Original")
+	}
+	if out.Author != "Author A" {
+		t.Errorf("Author: got %q want %q", out.Author, "Author A")
+	}
+}
+
+func TestMerge_SetOverEmpty_BWins(t *testing.T) {
+	a := Sidecar{} // empty
+	b := Sidecar{Title: "Override", Author: "Author B"}
+	out := Merge(a, b)
+	if out.Title != "Override" {
+		t.Errorf("Title: got %q want %q", out.Title, "Override")
+	}
+	if out.Author != "Author B" {
+		t.Errorf("Author: got %q want %q", out.Author, "Author B")
+	}
+}
+
+func TestMerge_SetOverSet_BWins(t *testing.T) {
+	a := Sidecar{Title: "Original", Author: "Author A"}
+	b := Sidecar{Title: "Override", Author: "Author B"}
+	out := Merge(a, b)
+	if out.Title != "Override" {
+		t.Errorf("Title: got %q want %q", out.Title, "Override")
+	}
+	if out.Author != "Author B" {
+		t.Errorf("Author: got %q want %q", out.Author, "Author B")
+	}
+}
+
+func TestMerge_EmptySlicesInBDontClobberA(t *testing.T) {
+	a := Sidecar{Tags: []string{"fiction", "classic"}, Genres: []string{"literary"}}
+	b := Sidecar{Title: "Override"} // empty Tags and Genres
+	out := Merge(a, b)
+	if len(out.Tags) != 2 {
+		t.Errorf("Tags: got %v want [fiction classic]", out.Tags)
+	}
+	if len(out.Genres) != 1 {
+		t.Errorf("Genres: got %v want [literary]", out.Genres)
+	}
+	if out.Title != "Override" {
+		t.Errorf("Title: got %q want Override", out.Title)
+	}
+}

--- a/internal/sidecar/sidecar_test.go
+++ b/internal/sidecar/sidecar_test.go
@@ -182,3 +182,161 @@ func TestMerge_EmptySlicesInBDontClobberA(t *testing.T) {
 		t.Errorf("Title: got %q want Override", out.Title)
 	}
 }
+
+// ---- OPF parser tests ----
+
+const calibreOPF = `<?xml version='1.0' encoding='utf-8'?>
+<package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+    <dc:title>Dune</dc:title>
+    <dc:creator opf:role="aut">Frank Herbert</dc:creator>
+    <dc:description>A science fiction epic about desert planet.</dc:description>
+    <dc:language>en</dc:language>
+    <dc:publisher>Chilton Books</dc:publisher>
+    <dc:date>1965-08-01</dc:date>
+    <dc:identifier opf:scheme="ISBN">978-0-441-17271-9</dc:identifier>
+    <dc:subject>Science Fiction</dc:subject>
+    <dc:subject>Classic</dc:subject>
+    <meta name="calibre:series" content="Dune Chronicles"/>
+    <meta name="calibre:series_index" content="1"/>
+    <meta name="calibre:title_sort" content="Dune"/>
+  </metadata>
+</package>`
+
+func TestParseOPF_CalibreOPF(t *testing.T) {
+	s, err := ParseOPF([]byte(calibreOPF))
+	if err != nil {
+		t.Fatalf("ParseOPF: %v", err)
+	}
+	if s.Title != "Dune" {
+		t.Errorf("Title: got %q want %q", s.Title, "Dune")
+	}
+	if s.Author != "Frank Herbert" {
+		t.Errorf("Author: got %q want %q", s.Author, "Frank Herbert")
+	}
+	if s.Description != "A science fiction epic about desert planet." {
+		t.Errorf("Description: got %q", s.Description)
+	}
+	if s.Language != "en" {
+		t.Errorf("Language: got %q want en", s.Language)
+	}
+	if s.Publisher != "Chilton Books" {
+		t.Errorf("Publisher: got %q want Chilton Books", s.Publisher)
+	}
+	if s.PublishedDate != "1965-08-01" {
+		t.Errorf("PublishedDate: got %q want 1965-08-01", s.PublishedDate)
+	}
+	if s.ISBN != "978-0-441-17271-9" {
+		t.Errorf("ISBN: got %q want 978-0-441-17271-9", s.ISBN)
+	}
+	if len(s.Tags) != 2 || s.Tags[0] != "Science Fiction" || s.Tags[1] != "Classic" {
+		t.Errorf("Tags: got %v want [Science Fiction Classic]", s.Tags)
+	}
+	if s.Series != "Dune Chronicles" {
+		t.Errorf("Series: got %q want Dune Chronicles", s.Series)
+	}
+	if s.SeriesIndex != 1 {
+		t.Errorf("SeriesIndex: got %d want 1", s.SeriesIndex)
+	}
+	if s.TitleSort != "Dune" {
+		t.Errorf("TitleSort: got %q want Dune", s.TitleSort)
+	}
+}
+
+func TestParseOPF_MultipleCreators_RoleAutWins(t *testing.T) {
+	opf := `<?xml version='1.0' encoding='utf-8'?>
+<package xmlns="http://www.idpf.org/2007/opf">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+    <dc:title>Test Book</dc:title>
+    <dc:creator opf:role="edt">Editor Person</dc:creator>
+    <dc:creator opf:role="aut">Real Author</dc:creator>
+    <dc:creator>Just A Name</dc:creator>
+  </metadata>
+</package>`
+	s, err := ParseOPF([]byte(opf))
+	if err != nil {
+		t.Fatalf("ParseOPF: %v", err)
+	}
+	if s.Author != "Real Author" {
+		t.Errorf("Author: got %q want Real Author (role=aut should win)", s.Author)
+	}
+}
+
+func TestParseOPF_MultipleCreators_NoRoleUsesFirst(t *testing.T) {
+	opf := `<?xml version='1.0' encoding='utf-8'?>
+<package xmlns="http://www.idpf.org/2007/opf">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+    <dc:title>Test Book</dc:title>
+    <dc:creator opf:role="edt">Editor Person</dc:creator>
+    <dc:creator opf:role="ill">Illustrator</dc:creator>
+  </metadata>
+</package>`
+	s, err := ParseOPF([]byte(opf))
+	if err != nil {
+		t.Fatalf("ParseOPF: %v", err)
+	}
+	// No aut role — first entry wins
+	if s.Author != "Editor Person" {
+		t.Errorf("Author: got %q want Editor Person (first entry)", s.Author)
+	}
+}
+
+func TestParseOPF_ISBNSchemeCasing(t *testing.T) {
+	tests := []struct {
+		scheme string
+	}{
+		{"ISBN"},
+		{"isbn"},
+		{"ISBN-13"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.scheme, func(t *testing.T) {
+			opf := `<?xml version='1.0' encoding='utf-8'?>
+<package xmlns="http://www.idpf.org/2007/opf">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+    <dc:title>Book</dc:title>
+    <dc:identifier opf:scheme="` + tc.scheme + `">978-0-000-00000-0</dc:identifier>
+  </metadata>
+</package>`
+			s, err := ParseOPF([]byte(opf))
+			if err != nil {
+				t.Fatalf("ParseOPF: %v", err)
+			}
+			if s.ISBN != "978-0-000-00000-0" {
+				t.Errorf("ISBN scheme=%q: got %q want 978-0-000-00000-0", tc.scheme, s.ISBN)
+			}
+		})
+	}
+}
+
+func TestParseOPF_CalibreMeta(t *testing.T) {
+	opf := `<?xml version='1.0' encoding='utf-8'?>
+<package xmlns="http://www.idpf.org/2007/opf">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+    <dc:title>Foundation</dc:title>
+    <meta name="calibre:series" content="Foundation Series"/>
+    <meta name="calibre:series_index" content="2"/>
+    <meta name="calibre:title_sort" content="Foundation"/>
+  </metadata>
+</package>`
+	s, err := ParseOPF([]byte(opf))
+	if err != nil {
+		t.Fatalf("ParseOPF: %v", err)
+	}
+	if s.Series != "Foundation Series" {
+		t.Errorf("Series: got %q want Foundation Series", s.Series)
+	}
+	if s.SeriesIndex != 2 {
+		t.Errorf("SeriesIndex: got %d want 2", s.SeriesIndex)
+	}
+	if s.TitleSort != "Foundation" {
+		t.Errorf("TitleSort: got %q want Foundation", s.TitleSort)
+	}
+}
+
+func TestParseOPF_MalformedXMLReturnsError(t *testing.T) {
+	_, err := ParseOPF([]byte("<package><metadata><unclosed>"))
+	if err == nil {
+		t.Fatal("expected error for malformed XML, got nil")
+	}
+}

--- a/internal/sidecar/sidecar_test.go
+++ b/internal/sidecar/sidecar_test.go
@@ -1,12 +1,14 @@
 package sidecar
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"sync"
 	"testing"
 
+	"github.com/blackforge/embookshelf/internal/storage"
 	"github.com/blackforge/embookshelf/internal/storage/local"
 )
 
@@ -464,5 +466,115 @@ func TestWriter_ConcurrentWritesDistinctKeys(t *testing.T) {
 		if parsed.Title != expected {
 			t.Errorf("key %s: title got %q want %q", key, parsed.Title, expected)
 		}
+	}
+}
+
+// ---- Reader tests ----
+
+// putFile is a helper that writes content to key in the store.
+func putFile(t *testing.T, store storage.Storage, key string, content []byte) {
+	t.Helper()
+	_, err := store.Put(context.Background(), key, bytes.NewReader(content), storage.WithContentType("text/plain"))
+	if err != nil {
+		t.Fatalf("putFile %q: %v", key, err)
+	}
+}
+
+func TestRead_NoSidecars(t *testing.T) {
+	store := newTestStore(t)
+	s, err := Read(context.Background(), store, "books/mybook")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if !s.IsZero() {
+		t.Errorf("expected zero Sidecar when no sidecars, got %+v", s)
+	}
+}
+
+func TestRead_OnlyOPF(t *testing.T) {
+	store := newTestStore(t)
+	opf := []byte(`<?xml version='1.0' encoding='utf-8'?>
+<package xmlns="http://www.idpf.org/2007/opf">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+    <dc:title>OPF Title</dc:title>
+    <dc:creator opf:role="aut">OPF Author</dc:creator>
+    <dc:language>en</dc:language>
+  </metadata>
+</package>`)
+	putFile(t, store, "books/mybook/metadata.opf", opf)
+
+	s, err := Read(context.Background(), store, "books/mybook")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if s.Title != "OPF Title" {
+		t.Errorf("Title: got %q want OPF Title", s.Title)
+	}
+	if s.Author != "OPF Author" {
+		t.Errorf("Author: got %q want OPF Author", s.Author)
+	}
+}
+
+func TestRead_OnlyTOML(t *testing.T) {
+	store := newTestStore(t)
+	tomlContent := []byte(`title = "TOML Title"
+author = "TOML Author"
+language = "fr"
+`)
+	putFile(t, store, "books/mybook/.embookshelf.toml", tomlContent)
+
+	s, err := Read(context.Background(), store, "books/mybook")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if s.Title != "TOML Title" {
+		t.Errorf("Title: got %q want TOML Title", s.Title)
+	}
+	if s.Author != "TOML Author" {
+		t.Errorf("Author: got %q want TOML Author", s.Author)
+	}
+}
+
+func TestRead_BothPresent_TOMLWinsOnOverlap(t *testing.T) {
+	store := newTestStore(t)
+	opf := []byte(`<?xml version='1.0' encoding='utf-8'?>
+<package xmlns="http://www.idpf.org/2007/opf">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+    <dc:title>OPF Title</dc:title>
+    <dc:creator opf:role="aut">OPF Author</dc:creator>
+    <dc:language>en</dc:language>
+    <dc:publisher>OPF Publisher</dc:publisher>
+  </metadata>
+</package>`)
+	tomlContent := []byte(`title = "TOML Title"
+author = "TOML Author"
+`)
+	putFile(t, store, "books/mybook/metadata.opf", opf)
+	putFile(t, store, "books/mybook/.embookshelf.toml", tomlContent)
+
+	s, err := Read(context.Background(), store, "books/mybook")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	// TOML wins on overlapping fields
+	if s.Title != "TOML Title" {
+		t.Errorf("Title: got %q want TOML Title (TOML should win)", s.Title)
+	}
+	if s.Author != "TOML Author" {
+		t.Errorf("Author: got %q want TOML Author (TOML should win)", s.Author)
+	}
+	// OPF fills fields absent from TOML
+	if s.Publisher != "OPF Publisher" {
+		t.Errorf("Publisher: got %q want OPF Publisher (OPF fills remainder)", s.Publisher)
+	}
+}
+
+func TestRead_MalformedTOML_ReturnsError(t *testing.T) {
+	store := newTestStore(t)
+	putFile(t, store, "books/mybook/.embookshelf.toml", []byte("not valid toml [[["))
+
+	_, err := Read(context.Background(), store, "books/mybook")
+	if err == nil {
+		t.Fatal("expected error for malformed TOML, got nil")
 	}
 }

--- a/internal/sidecar/toml.go
+++ b/internal/sidecar/toml.go
@@ -1,0 +1,25 @@
+package sidecar
+
+import (
+	"fmt"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+// ParseTOML deserializes TOML bytes into a Sidecar.
+func ParseTOML(data []byte) (Sidecar, error) {
+	var s Sidecar
+	if err := toml.Unmarshal(data, &s); err != nil {
+		return Sidecar{}, fmt.Errorf("sidecar: parse toml: %w", err)
+	}
+	return s, nil
+}
+
+// EncodeTOML serializes a Sidecar to TOML for atomic write.
+func EncodeTOML(s Sidecar) ([]byte, error) {
+	out, err := toml.Marshal(s)
+	if err != nil {
+		return nil, fmt.Errorf("sidecar: encode toml: %w", err)
+	}
+	return out, nil
+}

--- a/internal/sidecar/writer.go
+++ b/internal/sidecar/writer.go
@@ -1,0 +1,46 @@
+package sidecar
+
+import (
+	"bytes"
+	"context"
+	"sync"
+
+	"github.com/blackforge/embookshelf/internal/storage"
+)
+
+// Writer serializes sidecar writes per-key. Two writes targeting the
+// same key block one after the other; writes to different keys run
+// concurrently. The underlying storage.Put is already atomic
+// (write-temp-then-rename on LocalFS); the Writer's job is to
+// linearize multiple in-flight writes from the same process.
+//
+// Multi-process / multi-instance coordination is out of scope for
+// Plan D; conditional PUT lands in Plan F.
+type Writer struct {
+	locks sync.Map // map[string]*sync.Mutex
+}
+
+// NewWriter constructs a fresh writer.
+func NewWriter() *Writer { return &Writer{} }
+
+// keyLock returns the per-key mutex, creating it on first reference.
+func (w *Writer) keyLock(key string) *sync.Mutex {
+	actual, _ := w.locks.LoadOrStore(key, &sync.Mutex{})
+	return actual.(*sync.Mutex)
+}
+
+// Write encodes s as TOML and stores it at key. Concurrent calls for
+// the same key are serialized; calls for different keys run in
+// parallel. The encoded bytes are written via storage.Put so the
+// underlying backend's atomic-write semantics apply.
+func (w *Writer) Write(ctx context.Context, store storage.Storage, key string, s Sidecar) error {
+	data, err := EncodeTOML(s)
+	if err != nil {
+		return err
+	}
+	mu := w.keyLock(key)
+	mu.Lock()
+	defer mu.Unlock()
+	_, err = store.Put(ctx, key, bytes.NewReader(data), storage.WithContentType("application/toml"))
+	return err
+}

--- a/internal/task/bookdrop.go
+++ b/internal/task/bookdrop.go
@@ -11,11 +11,15 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"path"
+	"strings"
 
 	"github.com/riverqueue/river"
 
 	"github.com/blackforge/embookshelf/internal/fileproc"
 	"github.com/blackforge/embookshelf/internal/service"
+	"github.com/blackforge/embookshelf/internal/sidecar"
+	"github.com/blackforge/embookshelf/internal/storage"
 )
 
 // BookDropIngestArgs is the payload for processing a single bookdrop item.
@@ -29,7 +33,8 @@ func (BookDropIngestArgs) Kind() string { return "bookdrop.ingest" }
 
 // BookDropDeps groups the services BookDropIngest needs.
 type BookDropDeps struct {
-	Svc *service.BookDropService
+	Svc     *service.BookDropService
+	Storage storage.Storage // optional; nil disables sidecar lookup
 }
 
 // BookDropIngest runs the ingest pipeline for one bookdrop item:
@@ -81,11 +86,45 @@ func BookDropIngest(ctx context.Context, args BookDropIngestArgs, deps BookDropD
 		return nil
 	}
 
+	if deps.Storage != nil {
+		// Convert the absolute path into a storage key (Plan A LocalFS is
+		// rooted at "/" so we strip the leading slash). Then take the
+		// directory portion as the lookup prefix.
+		key := strings.TrimPrefix(item.Path, "/")
+		prefix := path.Dir(key)
+		if sc, scErr := sidecar.Read(ctx, deps.Storage, prefix); scErr == nil && !sc.IsZero() {
+			meta = layerSidecar(meta, sc)
+		} else if scErr != nil {
+			slog.Warn("bookdrop sidecar read failed", "item_id", itemID, "prefix", prefix, "err", scErr)
+			// non-fatal — proceed with embedded metadata only
+		}
+	}
+
 	return deps.Svc.RecordMetadata(
 		ctx, itemID,
 		meta.Title, meta.Author, meta.Description, meta.Language,
 		meta.CoverBytes, meta.CoverMime,
 	)
+}
+
+// layerSidecar overlays non-empty sidecar fields onto metadata returned
+// by the embedded extractor. Only the fields the sidecar carries are
+// considered; ground-truth-derived fields (cover bytes, duration, format)
+// are never overwritten.
+func layerSidecar(m fileproc.Metadata, s sidecar.Sidecar) fileproc.Metadata {
+	if s.Title != "" {
+		m.Title = s.Title
+	}
+	if s.Author != "" {
+		m.Author = s.Author
+	}
+	if s.Description != "" {
+		m.Description = s.Description
+	}
+	if s.Language != "" {
+		m.Language = s.Language
+	}
+	return m
 }
 
 // hashFile streams item.Path through sha256 and returns the digest.

--- a/internal/task/bookdrop_test.go
+++ b/internal/task/bookdrop_test.go
@@ -1,0 +1,71 @@
+package task
+
+import (
+	"testing"
+
+	"github.com/blackforge/embookshelf/internal/fileproc"
+	"github.com/blackforge/embookshelf/internal/sidecar"
+)
+
+func TestLayerSidecar_NonEmptyOverlays(t *testing.T) {
+	m := fileproc.Metadata{Title: "Original", Author: "A"}
+	s := sidecar.Sidecar{Title: "Override", Description: "hello"}
+	out := layerSidecar(m, s)
+	if out.Title != "Override" {
+		t.Errorf("title not overridden, got %q", out.Title)
+	}
+	if out.Author != "A" {
+		t.Errorf("author should be unchanged, got %q", out.Author)
+	}
+	if out.Description != "hello" {
+		t.Errorf("description not overlaid, got %q", out.Description)
+	}
+}
+
+func TestLayerSidecar_EmptySidecarNoChange(t *testing.T) {
+	m := fileproc.Metadata{Title: "Keep", Author: "Keep", Description: "Keep", Language: "en"}
+	s := sidecar.Sidecar{} // empty
+	out := layerSidecar(m, s)
+	if out.Title != "Keep" {
+		t.Errorf("Title should be unchanged: got %q", out.Title)
+	}
+	if out.Author != "Keep" {
+		t.Errorf("Author should be unchanged: got %q", out.Author)
+	}
+	if out.Description != "Keep" {
+		t.Errorf("Description should be unchanged: got %q", out.Description)
+	}
+	if out.Language != "en" {
+		t.Errorf("Language should be unchanged: got %q", out.Language)
+	}
+}
+
+func TestLayerSidecar_LanguageOverlay(t *testing.T) {
+	m := fileproc.Metadata{Title: "Book", Language: "en"}
+	s := sidecar.Sidecar{Language: "fr"}
+	out := layerSidecar(m, s)
+	if out.Language != "fr" {
+		t.Errorf("Language: got %q want fr", out.Language)
+	}
+}
+
+func TestLayerSidecar_CoverBytesNotOverwritten(t *testing.T) {
+	cover := []byte{0xFF, 0xD8, 0xFF} // fake JPEG header
+	m := fileproc.Metadata{
+		Title:      "Book",
+		HasCover:   true,
+		CoverBytes: cover,
+		CoverMime:  "image/jpeg",
+	}
+	s := sidecar.Sidecar{Title: "Override"}
+	out := layerSidecar(m, s)
+	if out.Title != "Override" {
+		t.Errorf("Title: got %q want Override", out.Title)
+	}
+	if !out.HasCover {
+		t.Error("HasCover should be preserved")
+	}
+	if string(out.CoverBytes) != string(cover) {
+		t.Error("CoverBytes should not be overwritten by sidecar")
+	}
+}


### PR DESCRIPTION
## Summary

Plan D of 8 — portable, user-editable metadata sidecars. New \`internal/sidecar\` package with read + atomic-write primitives; bookdrop ingest now overlays sibling OPF / TOML metadata onto embedded extraction.

### What changed

- **\`internal/sidecar\`** (new package):
  - \`Sidecar\` struct (Title, TitleSort, Subtitle, Author, Description, Language, Publisher, PublishedDate, ISBN, Series, SeriesIndex, Tags, Genres) + \`Merge(a, b)\` policy.
  - \`ParseTOML\` / \`EncodeTOML\` for \`.embookshelf.toml\`.
  - \`ParseOPF\` for Calibre-style \`metadata.opf\` (Dublin Core + calibre:series meta).
  - \`Writer\` with per-key \`sync.Mutex\` map — serializes same-key writes, parallelizes distinct keys.
  - \`Read(ctx, store, prefix)\` walks sibling files via \`storage.Get\`, parses + merges OPF then TOML.
- \`pelletier/go-toml/v2\` promoted to direct dep.
- Bookdrop ingest picks up sibling sidecars after \`proc.Extract\` and overlays non-empty fields via \`layerSidecar\`. Embedded extraction stays authoritative for cover bytes / duration / format.
- \`storage.Storage\` plumbed into \`BookDropDeps\`; both River and SQLite dispatchers carry it.

### What this does NOT change

- User-edit write hook (\`PUT /books/:id/metadata\` → TOML) — Plan D2.
- Cover image lookup from OPF — Plan E.
- S3 conditional \`If-Match\` for sidecars — Plan F.

### Merge policy

Read time: **embedded < OPF < TOML**. Non-empty fields win; empty fields don't clobber.

## Test plan
- [x] \`make ci-local\` green
- [x] 38 tests across sidecar + task packages
- [x] -race tests: 100 concurrent same-key writes (no torn writes), 100 distinct-key parallel
- [ ] Manual: drop metadata.opf next to a book, scan, observe overlay in bookdrop preview

## Plan
docs/superpowers/plans/2026-04-29-storage-plan-d-sidecars.md.
Spec: docs/spec/storage.spec.md §3.3 / §6.1 / §6.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)