### PR TITLE
fix(storageloader): root LocalFS at "/" regardless of config.root

### DIFF
--- a/internal/storageloader/loader.go
+++ b/internal/storageloader/loader.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path/filepath"
 
 	"github.com/blackforge/embookshelf/internal/config"
 	"github.com/blackforge/embookshelf/internal/model"
@@ -78,23 +77,17 @@ func LoadStorageBackends(ctx context.Context, backendRepo *repo.StorageBackendRe
 func buildBackend(ctx context.Context, row model.StorageBackend) (storage.Storage, error) {
 	switch row.Kind {
 	case "local":
-		root, ok := row.Config["root"].(string)
-		if !ok || root == "" {
-			return nil, fmt.Errorf("missing or invalid config.root")
-		}
-		// Pre-storage_v2 libraries could be configured with relative
-		// paths (e.g. "./data/main"). The Plan-B backfill copies that
-		// value verbatim into storage_backends.config.root, but
-		// local.New requires absolute paths. Resolve here against the
-		// process cwd so an upgrade doesn't refuse to boot.
-		if !filepath.IsAbs(root) {
-			abs, err := filepath.Abs(root)
-			if err != nil {
-				return nil, fmt.Errorf("resolve root %q: %w", root, err)
-			}
-			root = abs
-		}
-		ls, err := local.New(root)
+		// LocalFS is always rooted at "/". The library's actual root
+		// path lives in libraries.root; callers (scan worker, bookdrop
+		// ingest, file handler) pass absolute paths as keys, which the
+		// "/"-rooted LocalFS resolves correctly. Per-library rooting
+		// for LocalFS was an over-application of Plan F's S3 bucket
+		// model — S3 needs per-bucket-prefix rooting, but the local
+		// filesystem doesn't, and rooting per-library broke every
+		// caller that passes absolute paths.
+		//
+		// row.Config["root"] is informational only for the local kind.
+		ls, err := local.New("/")
 		if err != nil {
 			return nil, err
 		}

--- a/internal/storageloader/loader_test.go
+++ b/internal/storageloader/loader_test.go
@@ -58,24 +58,43 @@ func TestLoadStorageBackends_LocalRow(t *testing.T) {
 	}
 }
 
-// TestLoadStorageBackends_LocalMissingRootErrors verifies that a local backend
-// row with a missing config.root field returns an error.
-func TestLoadStorageBackends_LocalMissingRootErrors(t *testing.T) {
+// TestLoadStorageBackends_LocalIgnoresConfigRoot verifies that a local
+// backend row's config.root is informational only — the LocalFS is always
+// constructed rooted at "/" so callers can pass absolute paths as keys.
+// Per-library rooting belongs to S3 (per-bucket-prefix), not local FS.
+func TestLoadStorageBackends_LocalIgnoresConfigRoot(t *testing.T) {
 	t.Setenv("REPOTEST_DIALECT", "sqlite")
 	d := repotest.New(t)
 	backendRepo := repo.NewStorageBackendRepo(d)
 
-	// Create a local backend with no root.
-	_, err := backendRepo.Create(context.Background(), "local", map[string]any{})
-	if err != nil {
-		t.Fatalf("create backend row: %v", err)
+	// Various config.root values — including missing, empty, relative,
+	// and a non-existent absolute path — all produce a working backend.
+	for _, cfg := range []map[string]any{
+		{},
+		{"root": ""},
+		{"root": "./data/main"},
+		{"root": "/absolute/somewhere/that/does/not/exist"},
+	} {
+		row, err := backendRepo.Create(context.Background(), "local", cfg)
+		if err != nil {
+			t.Fatalf("create backend row %v: %v", cfg, err)
+		}
+		resolver, err := storageloader.LoadStorageBackends(context.Background(), backendRepo, config.DialectSQLite)
+		if err != nil {
+			t.Fatalf("LoadStorageBackends with config %v: %v", cfg, err)
+		}
+		store, err := resolver.Resolve(row.ID)
+		if err != nil {
+			t.Fatalf("resolve %s: %v", row.ID, err)
+		}
+		if store == nil {
+			t.Fatalf("expected non-nil storage for config %v", cfg)
+		}
+		// Cleanup so the next iteration sees a clean table.
+		if err := backendRepo.Delete(context.Background(), row.ID); err != nil {
+			t.Fatalf("delete backend row: %v", err)
+		}
 	}
-
-	_, err = storageloader.LoadStorageBackends(context.Background(), backendRepo, config.DialectSQLite)
-	if err == nil {
-		t.Fatal("expected error for local backend with missing root")
-	}
-	t.Logf("got expected error: %v", err)
 }
 
 // TestLoadStorageBackends_SQLiteWithS3Errors verifies that having an S3 row
@@ -108,28 +127,4 @@ func TestLoadStorageBackends_SQLiteWithS3Errors(t *testing.T) {
 		t.Fatal("expected error for SQLite+S3 combination")
 	}
 	t.Logf("got expected error (SQLite+S3 rejected): %v", err)
-}
-
-// TestLoadStorageBackends_RelativeLocalRoot verifies that a local backend
-// stored with a relative root (a pre-storage_v2 library config copied
-// verbatim by the Plan-B backfill) resolves to absolute via filepath.Abs
-// rather than failing the local.New "must be absolute" check. Regression
-// guard for the boot-time error reported by users upgrading from older
-// installs whose libraries.path was "./data/main" or similar.
-func TestLoadStorageBackends_RelativeLocalRoot(t *testing.T) {
-	t.Setenv("REPOTEST_DIALECT", "sqlite")
-	d := repotest.New(t)
-	backendRepo := repo.NewStorageBackendRepo(d)
-
-	if _, err := backendRepo.Create(context.Background(), "local", map[string]any{"root": "./data/main"}); err != nil {
-		t.Fatalf("create backend row with relative root: %v", err)
-	}
-
-	resolver, err := storageloader.LoadStorageBackends(context.Background(), backendRepo, config.DialectSQLite)
-	if err != nil {
-		t.Fatalf("LoadStorageBackends: %v", err)
-	}
-	if resolver == nil {
-		t.Fatal("expected non-nil resolver")
-	}
 }


### PR DESCRIPTION
## Summary

Reverses Plan F's per-library LocalFS rooting. Replaces (and supersedes) the relative-path workaround in PR #66 with the structurally-correct fix.

### The bug PR #66 only half-fixed

Plan F made each backend rooted at its library's path. For S3 that's correct (per-bucket-prefix is natural). For LocalFS it broke every caller:

- **Scan worker**: \`store.List(ctx, lib.Path)\` on a LocalFS rooted at the same path → \`filepath.Join(libRoot, libRoot)\` → walks an empty sub-tree → finds 0 files silently.
- **Bookdrop ingest**: \`store.Open(strings.TrimPrefix(item.Path, "/"))\` against the default backend (now rooted at the first library, not at \`/\`) → opens \`{libRoot}/{originalAbsPath}\` → never finds the staged file.
- **File handler**: would have hit the same issue once it migrated.

PR #66 fixed the immediate boot crash by \`filepath.Abs\`-ing the relative root, but didn't address the actual semantic mismatch — \`./data/main\` resolved to absolute still produces a per-library LocalFS that breaks all callers.

### Fix

In \`storageloader.buildBackend\` for the \`local\` kind, always construct \`local.New("/")\`. The library's actual root path stays in \`libraries.root\` and is used as a prefix by callers — which is exactly what Plan A established and what every consumer still expects. \`storage_backends.config.root\` becomes informational metadata for the local kind.

S3 backends keep per-bucket-prefix rooting — unaffected.

### Behavior

Before: app boots, scan finds 0 files in the library, bookdrop ingest never finds staged files.
After: app boots, scan walks \`libraries.root\` correctly, bookdrop ingest opens staged files via the default \`/\`-rooted backend.

## Test plan
- [x] \`make ci-local\` green (0 lint issues)
- [x] \`TestLoadStorageBackends_LocalIgnoresConfigRoot\` covers missing/empty/relative/non-existent root → all produce a working backend
- [x] Existing \`TestLoadStorageBackends_LocalRow\` and \`TestLoadStorageBackends_EmptyTable\` still pass
- [ ] Manual smoke against the user's \`./data/main\` install: scan should now discover existing files

🤖 Generated with [Claude Code](https://claude.com/claude-code)