### PR TITLE
chore(env): document S3 / presign / S3-events env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,67 @@ OTEL_TRACES_SAMPLER_ARG=1.0
 # VITE_OTEL_ENABLED=true
 # VITE_OTEL_SERVICE_NAME=embookshelf-frontend
 # VITE_OTEL_OTLP_ENDPOINT=/v1/traces
+
+# ---------------------------------------------------------------------------
+# Storage backends (Plans F–H)
+# ---------------------------------------------------------------------------
+#
+# Per-library storage backends are configured in the database
+# (storage_backends table), NOT via env. Add an S3 backend by inserting a
+# row with kind='s3' and a config JSON object — for example via psql:
+#
+#   INSERT INTO storage_backends (id, kind, config) VALUES (
+#     gen_random_uuid(),
+#     's3',
+#     '{
+#       "bucket": "my-library",
+#       "region": "us-east-1",
+#       "endpoint": "",
+#       "prefix": "",
+#       "access_key_id": "",
+#       "secret_access_key": "",
+#       "force_path_style": false
+#     }'::jsonb
+#   );
+#
+# Then assign one or more libraries to it: UPDATE libraries SET backend_id =
+# '<that uuid>', root = '' WHERE id = '<library uuid>';
+#
+# Config keys for kind='s3':
+#   bucket             — required; the bucket name
+#   region             — required for AWS; placeholder ok for minio/R2/B2
+#   endpoint           — empty for AWS regional; set for minio/R2/B2/Wasabi
+#   prefix             — optional library prefix inside the bucket
+#   access_key_id      — leave empty to use the AWS default credential chain
+#   secret_access_key  —   (env vars, shared config, IRSA, etc.)
+#   force_path_style   — true for minio and most S3-compat backends; false for AWS
+#
+# When access_key_id / secret_access_key are empty, the AWS SDK reads
+# AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION, AWS_PROFILE, etc.
+# from the environment. Set them here for credential-chain auth:
+# AWS_ACCESS_KEY_ID=
+# AWS_SECRET_ACCESS_KEY=
+# AWS_REGION=us-east-1
+
+# AES-256-GCM key for at-rest encryption of secrets (provider API keys,
+# S3 access keys stored in storage_backends.config). Generate with
+# `openssl rand -base64 32`. Unset = plaintext + a loud warning at boot.
+# EMBOOKSHELF_SECRET_KEY=
+
+# Presigned-URL redirect for S3-backed book downloads (Plan G). When the
+# backing storage advertises CapPresign, /api/books/:id/file 302-redirects
+# to a presigned GET URL valid for PRESIGN_TTL. Set FALLBACK=stream to
+# disable the redirect and stream bytes through the app server instead
+# (useful for clients that can't follow cross-origin redirects).
+EMBOOKSHELF_PRESIGN_TTL=10m
+# EMBOOKSHELF_PRESIGN_FALLBACK=stream
+
+# S3 event-driven scan reconciliation (Plan H). Opt-in. When set, a
+# goroutine long-polls the SQS queue, decodes ObjectCreated/ObjectRemoved
+# events, and applies them to the files table — much faster than the
+# periodic full walk. Configure your bucket to send events to this queue
+# (S3 Events → SQS, see docs/ops/s3-lifecycle.md). Without this var the
+# loop never starts; the periodic walk remains the only reconciler.
+# EMBOOKSHELF_S3_EVENT_QUEUE=https://sqs.us-east-1.amazonaws.com/123/queue
+# EMBOOKSHELF_S3_EVENT_REGION=us-east-1
+# EMBOOKSHELF_S3_EVENT_POLL_INTERVAL=30s


### PR DESCRIPTION
## Summary

Extends \`.env.example\` with a **Storage backends** section covering the env surface introduced by Plans F–H. Operators wiring S3 today have to cross-reference \`docs/spec/storage.spec.md\` + the plan docs + \`internal/config/config.go\` to find the right knobs; this consolidates them in one place.

### What's added

- **S3 backend config shape**: how to insert a \`storage_backends\` row with \`kind='s3'\` (configured in the DB, not env) plus the JSON keys (\`bucket\`, \`region\`, \`endpoint\`, \`prefix\`, \`access_key_id\`, \`secret_access_key\`, \`force_path_style\`).
- **AWS default credential chain**: when \`access_key_id\` / \`secret_access_key\` are blank in the row, the AWS SDK reads \`AWS_ACCESS_KEY_ID\` / \`AWS_SECRET_ACCESS_KEY\` / \`AWS_REGION\` from env. Documented as commented-out env vars.
- **\`EMBOOKSHELF_SECRET_KEY\`**: AES-256-GCM key for at-rest encryption of stored credentials (already existed in code, just not in the example).
- **Plan G presign vars**: \`EMBOOKSHELF_PRESIGN_TTL\` (default 10m), \`EMBOOKSHELF_PRESIGN_FALLBACK=stream\` (escape hatch for clients that can't follow cross-origin redirects).
- **Plan H SQS event vars**: \`EMBOOKSHELF_S3_EVENT_QUEUE\`, \`EMBOOKSHELF_S3_EVENT_REGION\`, \`EMBOOKSHELF_S3_EVENT_POLL_INTERVAL\`.

All defaults are off / blank — a fresh \`cp .env.example .env\` produces a working local install with no S3 dependencies.

## Test plan
- [x] No code changes; existing CI applies.
- [ ] Operator-level: copy `.env.example` → set the S3 vars → verify boot works against an S3 bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)