### PR TITLE
fix(storageloader): resolve relative local backend root via filepath.Abs

### DIFF
--- a/internal/storageloader/loader.go
+++ b/internal/storageloader/loader.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 
 	"github.com/blackforge/embookshelf/internal/config"
 	"github.com/blackforge/embookshelf/internal/model"
@@ -80,6 +81,18 @@ func buildBackend(ctx context.Context, row model.StorageBackend) (storage.Storag
 		root, ok := row.Config["root"].(string)
 		if !ok || root == "" {
 			return nil, fmt.Errorf("missing or invalid config.root")
+		}
+		// Pre-storage_v2 libraries could be configured with relative
+		// paths (e.g. "./data/main"). The Plan-B backfill copies that
+		// value verbatim into storage_backends.config.root, but
+		// local.New requires absolute paths. Resolve here against the
+		// process cwd so an upgrade doesn't refuse to boot.
+		if !filepath.IsAbs(root) {
+			abs, err := filepath.Abs(root)
+			if err != nil {
+				return nil, fmt.Errorf("resolve root %q: %w", root, err)
+			}
+			root = abs
 		}
 		ls, err := local.New(root)
 		if err != nil {

--- a/internal/storageloader/loader_test.go
+++ b/internal/storageloader/loader_test.go
@@ -109,3 +109,27 @@ func TestLoadStorageBackends_SQLiteWithS3Errors(t *testing.T) {
 	}
 	t.Logf("got expected error (SQLite+S3 rejected): %v", err)
 }
+
+// TestLoadStorageBackends_RelativeLocalRoot verifies that a local backend
+// stored with a relative root (a pre-storage_v2 library config copied
+// verbatim by the Plan-B backfill) resolves to absolute via filepath.Abs
+// rather than failing the local.New "must be absolute" check. Regression
+// guard for the boot-time error reported by users upgrading from older
+// installs whose libraries.path was "./data/main" or similar.
+func TestLoadStorageBackends_RelativeLocalRoot(t *testing.T) {
+	t.Setenv("REPOTEST_DIALECT", "sqlite")
+	d := repotest.New(t)
+	backendRepo := repo.NewStorageBackendRepo(d)
+
+	if _, err := backendRepo.Create(context.Background(), "local", map[string]any{"root": "./data/main"}); err != nil {
+		t.Fatalf("create backend row with relative root: %v", err)
+	}
+
+	resolver, err := storageloader.LoadStorageBackends(context.Background(), backendRepo, config.DialectSQLite)
+	if err != nil {
+		t.Fatalf("LoadStorageBackends: %v", err)
+	}
+	if resolver == nil {
+		t.Fatal("expected non-nil resolver")
+	}
+}


### PR DESCRIPTION
## Summary

Boot-time fix for users upgrading from pre-storage_v2 installs whose libraries were configured with relative paths.

### Symptom

\`\`\`
storage_v2 backfill complete  backends=1 libraries_wired=1 ...
ERROR storage backends err=\"storage_backends/{uuid} (local): local: root must be absolute, got \\\"./data/main\\\"\"
\`\`\`

### Cause

\`local.New\` enforces absolute roots. The Plan-B backfill copies \`libraries.path\` verbatim into \`storage_backends.config.root\`. Pre-storage_v2 the path could be relative (e.g. \`./data/main\`), and the file handler called \`c.File(absPath)\` after \`filepath.Abs(book.Path)\` — relative-cwd was the implicit contract. The new \`LoadStorageBackends\` path didn't honor that.

### Fix

In \`storageloader.buildBackend\` for the \`local\` case: if \`config.root\` isn't absolute, resolve it via \`filepath.Abs\` against the process cwd before passing to \`local.New\`. Matches the implicit pre-storage_v2 behavior; one-line guard plus a regression test.

### What this does NOT fix

The library scan worker still uses \`lib.Path\` (relative) as the prefix to \`store.List\`, which on a per-library-rooted backend produces a double-prefixed path and finds 0 files. That's a Plan F cutover loose end — the scan should pass an empty prefix when the backend is rooted at the library. Tracked separately; this PR unblocks boot only.

## Test plan
- [x] New \`TestLoadStorageBackends_RelativeLocalRoot\` regression test
- [x] \`go test ./internal/storageloader/...\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)