### PR TITLE
feat: S3 libraries via shared bucket

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,40 +33,20 @@ OTEL_TRACES_SAMPLER_ARG=1.0
 # VITE_OTEL_OTLP_ENDPOINT=/v1/traces
 
 # ---------------------------------------------------------------------------
-# Storage backends (Plans F–H)
+# Shared S3 bucket for s3-kind libraries
 # ---------------------------------------------------------------------------
 #
-# Per-library storage backends are configured in the database
-# (storage_backends table), NOT via env. Add an S3 backend by inserting a
-# row with kind='s3' and a config JSON object — for example via psql:
+# When EMBOOKSHELF_S3_BUCKET is set, the library-create UI offers an
+# "S3" option that allocates a prefix in this bucket (libraries/{slug}/).
+# Single bucket per deployment; each library gets its own prefix.
+# EMBOOKSHELF_S3_BUCKET=my-embookshelf-library
+# EMBOOKSHELF_S3_REGION=us-east-1
+# EMBOOKSHELF_S3_ENDPOINT=
+# EMBOOKSHELF_S3_ACCESS_KEY_ID=
+# EMBOOKSHELF_S3_SECRET_ACCESS_KEY=
+# EMBOOKSHELF_S3_FORCE_PATH_STYLE=false
 #
-#   INSERT INTO storage_backends (id, kind, config) VALUES (
-#     gen_random_uuid(),
-#     's3',
-#     '{
-#       "bucket": "my-library",
-#       "region": "us-east-1",
-#       "endpoint": "",
-#       "prefix": "",
-#       "access_key_id": "",
-#       "secret_access_key": "",
-#       "force_path_style": false
-#     }'::jsonb
-#   );
-#
-# Then assign one or more libraries to it: UPDATE libraries SET backend_id =
-# '<that uuid>', root = '' WHERE id = '<library uuid>';
-#
-# Config keys for kind='s3':
-#   bucket             — required; the bucket name
-#   region             — required for AWS; placeholder ok for minio/R2/B2
-#   endpoint           — empty for AWS regional; set for minio/R2/B2/Wasabi
-#   prefix             — optional library prefix inside the bucket
-#   access_key_id      — leave empty to use the AWS default credential chain
-#   secret_access_key  —   (env vars, shared config, IRSA, etc.)
-#   force_path_style   — true for minio and most S3-compat backends; false for AWS
-#
-# When access_key_id / secret_access_key are empty, the AWS SDK reads
+# When ACCESS_KEY_ID / SECRET_ACCESS_KEY are empty, the AWS SDK reads
 # AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION, AWS_PROFILE, etc.
 # from the environment. Set them here for credential-chain auth:
 # AWS_ACCESS_KEY_ID=

--- a/cmd/embookshelf/main.go
+++ b/cmd/embookshelf/main.go
@@ -128,7 +128,13 @@ func main() {
 	covers := coverstore.New(filepath.Join(cfg.DataPath, "covers"))
 
 	// Services.
-	libSvc := service.NewLibraryService(libRepo)
+	backendRepo := repo.NewStorageBackendRepo(dbh)
+	libSvc := service.NewLibraryService(libRepo, service.LibraryServiceDeps{
+		Backends: backendRepo,
+		SharedS3: cfg.SharedS3,
+		Resolver: storageResolver,
+		Dialect:  config.Dialect(string(dbh.Dialect)),
+	})
 	shelfSvc := service.NewShelfService(shelfRepo)
 	searchSvc := service.NewSearchService(libRepo, shelfRepo)
 	authSvc := service.NewAuthService(userRepo, sessionRepo, hub)

--- a/docs/superpowers/plans/2026-04-30-s3-libraries-via-shared-bucket.md
+++ b/docs/superpowers/plans/2026-04-30-s3-libraries-via-shared-bucket.md
@@ -1,0 +1,429 @@
+# S3 Libraries via Shared Bucket — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development.
+
+**Goal:** Operator configures one S3 bucket via env. Library creation gains a `kind: "local" | "s3"` choice. Choosing s3 allocates an auto-derived prefix (`libraries/{slug}/`) inside the shared bucket, materializes a per-library `storage_backends` row, and points `libraries.backend_id` at it. Library deletion accepts an optional `purge` flag that also strips the bucket prefix; default off.
+
+**Architecture:** Env vars (`EMBOOKSHELF_S3_BUCKET`, `_REGION`, `_ENDPOINT`, `_ACCESS_KEY_ID`, `_SECRET_ACCESS_KEY`, `_FORCE_PATH_STYLE`) feed a new `config.SharedS3()` struct. When the operator creates a library with `kind=s3`, the service:
+
+1. Validates `cfg.SharedS3.Configured()` (bucket non-empty).
+2. Derives prefix = `libraries/{slug}/`.
+3. INSERTs a `storage_backends` row (`kind='s3'`, config from env + computed prefix).
+4. INSERTs a `libraries` row with `backend_id` set, `path` left empty (s3 libraries have no filesystem path), `root` left empty (the backend already roots at `bucket+prefix`).
+
+Per-library s3 backends share bucket/region/credentials but each has its own prefix — matching Plan F's existing s3 backend semantics. No change to `s3.Backend`. The library scan, file backfill, presign, and cover paths inherited from Plans C/F/G all work unchanged for s3 libraries.
+
+Library deletion stays soft by default. With `?purge=true`, after `repo.DeleteLibrary` succeeds, the service iterates `storage.List(ctx, "")` against the s3 backend, batches keys 1000 at a time into `DeleteObjects`, then deletes the `storage_backends` row. Errors are logged but don't fail the response — the DB row is already gone, the prefix may need manual cleanup.
+
+**Tech stack:** Reuses Plan F's `aws-sdk-go-v2/service/s3` (DeleteObjects already on `s3.Client`). No new third-party deps.
+
+**Companion reference:** `docs/spec/storage.spec.md` §3.2 (S3 layout, "one bucket per environment, libraries are prefixes"). `docs/CONTEXT.md` (terms).
+
+**Locked decisions:**
+- Shared S3 config via env, never DB-editable. Rotating creds = rotating env vars.
+- Library create accepts `kind: "local" | "s3"`, default `local`. `kind=s3` ignores `path`.
+- Prefix is always auto-derived from slug: `libraries/{slug}/`. No operator override.
+- Library delete with `?purge=true` (default false) cascade-deletes the bucket prefix.
+- One backend row per library (matches Plan F). Bucket-level config replicated into each row's config; per-library prefix is what differs.
+- Bookdrop staging area stays local. Approval flow does NOT auto-upload to s3 in this plan — explicitly out of scope.
+
+**Out of scope:**
+- **Approve → upload to S3.** Currently `Approve` records a files row pointing at the bookdrop's local path. For s3 libraries this leaves the file in `BOOKDROP_PATH` rather than moving it into the bucket. Operator workaround: pre-upload via `aws s3 sync`, scan picks up. Real fix is a follow-up plan.
+- Migrating an existing local library to s3.
+- Drag-drop upload directly to s3 from the UI.
+- Sharing one library across multiple buckets.
+- Per-library credential overrides (use the env defaults).
+- Settings UI for the shared bucket — config is env-only.
+
+**Depends on:** Plans A–H merged. PR #68 (LocalFS rooted at "/") merged.
+
+---
+
+## File Structure
+
+### Files modified
+
+| Path | Change |
+|---|---|
+| `.env.example` | Replace the documentation-only block from PR #69 with the working `EMBOOKSHELF_S3_*` env vars that the loader actually reads. |
+| `internal/config/config.go` | Add `SharedS3 SharedS3Config` to `Config`. New struct with `Bucket`, `Region`, `Endpoint`, `AccessKeyID`, `SecretAccessKey`, `ForcePathStyle`, `Configured() bool`. |
+| `internal/repo/library.go` | `CreateLibrary` gains `(name, slug, path string, backendID *string)` signature; `path` may be empty for s3 libraries. Drop the `libraries_path_key` UNIQUE on empty paths if not already (it should already be partial). |
+| `internal/service/library.go` | `Create(ctx, name, kind, path)` switches on kind. `kind=s3` builds the storage_backends row from `cfg.SharedS3` + auto-prefix, then inserts the library. New `DeleteLibraryWithPurge(ctx, id, purge bool)`. |
+| `internal/handler/library.go` | `POST /api/libraries` accepts `kind` field; `DELETE /api/libraries/:id` accepts `?purge=true` query param. |
+| `ui/src/api/libraries.ts` | TS client: `createLibrary({name, kind, path?})`, `deleteLibrary(id, {purge})`. |
+| `ui/src/routes/_app.settings.tsx` (or wherever the library form lives — find via `grep -rn "createLibrary\b" ui/src/`) | Kind selector dropdown; for kind=s3 hide the Path input and show a derived-prefix preview. Purge checkbox in delete confirm. |
+
+### Files NOT touched
+
+- `internal/storage/*` — no changes; backend already supports the per-library s3 shape.
+- `internal/storageloader/loader.go` — already builds s3 backends from rows.
+- `internal/task/library_scan.go` — works as-is; for s3 libraries `lib.Root` is empty, scan calls `store.List(ctx, "")`, the per-backend prefix is already encoded in the s3 backend.
+- `internal/service/bookdrop.go` (Approve flow) — explicitly out of scope. Books approve into the bookdrop's local path; for s3 libraries the operator must `aws s3 sync` files in.
+- DB migrations — none needed.
+
+---
+
+## Phase 1 — Env Config
+
+### Task 1: `SharedS3Config` + env wiring
+
+**Files:**
+- Modify: `internal/config/config.go`
+- Modify: `internal/config/config_test.go` if present
+- Modify: `.env.example`
+
+```go
+// internal/config/config.go
+
+// SharedS3Config carries the bucket-level S3 configuration shared by
+// every s3-kind library in the deployment. Env-driven; not editable
+// from the UI. Per-library prefix is computed from libraries.slug.
+type SharedS3Config struct {
+    Bucket          string
+    Region          string
+    Endpoint        string
+    AccessKeyID     string
+    SecretAccessKey string
+    ForcePathStyle  bool
+}
+
+// Configured reports whether the shared bucket is set. Used by the
+// library-create handler to gate the kind=s3 path.
+func (s SharedS3Config) Configured() bool {
+    return strings.TrimSpace(s.Bucket) != ""
+}
+```
+
+In `Load()`, populate from env. Read `EMBOOKSHELF_S3_BUCKET`, `EMBOOKSHELF_S3_REGION` (default `"us-east-1"` only when bucket is set, else empty), `EMBOOKSHELF_S3_ENDPOINT`, `EMBOOKSHELF_S3_ACCESS_KEY_ID`, `EMBOOKSHELF_S3_SECRET_ACCESS_KEY`, `EMBOOKSHELF_S3_FORCE_PATH_STYLE` (bool: "true" / "1").
+
+`.env.example`: replace the "Storage backends" block from PR #69 (the documentation-only INSERT example) with the working env vars:
+
+```
+# Shared S3 bucket for libraries created with kind=s3.
+# When EMBOOKSHELF_S3_BUCKET is set, the library-create UI offers an
+# "S3" option that allocates a prefix in this bucket (libraries/{slug}/).
+# Single bucket per deployment; each library gets its own prefix.
+# EMBOOKSHELF_S3_BUCKET=my-embookshelf-library
+# EMBOOKSHELF_S3_REGION=us-east-1
+# EMBOOKSHELF_S3_ENDPOINT=
+# EMBOOKSHELF_S3_ACCESS_KEY_ID=
+# EMBOOKSHELF_S3_SECRET_ACCESS_KEY=
+# EMBOOKSHELF_S3_FORCE_PATH_STYLE=false
+```
+
+Keep the AWS_* fallback section (the SDK reads those when ACCESS_KEY_ID is empty). Drop the long DB-INSERT block — the new flow makes it obsolete.
+
+**Tests:** unit-test `Load()` reading the new env vars; assert `SharedS3Config.Configured()` flips true when bucket is set, false otherwise.
+
+Commit:
+```bash
+git commit -m "feat(config): SharedS3Config from EMBOOKSHELF_S3_* env vars"
+```
+
+---
+
+## Phase 2 — Library Create Cutover
+
+### Task 2: `LibraryRepo.CreateLibrary` accepts optional `backendID`
+
+**File:** `internal/repo/library.go`
+
+Change signature:
+
+```go
+func (r *LibraryRepo) CreateLibrary(ctx context.Context, name, slug, path string, backendID *string) (model.Library, error)
+```
+
+`backendID == nil` → INSERT with NULL backend_id (existing behavior for local libraries). `backendID != nil` → INSERT with that value. The migration already added `libraries.backend_id` (Plan B); the partial-unique on `path` excludes empty strings (Plan B), so multiple s3 libraries with empty path don't collide.
+
+Update the SQL:
+
+```sql
+INSERT INTO libraries (id, name, slug, path, backend_id, root)
+VALUES ($1, $2, $3, $4, $5, $6)
+RETURNING ...
+```
+
+`root` for s3 libraries is empty (the backend has the prefix encoded); `root` for local libraries equals `path`.
+
+Update the only caller (`service.LibraryService.Create`) — Task 3.
+
+Commit:
+```bash
+git commit -m "feat(repo): CreateLibrary takes optional backend_id + root"
+```
+
+### Task 3: `LibraryService.Create(ctx, name, kind, path)` with s3 branch
+
+**Files:**
+- Modify: `internal/service/library.go`
+- Modify: `internal/service/library_test.go` if present
+
+```go
+type LibraryKind string
+
+const (
+    LibraryKindLocal LibraryKind = "local"
+    LibraryKindS3    LibraryKind = "s3"
+)
+
+// LibraryServiceDeps groups the deps the service needs beyond its
+// repo. Used to keep the constructor stable.
+type LibraryServiceDeps struct {
+    Backends *repo.StorageBackendRepo
+    SharedS3 config.SharedS3Config
+}
+
+// Create inserts a new library. Kind selects the storage flavor:
+//
+//   - local: path is required, names a filesystem directory. No
+//     backend row is created; backend_id stays NULL and the loader
+//     falls back to the LocalFS-at-/ default.
+//   - s3: path is ignored; the service derives prefix=libraries/{slug}/,
+//     INSERTs a storage_backends row from cfg.SharedS3, and points
+//     the library at that backend.
+func (s *LibraryService) Create(ctx context.Context, name string, kind LibraryKind, path string) (model.Library, error) {
+    name = strings.TrimSpace(name)
+    slug := slugify(name)
+
+    switch kind {
+    case "", LibraryKindLocal:
+        path = strings.TrimRight(strings.TrimSpace(path), "/")
+        return s.repo.CreateLibrary(ctx, name, slug, path, nil)
+
+    case LibraryKindS3:
+        if !s.deps.SharedS3.Configured() {
+            return model.Library{}, ErrS3NotConfigured
+        }
+        prefix := "libraries/" + slug + "/"
+        cfg := map[string]any{
+            "bucket":            s.deps.SharedS3.Bucket,
+            "region":            s.deps.SharedS3.Region,
+            "endpoint":          s.deps.SharedS3.Endpoint,
+            "prefix":            prefix,
+            "access_key_id":     s.deps.SharedS3.AccessKeyID,
+            "secret_access_key": s.deps.SharedS3.SecretAccessKey,
+            "force_path_style":  s.deps.SharedS3.ForcePathStyle,
+        }
+        backend, err := s.deps.Backends.Create(ctx, "s3", cfg)
+        if err != nil {
+            return model.Library{}, fmt.Errorf("create s3 backend row: %w", err)
+        }
+        lib, err := s.repo.CreateLibrary(ctx, name, slug, "", &backend.ID)
+        if err != nil {
+            // Best-effort cleanup of the backend row we just inserted.
+            _ = s.deps.Backends.Delete(ctx, backend.ID)
+            return model.Library{}, err
+        }
+        return lib, nil
+
+    default:
+        return model.Library{}, fmt.Errorf("unknown library kind %q", kind)
+    }
+}
+
+var ErrS3NotConfigured = errors.New("s3 libraries require EMBOOKSHELF_S3_BUCKET to be set")
+```
+
+Update `NewLibraryService` to accept the deps:
+
+```go
+func NewLibraryService(r *repo.LibraryRepo, deps LibraryServiceDeps) *LibraryService { ... }
+```
+
+Update `cmd/embookshelf/main.go` to pass `LibraryServiceDeps{Backends: backendRepo, SharedS3: cfg.SharedS3}`.
+
+**Tests:**
+- `kind=local` happy path (existing tests still pass).
+- `kind=s3` with bucket configured → backend row + library row, both reachable.
+- `kind=s3` without bucket → `ErrS3NotConfigured`.
+- `kind=s3` slug collision → ErrLibraryNameTaken; backend row not orphaned (cleanup).
+- `kind=""` defaults to local (backward compat).
+
+Commit:
+```bash
+git commit -m "feat(service): library Create dispatches by kind (local|s3)"
+```
+
+### Task 4: `LibraryService.DeleteLibrary` with optional purge
+
+**Files:**
+- Modify: `internal/service/library.go`
+- Modify: `internal/handler/library.go`
+
+```go
+// DeleteLibrary removes the library row. When purge is true and the
+// library is backed by an s3 backend, also strips every object under
+// the backend's prefix. The backend row is deleted last; failures
+// during purge are logged but the response still succeeds (operator
+// can manually clean up the bucket if needed).
+func (s *LibraryService) DeleteLibrary(ctx context.Context, id string, purge bool) ([]string, error) {
+    lib, err := s.repo.GetByID(ctx, id)
+    if err != nil {
+        return nil, err
+    }
+    bookIDs, err := s.repo.DeleteLibrary(ctx, id)
+    if err != nil {
+        return nil, err
+    }
+    if purge && lib.BackendID != nil {
+        s.purgeBackend(ctx, *lib.BackendID)
+    }
+    return bookIDs, nil
+}
+
+func (s *LibraryService) purgeBackend(ctx context.Context, backendID string) {
+    if s.deps.Resolver == nil { return }
+    store, err := s.deps.Resolver.Resolve(backendID)
+    if err != nil {
+        slog.Warn("library purge: resolve backend", "id", backendID, "err", err)
+        return
+    }
+    it, err := store.List(ctx, "")
+    if err != nil {
+        slog.Warn("library purge: list", "id", backendID, "err", err)
+        return
+    }
+    defer func() { _ = it.Close() }()
+    for {
+        obj, err := it.Next(ctx)
+        if errors.Is(err, io.EOF) { break }
+        if err != nil {
+            slog.Warn("library purge: iterate", "id", backendID, "err", err)
+            break
+        }
+        if err := store.Delete(ctx, obj.Key); err != nil {
+            slog.Warn("library purge: delete", "key", obj.Key, "err", err)
+            continue
+        }
+    }
+    // Drop the backend row so future reads through Resolver don't
+    // hit a stale config. ErrStorageBackendInUse should not fire
+    // here — the library row is already gone.
+    if err := s.deps.Backends.Delete(ctx, backendID); err != nil {
+        slog.Warn("library purge: delete backend row", "id", backendID, "err", err)
+    }
+}
+```
+
+Add `Resolver storage.Resolver` to `LibraryServiceDeps`. main.go passes it.
+
+**Handler:**
+
+```go
+// internal/handler/library.go DeleteLibrary handler:
+purge := c.Query("purge") == "true"
+bookIDs, err := h.libsvc.DeleteLibrary(c.Request.Context(), id, purge)
+```
+
+Existing local library deletes don't call into `purgeBackend` (BackendID is nil) — behavior unchanged.
+
+**Tests:**
+- Local library delete (purge=false) → DB rows go, no purge logic invoked.
+- Local library delete (purge=true) → same as above, no S3 calls (BackendID is nil).
+- S3 library delete (purge=false) → DB rows go, S3 prefix untouched, backend row remains.
+- S3 library delete (purge=true) → DB rows go, every key under prefix is deleted, backend row deleted.
+- S3 library delete (purge=true) with list error → DB delete succeeds, error logged, response success.
+
+Commit:
+```bash
+git commit -m "feat(service+handler): library delete with optional ?purge=true"
+```
+
+### Task 5: Handler accepts `kind` field on POST /api/libraries
+
+**File:** `internal/handler/library.go`
+
+Find the create-library handler (`grep -n "func.*CreateLibrary\b\|func.*Libraries\b" internal/handler/library.go`). Update the request struct:
+
+```go
+type createLibraryReq struct {
+    Name string `json:"name" binding:"required"`
+    Kind string `json:"kind"`            // "local" (default) | "s3"
+    Path string `json:"path"`            // required for kind=local
+}
+```
+
+Validate: when kind=local (or empty), path must be non-empty. When kind=s3, path is ignored. Map `service.ErrS3NotConfigured` → HTTP 400 with a clear message.
+
+Commit:
+```bash
+git commit -m "feat(handler): POST /api/libraries accepts kind field"
+```
+
+---
+
+## Phase 3 — UI
+
+### Task 6: TypeScript client + library form
+
+**Files:**
+- Modify: `ui/src/api/libraries.ts` (or wherever the API client is — find via `grep -rn "POST.*libraries\b\|createLibrary" ui/src/`).
+- Modify: the library-create form component.
+
+API client:
+
+```typescript
+export type LibraryKind = 'local' | 's3';
+
+export type CreateLibraryInput = {
+  name: string;
+  kind: LibraryKind;
+  path?: string;  // required for kind='local', omitted for 's3'
+};
+
+export async function createLibrary(input: CreateLibraryInput): Promise<Library> { ... }
+export async function deleteLibrary(id: string, opts?: { purge?: boolean }): Promise<void> {
+  const params = opts?.purge ? '?purge=true' : '';
+  // ... fetch DELETE /api/libraries/{id}${params}
+}
+```
+
+Form changes:
+
+- **Kind selector**: dropdown / segmented control with two options: "Local filesystem" and "S3 bucket". Disable the s3 option (with a tooltip "Set EMBOOKSHELF_S3_BUCKET to enable") when the server returns `s3Available: false` in some bootstrap endpoint — or just let the create call fail with a 400 and surface the error inline.
+- **Path field**: visible only when kind=local. For kind=s3, show a read-only preview: `libraries/{slug}/` (computed from the entered name).
+- **Delete confirm**: add a "Also delete files in S3 bucket" checkbox, visible only for s3 libraries. Posts the `purge=true` query param.
+
+Server bootstrap endpoint (small): `GET /api/config` returns `{ s3Available: boolean }` so the UI can disable the s3 option pre-emptively rather than failing post-submit. Add to the existing settings-bootstrap response if there is one, else a tiny new endpoint.
+
+**Tests:** existing UI test suite covers the form; add a test that the s3 kind sends `path: undefined` (or omits it).
+
+Commit:
+```bash
+git commit -m "feat(ui): library create form + delete confirm support s3 kind"
+```
+
+---
+
+## Phase 4 — Verification
+
+### Task 7: Verify and PR
+
+- [ ] `make ci-local` green.
+- [ ] Manual smoke (env-driven):
+  - Set `EMBOOKSHELF_S3_BUCKET=test-bucket` (with valid creds).
+  - Boot. UI library-create form shows the S3 option enabled.
+  - Create a library named "Sci-Fi" with kind=s3 → backend row + library row land; bucket is empty.
+  - `aws s3 sync ./local/scifi/ s3://test-bucket/libraries/sci-fi/` to seed files.
+  - Library scan discovers the files; `files` rows appear with content_hash NULL.
+  - Boot worker fills hashes via the s3 source.
+  - File-serve URL 302-redirects to a presigned URL.
+  - Delete the library with purge=true → backend row gone, bucket prefix empty.
+- [ ] Push, open PR.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §3.2 S3 layout ("one bucket per environment, libraries are prefixes") → covered.
+- §10 SQLite + S3 refusal → still enforced by the existing `storageloader` check; creating an s3 library on a SQLite install works at the API level (the row inserts) but boot will refuse on next restart. Worth a guard at create-time too — add `s.deps.Dialect != SQLite` check to the s3 branch.
+
+**Risks:**
+- Approve → upload to s3 is missing. UX says "create s3 library" but actually using it for new imports requires manual `aws s3 sync`. Document as a follow-up plan.
+- Slug collisions on create → handled (ErrLibraryNameTaken). The orphaned-backend-row cleanup is best-effort; on cleanup failure the next create with the same slug will leak two backend rows. Acceptable; admin can manually delete.
+- Purge during a concurrent scan → could race (scan reads keys that purge is deleting). Mitigated because purge runs after the library row is gone — scans of that library_id won't dispatch.
+- The handler-side bootstrap for `s3Available` is the only signal the UI has that S3 is configured. If env changes between page loads, UI shows stale state. Self-hosted reload-the-page is acceptable.
+
+**Type consistency:** `LibraryKind`, `LibraryKindLocal`, `LibraryKindS3`, `SharedS3Config`, `LibraryServiceDeps`, `ErrS3NotConfigured`, `purgeBackend` consistent across the plan.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,24 @@ import (
 	"time"
 )
 
+// SharedS3Config carries the bucket-level S3 configuration shared by
+// every s3-kind library in the deployment. Env-driven; not editable
+// from the UI. Per-library prefix is computed from libraries.slug.
+type SharedS3Config struct {
+	Bucket          string
+	Region          string
+	Endpoint        string
+	AccessKeyID     string
+	SecretAccessKey string
+	ForcePathStyle  bool
+}
+
+// Configured reports whether the shared bucket is set. Used by the
+// library-create handler to gate the kind=s3 path.
+func (s SharedS3Config) Configured() bool {
+	return strings.TrimSpace(s.Bucket) != ""
+}
+
 type Config struct {
 	Port             int
 	DatabaseURL      string
@@ -31,6 +49,11 @@ type Config struct {
 	// Unset = plaintext storage (dev mode); the server logs a warning
 	// on boot so the fact doesn't silently linger.
 	SecretKey string
+
+	// SharedS3 is the shared bucket configuration for libraries created with
+	// kind=s3. Populated from EMBOOKSHELF_S3_* env vars. When Bucket is
+	// empty, s3-kind library creation is disabled.
+	SharedS3 SharedS3Config
 
 	// S3EventQueueURL is the SQS queue URL from which S3 event notifications
 	// are polled. When empty (default) the SQS poll loop is disabled and the
@@ -74,6 +97,14 @@ type Config struct {
 }
 
 func Load() (Config, error) {
+	// Shared S3 bucket config. Region defaults to "us-east-1" only when
+	// bucket is set (matching Plan F's per-backend behaviour).
+	s3Bucket := envStr("EMBOOKSHELF_S3_BUCKET", "")
+	s3Region := envStr("EMBOOKSHELF_S3_REGION", "")
+	if s3Bucket != "" && s3Region == "" {
+		s3Region = "us-east-1"
+	}
+
 	cfg := Config{
 		Port:             envInt("EMBOOKSHELF_PORT", 6060),
 		DatabaseURL:      envStr("DATABASE_URL", "sqlite://./data/embookshelf.db"),
@@ -89,6 +120,15 @@ func Load() (Config, error) {
 
 		AppURL:    strings.TrimRight(envStr("APP_URL", ""), "/"),
 		SecretKey: envStr("EMBOOKSHELF_SECRET_KEY", ""),
+
+		SharedS3: SharedS3Config{
+			Bucket:          s3Bucket,
+			Region:          s3Region,
+			Endpoint:        envStr("EMBOOKSHELF_S3_ENDPOINT", ""),
+			AccessKeyID:     envStr("EMBOOKSHELF_S3_ACCESS_KEY_ID", ""),
+			SecretAccessKey: envStr("EMBOOKSHELF_S3_SECRET_ACCESS_KEY", ""),
+			ForcePathStyle:  envBool("EMBOOKSHELF_S3_FORCE_PATH_STYLE", false),
+		},
 
 		S3EventQueueURL:     envStr("EMBOOKSHELF_S3_EVENT_QUEUE", ""),
 		S3EventQueueRegion:  envStr("EMBOOKSHELF_S3_EVENT_REGION", "us-east-1"),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,76 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/blackforge/embookshelf/internal/config"
+)
+
+func TestLoad_SharedS3_Configured(t *testing.T) {
+	t.Setenv("EMBOOKSHELF_S3_BUCKET", "my-bucket")
+	t.Setenv("EMBOOKSHELF_S3_REGION", "eu-west-1")
+	t.Setenv("EMBOOKSHELF_S3_ENDPOINT", "https://minio.local")
+	t.Setenv("EMBOOKSHELF_S3_ACCESS_KEY_ID", "AKID")
+	t.Setenv("EMBOOKSHELF_S3_SECRET_ACCESS_KEY", "SECRET")
+	t.Setenv("EMBOOKSHELF_S3_FORCE_PATH_STYLE", "true")
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	s3 := cfg.SharedS3
+	if s3.Bucket != "my-bucket" {
+		t.Errorf("Bucket=%q want %q", s3.Bucket, "my-bucket")
+	}
+	if s3.Region != "eu-west-1" {
+		t.Errorf("Region=%q want %q", s3.Region, "eu-west-1")
+	}
+	if s3.Endpoint != "https://minio.local" {
+		t.Errorf("Endpoint=%q want %q", s3.Endpoint, "https://minio.local")
+	}
+	if s3.AccessKeyID != "AKID" {
+		t.Errorf("AccessKeyID=%q want %q", s3.AccessKeyID, "AKID")
+	}
+	if s3.SecretAccessKey != "SECRET" {
+		t.Errorf("SecretAccessKey=%q want %q", s3.SecretAccessKey, "SECRET")
+	}
+	if !s3.ForcePathStyle {
+		t.Error("ForcePathStyle should be true")
+	}
+	if !s3.Configured() {
+		t.Error("Configured() should return true when bucket is set")
+	}
+}
+
+func TestLoad_SharedS3_NotConfigured(t *testing.T) {
+	// Ensure the env vars are absent.
+	t.Setenv("EMBOOKSHELF_S3_BUCKET", "")
+	t.Setenv("EMBOOKSHELF_S3_REGION", "")
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.SharedS3.Configured() {
+		t.Error("Configured() should return false when bucket is empty")
+	}
+	// Region should stay empty (not defaulted) when bucket is unset.
+	if cfg.SharedS3.Region != "" {
+		t.Errorf("Region=%q want empty when bucket is unset", cfg.SharedS3.Region)
+	}
+}
+
+func TestLoad_SharedS3_DefaultRegion(t *testing.T) {
+	// When bucket is set but region is not, region should default to us-east-1.
+	t.Setenv("EMBOOKSHELF_S3_BUCKET", "auto-region-bucket")
+	t.Setenv("EMBOOKSHELF_S3_REGION", "")
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.SharedS3.Region != "us-east-1" {
+		t.Errorf("Region=%q want %q", cfg.SharedS3.Region, "us-east-1")
+	}
+}

--- a/internal/handler/instance.go
+++ b/internal/handler/instance.go
@@ -121,6 +121,24 @@ type instanceSummaryDTO struct {
 	Books     int    `json:"books"`
 }
 
+// appConfigDTO is the lightweight feature-flag response for GET /api/v1/config.
+// All signed-in users can read it so the UI can gate features pre-emptively
+// without requiring an admin round-trip.
+type appConfigDTO struct {
+	// S3Available reports whether EMBOOKSHELF_S3_BUCKET is configured. When
+	// false the UI disables the "S3" kind option in the library-create form
+	// so the user learns immediately rather than on submit.
+	S3Available bool `json:"s3Available"`
+}
+
+// AppConfig returns lightweight feature flags derived from the server
+// configuration. Session-authed, not admin-gated.
+func (h *Handler) AppConfig(c *gin.Context) {
+	c.JSON(http.StatusOK, appConfigDTO{
+		S3Available: h.cfg.SharedS3.Configured(),
+	})
+}
+
 // InstanceSummary returns the non-sensitive instance fields (version
 // and catalog-size counts). Session-authed but not admin-gated — the
 // status bar at the bottom of every page reads this.

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -61,6 +61,7 @@ func (h *Handler) Engine() *gin.Engine {
 			authed.PATCH("/me", h.AccountUpdateName)
 			authed.POST("/me/password", h.AccountChangePassword)
 			authed.GET("/instance", h.InstanceSummary)
+			authed.GET("/config", h.AppConfig)
 
 			// Cross-entity search powering the global command palette
 			// and the library page combobox.

--- a/internal/handler/settings.go
+++ b/internal/handler/settings.go
@@ -15,6 +15,7 @@ import (
 	"github.com/blackforge/embookshelf/internal/fileproc"
 	"github.com/blackforge/embookshelf/internal/pattern"
 	"github.com/blackforge/embookshelf/internal/repo"
+	"github.com/blackforge/embookshelf/internal/service"
 )
 
 // settingsLibraryDTO exposes the library row plus its scan aggregates
@@ -64,7 +65,8 @@ func (h *Handler) SettingsLibraries(c *gin.Context) {
 // best-effort because they're owned by this service.
 func (h *Handler) SettingsLibraryDelete(c *gin.Context) {
 	id := c.Param("id")
-	bookIDs, err := h.lib.DeleteLibrary(c.Request.Context(), id)
+	purge := c.Query("purge") == "true"
+	bookIDs, err := h.lib.DeleteLibrary(c.Request.Context(), id, purge)
 	if err != nil {
 		if errors.Is(err, repo.ErrNotFound) {
 			writeError(c, http.StatusNotFound, "library not found")
@@ -85,7 +87,8 @@ func (h *Handler) SettingsLibraryDelete(c *gin.Context) {
 
 type createLibraryReq struct {
 	Name string `json:"name"`
-	Path string `json:"path"`
+	Kind string `json:"kind"` // "local" (default) | "s3"
+	Path string `json:"path"` // required for kind=local; ignored for kind=s3
 	Scan bool   `json:"scan"`
 }
 
@@ -103,23 +106,27 @@ func (h *Handler) SettingsLibraryCreate(c *gin.Context) {
 		return
 	}
 	name := strings.TrimSpace(body.Name)
+	kind := service.LibraryKind(strings.TrimSpace(body.Kind))
 	path := strings.TrimRight(strings.TrimSpace(body.Path), "/")
 	if name == "" {
 		writeError(c, http.StatusBadRequest, "name is required")
 		return
 	}
-	if path == "" {
-		writeError(c, http.StatusBadRequest, "path is required")
+	// path is required for local libraries but optional for s3 libraries.
+	if kind != service.LibraryKindS3 && path == "" {
+		writeError(c, http.StatusBadRequest, "path is required for local libraries")
 		return
 	}
 
-	lib, err := h.lib.Create(c.Request.Context(), name, path)
+	lib, err := h.lib.Create(c.Request.Context(), name, kind, path)
 	if err != nil {
 		switch {
 		case errors.Is(err, repo.ErrLibraryNameTaken):
 			writeError(c, http.StatusConflict, "a library with that name already exists")
 		case errors.Is(err, repo.ErrLibraryPathTaken):
 			writeError(c, http.StatusConflict, "that filesystem path is already bound to another library")
+		case errors.Is(err, service.ErrS3NotConfigured):
+			writeError(c, http.StatusBadRequest, err.Error())
 		default:
 			writeServerError(c, "settings library create", err)
 		}

--- a/internal/repo/file_test.go
+++ b/internal/repo/file_test.go
@@ -23,7 +23,7 @@ func TestFileRepo_matrix(t *testing.T) {
 			ctx := context.Background()
 
 			// Seed a library that files can reference.
-			lib, err := lr.CreateLibrary(ctx, "Test Library", "test-library", "/tmp/test")
+			lib, err := lr.CreateLibrary(ctx, "Test Library", "test-library", "/tmp/test", nil)
 			if err != nil {
 				t.Fatalf("CreateLibrary: %v", err)
 			}
@@ -313,7 +313,7 @@ func TestFileRepo_matrix(t *testing.T) {
 			}
 
 			// --- 12. ListByLibrary isolation ---
-			lib2, err := lr.CreateLibrary(ctx, "Other Library", "other-library", "/tmp/other")
+			lib2, err := lr.CreateLibrary(ctx, "Other Library", "other-library", "/tmp/other", nil)
 			if err != nil {
 				t.Fatalf("CreateLibrary lib2: %v", err)
 			}

--- a/internal/repo/library.go
+++ b/internal/repo/library.go
@@ -110,26 +110,39 @@ const libColsReturning = `
 `
 
 // CreateLibrary inserts a new library row and returns the persisted
-// record. `slug` is UNIQUE (000001) and `path` is UNIQUE (000018) — a
-// collision on either surfaces as a typed sentinel (ErrLibraryNameTaken
-// or ErrLibraryPathTaken) so the handler can map it to a 409.
+// record. `slug` is UNIQUE (000001) and `path` is UNIQUE (000018, partial
+// — excludes empty strings so multiple s3 libraries with empty path don't
+// collide) — a collision on either surfaces as a typed sentinel
+// (ErrLibraryNameTaken or ErrLibraryPathTaken) so the handler can map it
+// to a 409.
+//
+// backendID == nil → INSERT with NULL backend_id (local libraries).
+// backendID != nil → INSERT with that value; path should be "".
+// root for s3 libraries is empty (the backend has the prefix encoded);
+// root for local libraries equals path.
 //
 // UUID is generated app-side via db.NewID() so the same INSERT works on
 // both Postgres (UUID column) and SQLite (TEXT column).
-func (r *LibraryRepo) CreateLibrary(ctx context.Context, name, slug, path string) (model.Library, error) {
+func (r *LibraryRepo) CreateLibrary(ctx context.Context, name, slug, path string, backendID *string) (model.Library, error) {
 	id := db.NewID()
+	// root mirrors path for local libraries; empty for s3 libraries (the
+	// backend already encodes the prefix).
+	root := path
+	if backendID != nil {
+		root = ""
+	}
 	const qPG = `
-		INSERT INTO libraries (id, name, slug, path)
-		VALUES ($1, $2, $3, $4)
+		INSERT INTO libraries (id, name, slug, path, backend_id, root)
+		VALUES ($1, $2, $3, $4, $5, $6)
 		RETURNING ` + libColsReturning
 
 	const qSQLite = `
-		INSERT INTO libraries (id, name, slug, path)
-		VALUES (?, ?, ?, ?)
+		INSERT INTO libraries (id, name, slug, path, backend_id, root)
+		VALUES (?, ?, ?, ?, ?, ?)
 		RETURNING ` + libColsReturning
 
 	row := r.db.SQL.QueryRowContext(ctx, db.SelectQ(r.db.Dialect, qPG, qSQLite),
-		id, name, slug, path)
+		id, name, slug, path, backendID, root)
 	l, err := r.scanLibrary(row)
 	if err != nil {
 		if ok, constraint := dberr.IsUniqueViolation(err); ok {

--- a/internal/repo/library_test.go
+++ b/internal/repo/library_test.go
@@ -25,15 +25,17 @@ func TestLibraryRepo_backendFields(t *testing.T) {
 			ctx := context.Background()
 
 			// 1. Fresh library has nil BackendID and nil Root; OrgMode defaults to 'book_per_folder'.
-			lib, err := lr.CreateLibrary(ctx, "Backend Test", "backend-test", "/tmp/bt")
+			lib, err := lr.CreateLibrary(ctx, "Backend Test", "backend-test", "/tmp/bt", nil)
 			if err != nil {
 				t.Fatalf("CreateLibrary: %v", err)
 			}
 			if lib.BackendID != nil {
 				t.Fatalf("BackendID should be nil on fresh library, got %v", lib.BackendID)
 			}
-			if lib.Root != nil {
-				t.Fatalf("Root should be nil on fresh library, got %v", lib.Root)
+			// Root equals path for local libraries (plan spec: "root for local
+			// libraries equals path").
+			if lib.Root == nil || *lib.Root != "/tmp/bt" {
+				t.Fatalf("Root should be /tmp/bt on fresh local library, got %v", lib.Root)
 			}
 			if lib.OrgMode != "book_per_folder" {
 				t.Fatalf("OrgMode=%q want book_per_folder", lib.OrgMode)
@@ -87,7 +89,7 @@ func TestLibraryRepo_setCoverHash(t *testing.T) {
 			r := repo.NewLibraryRepo(d)
 			ctx := context.Background()
 
-			lib, err := r.CreateLibrary(ctx, "Cover Test", "cover-test", "/tmp/ct")
+			lib, err := r.CreateLibrary(ctx, "Cover Test", "cover-test", "/tmp/ct", nil)
 			if err != nil {
 				t.Fatalf("CreateLibrary: %v", err)
 			}
@@ -162,7 +164,7 @@ func TestLibraryRepo_matrix(t *testing.T) {
 			ctx := context.Background()
 
 			// 1. Create
-			lib, err := r.CreateLibrary(ctx, "My Library", "my-library", "/tmp/books")
+			lib, err := r.CreateLibrary(ctx, "My Library", "my-library", "/tmp/books", nil)
 			if err != nil {
 				t.Fatalf("CreateLibrary: %v", err)
 			}
@@ -192,7 +194,7 @@ func TestLibraryRepo_matrix(t *testing.T) {
 			}
 
 			// 4. Duplicate slug → ErrLibraryNameTaken
-			_, err = r.CreateLibrary(ctx, "Other Name", "my-library", "/tmp/different")
+			_, err = r.CreateLibrary(ctx, "Other Name", "my-library", "/tmp/different", nil)
 			if !errors.Is(err, repo.ErrLibraryNameTaken) {
 				t.Fatalf("dup slug: got err=%v, want ErrLibraryNameTaken", err)
 			}

--- a/internal/repo/storage_backend_test.go
+++ b/internal/repo/storage_backend_test.go
@@ -81,7 +81,7 @@ func TestStorageBackendRepo_matrix(t *testing.T) {
 				t.Fatalf("Create b2: %v", err)
 			}
 			// Create a library that points at b2.
-			lib, err := lr.CreateLibrary(ctx, "Ref Library", "ref-library", "/tmp/ref")
+			lib, err := lr.CreateLibrary(ctx, "Ref Library", "ref-library", "/tmp/ref", nil)
 			if err != nil {
 				t.Fatalf("CreateLibrary: %v", err)
 			}

--- a/internal/scan/reattach_test.go
+++ b/internal/scan/reattach_test.go
@@ -22,11 +22,11 @@ func setupReattach(t *testing.T) (*repo.FileRepo, string, string) {
 	lr := repo.NewLibraryRepo(d)
 	ctx := context.Background()
 
-	lib1, err := lr.CreateLibrary(ctx, "Library One", "lib-one", "/tmp/lib1")
+	lib1, err := lr.CreateLibrary(ctx, "Library One", "lib-one", "/tmp/lib1", nil)
 	if err != nil {
 		t.Fatalf("CreateLibrary lib1: %v", err)
 	}
-	lib2, err := lr.CreateLibrary(ctx, "Library Two", "lib-two", "/tmp/lib2")
+	lib2, err := lr.CreateLibrary(ctx, "Library Two", "lib-two", "/tmp/lib2", nil)
 	if err != nil {
 		t.Fatalf("CreateLibrary lib2: %v", err)
 	}

--- a/internal/service/library.go
+++ b/internal/service/library.go
@@ -2,32 +2,106 @@ package service
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
 	"strings"
 
+	"github.com/blackforge/embookshelf/internal/config"
 	"github.com/blackforge/embookshelf/internal/model"
 	"github.com/blackforge/embookshelf/internal/repo"
+	"github.com/blackforge/embookshelf/internal/storage"
 )
+
+// LibraryKind selects the storage flavour for a new library.
+type LibraryKind string
+
+const (
+	LibraryKindLocal LibraryKind = "local"
+	LibraryKindS3    LibraryKind = "s3"
+)
+
+// ErrS3NotConfigured is returned when the caller requests kind=s3 but
+// EMBOOKSHELF_S3_BUCKET is not set in the environment.
+var ErrS3NotConfigured = errors.New("s3 libraries require EMBOOKSHELF_S3_BUCKET to be set")
+
+// LibraryServiceDeps groups the optional deps the service needs beyond its
+// repo. Used to keep the constructor stable across callers.
+type LibraryServiceDeps struct {
+	Backends *repo.StorageBackendRepo
+	SharedS3 config.SharedS3Config
+	// Resolver is used during purge to iterate and delete objects under the
+	// library's backend prefix. May be nil — purge is skipped when nil.
+	Resolver storage.Resolver
+	// Dialect is the DB dialect (postgres | sqlite). Used to guard s3
+	// library creation on SQLite installs where storageloader refuses to
+	// build s3 backends.
+	Dialect config.Dialect
+}
 
 type LibraryService struct {
 	repo *repo.LibraryRepo
+	deps LibraryServiceDeps
 }
 
-func NewLibraryService(r *repo.LibraryRepo) *LibraryService {
-	return &LibraryService{repo: r}
+func NewLibraryService(r *repo.LibraryRepo, deps LibraryServiceDeps) *LibraryService {
+	return &LibraryService{repo: r, deps: deps}
 }
 
 func (s *LibraryService) List(ctx context.Context) ([]model.Library, error) {
 	return s.repo.List(ctx)
 }
 
-// Create inserts a new library row bound to a single filesystem path.
-// The slug is derived from the name. Uniqueness is enforced at the DB
-// layer for both slug and path; the repo surfaces typed sentinels the
-// handler maps to a 409.
-func (s *LibraryService) Create(ctx context.Context, name, path string) (model.Library, error) {
+// Create inserts a new library. Kind selects the storage flavour:
+//
+//   - local (or ""): path is required, names a filesystem directory. No
+//     backend row is created; backend_id stays NULL and the loader falls
+//     back to the LocalFS-at-/ default.
+//   - s3: path is ignored; the service derives prefix = libraries/{slug}/,
+//     INSERTs a storage_backends row from cfg.SharedS3, and points the
+//     library at that backend.
+func (s *LibraryService) Create(ctx context.Context, name string, kind LibraryKind, path string) (model.Library, error) {
 	name = strings.TrimSpace(name)
-	path = strings.TrimRight(strings.TrimSpace(path), "/")
-	return s.repo.CreateLibrary(ctx, name, slugify(name), path, nil)
+	slug := slugify(name)
+
+	switch kind {
+	case "", LibraryKindLocal:
+		path = strings.TrimRight(strings.TrimSpace(path), "/")
+		return s.repo.CreateLibrary(ctx, name, slug, path, nil)
+
+	case LibraryKindS3:
+		if s.deps.Dialect == config.DialectSQLite {
+			return model.Library{}, errors.New("s3 libraries are not supported on SQLite installs")
+		}
+		if !s.deps.SharedS3.Configured() {
+			return model.Library{}, ErrS3NotConfigured
+		}
+		prefix := "libraries/" + slug + "/"
+		cfg := map[string]any{
+			"bucket":            s.deps.SharedS3.Bucket,
+			"region":            s.deps.SharedS3.Region,
+			"endpoint":          s.deps.SharedS3.Endpoint,
+			"prefix":            prefix,
+			"access_key_id":     s.deps.SharedS3.AccessKeyID,
+			"secret_access_key": s.deps.SharedS3.SecretAccessKey,
+			"force_path_style":  s.deps.SharedS3.ForcePathStyle,
+		}
+		backend, err := s.deps.Backends.Create(ctx, "s3", cfg)
+		if err != nil {
+			return model.Library{}, fmt.Errorf("create s3 backend row: %w", err)
+		}
+		lib, err := s.repo.CreateLibrary(ctx, name, slug, "", &backend.ID)
+		if err != nil {
+			// Best-effort cleanup of the orphaned backend row.
+			_ = s.deps.Backends.Delete(ctx, backend.ID)
+			return model.Library{}, err
+		}
+		return lib, nil
+
+	default:
+		return model.Library{}, fmt.Errorf("unknown library kind %q", kind)
+	}
 }
 
 // TouchScan stamps the library row with scan-completion aggregates.
@@ -40,13 +114,64 @@ func (s *LibraryService) GetByID(ctx context.Context, id string) (model.Library,
 	return s.repo.GetByID(ctx, id)
 }
 
-// DeleteLibrary removes a library row and cascades through books,
-// library_paths, and per-book user data via FK ON DELETE CASCADE.
-// Returns the list of book IDs that were transitively deleted so the
-// caller can clean up their cover-image files — those live outside the
-// DB and won't go away on their own.
-func (s *LibraryService) DeleteLibrary(ctx context.Context, id string) ([]string, error) {
-	return s.repo.DeleteLibrary(ctx, id)
+// DeleteLibrary removes a library row. When purge is true and the library
+// is backed by an s3 backend, also strips every object under the backend's
+// prefix. The backend row is deleted last; failures during purge are logged
+// but the response still succeeds. Purge errors are non-fatal because the
+// DB row is already gone and the operator can clean the bucket manually.
+func (s *LibraryService) DeleteLibrary(ctx context.Context, id string, purge bool) ([]string, error) {
+	lib, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	bookIDs, err := s.repo.DeleteLibrary(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if purge && lib.BackendID != nil {
+		s.purgeBackend(ctx, *lib.BackendID)
+	}
+	return bookIDs, nil
+}
+
+// purgeBackend iterates the s3 backend prefix and deletes every object,
+// then drops the backend row. Errors are logged and not returned — the
+// library row is already gone, so the prefix may need manual cleanup.
+func (s *LibraryService) purgeBackend(ctx context.Context, backendID string) {
+	if s.deps.Resolver == nil {
+		return
+	}
+	store, err := s.deps.Resolver.Resolve(backendID)
+	if err != nil {
+		slog.Warn("library purge: resolve backend", "id", backendID, "err", err)
+		return
+	}
+	it, err := store.List(ctx, "")
+	if err != nil {
+		slog.Warn("library purge: list", "id", backendID, "err", err)
+		return
+	}
+	defer func() { _ = it.Close() }()
+	for {
+		obj, err := it.Next(ctx)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			slog.Warn("library purge: iterate", "id", backendID, "err", err)
+			break
+		}
+		if err := store.Delete(ctx, obj.Key); err != nil {
+			slog.Warn("library purge: delete", "key", obj.Key, "err", err)
+			continue
+		}
+	}
+	// Drop the backend row so future reads through Resolver don't
+	// hit a stale config. ErrStorageBackendInUse should not fire here
+	// because the library row is already gone.
+	if err := s.deps.Backends.Delete(ctx, backendID); err != nil {
+		slog.Warn("library purge: delete backend row", "id", backendID, "err", err)
+	}
 }
 
 // SetFileNamingPattern stores (or clears) the per-library template used by

--- a/internal/service/library.go
+++ b/internal/service/library.go
@@ -27,7 +27,7 @@ func (s *LibraryService) List(ctx context.Context) ([]model.Library, error) {
 func (s *LibraryService) Create(ctx context.Context, name, path string) (model.Library, error) {
 	name = strings.TrimSpace(name)
 	path = strings.TrimRight(strings.TrimSpace(path), "/")
-	return s.repo.CreateLibrary(ctx, name, slugify(name), path)
+	return s.repo.CreateLibrary(ctx, name, slugify(name), path, nil)
 }
 
 // TouchScan stamps the library row with scan-completion aggregates.

--- a/internal/service/library_test.go
+++ b/internal/service/library_test.go
@@ -1,0 +1,139 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/blackforge/embookshelf/internal/config"
+	"github.com/blackforge/embookshelf/internal/repo"
+	"github.com/blackforge/embookshelf/internal/repo/repotest"
+	"github.com/blackforge/embookshelf/internal/service"
+)
+
+// newLibSvc is a helper that wires up a LibraryService backed by the
+// provided test DB. deps.Resolver is intentionally left nil (purge
+// tests will override it in their own helper).
+func newLibSvc(t *testing.T, dialect string, deps service.LibraryServiceDeps) *service.LibraryService {
+	t.Helper()
+	d := repotest.NewWithDialect(t, dialect)
+	lr := repo.NewLibraryRepo(d)
+	br := repo.NewStorageBackendRepo(d)
+	deps.Backends = br
+	deps.Dialect = config.Dialect(dialect)
+	return service.NewLibraryService(lr, deps)
+}
+
+// TestLibraryService_Create_local verifies that creating a local library
+// sets path + nil BackendID, and that kind="" defaults to local.
+func TestLibraryService_Create_local(t *testing.T) {
+	for _, dialect := range []string{"sqlite", "postgres"} {
+		dialect := dialect
+		t.Run(dialect, func(t *testing.T) {
+			svc := newLibSvc(t, dialect, service.LibraryServiceDeps{})
+			ctx := context.Background()
+
+			lib, err := svc.Create(ctx, "My Fiction", service.LibraryKindLocal, "/tmp/fiction")
+			if err != nil {
+				t.Fatalf("Create local: %v", err)
+			}
+			if lib.Path != "/tmp/fiction" {
+				t.Errorf("Path=%q want /tmp/fiction", lib.Path)
+			}
+			if lib.BackendID != nil {
+				t.Errorf("BackendID should be nil for local library, got %v", lib.BackendID)
+			}
+			if lib.Slug != "my-fiction" {
+				t.Errorf("Slug=%q want my-fiction", lib.Slug)
+			}
+		})
+	}
+}
+
+// TestLibraryService_Create_emptyKind verifies that kind="" defaults to local.
+func TestLibraryService_Create_emptyKind(t *testing.T) {
+	for _, dialect := range []string{"sqlite", "postgres"} {
+		dialect := dialect
+		t.Run(dialect, func(t *testing.T) {
+			svc := newLibSvc(t, dialect, service.LibraryServiceDeps{})
+			ctx := context.Background()
+
+			lib, err := svc.Create(ctx, "Classics", "", "/tmp/classics")
+			if err != nil {
+				t.Fatalf("Create empty kind: %v", err)
+			}
+			if lib.BackendID != nil {
+				t.Errorf("BackendID should be nil for default (local) library, got %v", lib.BackendID)
+			}
+		})
+	}
+}
+
+// TestLibraryService_Create_s3_notConfigured verifies that requesting
+// kind=s3 without a bucket returns ErrS3NotConfigured.
+func TestLibraryService_Create_s3_notConfigured(t *testing.T) {
+	// Use postgres dialect to bypass the SQLite guard.
+	svc := newLibSvc(t, "postgres", service.LibraryServiceDeps{
+		// SharedS3 has empty Bucket → Configured() == false.
+	})
+	ctx := context.Background()
+
+	_, err := svc.Create(ctx, "S3 Lib", service.LibraryKindS3, "")
+	if !errors.Is(err, service.ErrS3NotConfigured) {
+		t.Fatalf("got err=%v, want ErrS3NotConfigured", err)
+	}
+}
+
+// TestLibraryService_Create_s3_sqliteGuard verifies that creating an s3
+// library on a SQLite install returns an error.
+func TestLibraryService_Create_s3_sqliteGuard(t *testing.T) {
+	svc := newLibSvc(t, "sqlite", service.LibraryServiceDeps{
+		SharedS3: config.SharedS3Config{Bucket: "test-bucket", Region: "us-east-1"},
+	})
+	ctx := context.Background()
+
+	_, err := svc.Create(ctx, "S3 Lib", service.LibraryKindS3, "")
+	if err == nil {
+		t.Fatal("expected error creating s3 library on SQLite, got nil")
+	}
+}
+
+// TestLibraryService_Create_s3_configured verifies that when the shared
+// bucket is set and the dialect is postgres, Create allocates a backend row
+// and a library row pointing to it.
+func TestLibraryService_Create_s3_configured(t *testing.T) {
+	svc := newLibSvc(t, "postgres", service.LibraryServiceDeps{
+		SharedS3: config.SharedS3Config{
+			Bucket: "my-bucket",
+			Region: "us-east-1",
+		},
+	})
+	ctx := context.Background()
+
+	lib, err := svc.Create(ctx, "Sci Fi", service.LibraryKindS3, "")
+	if err != nil {
+		t.Fatalf("Create s3: %v", err)
+	}
+	if lib.BackendID == nil {
+		t.Fatal("BackendID should be non-nil for s3 library")
+	}
+	if lib.Path != "" {
+		t.Errorf("Path should be empty for s3 library, got %q", lib.Path)
+	}
+	// Slug should be derived from name.
+	if lib.Slug != "sci-fi" {
+		t.Errorf("Slug=%q want sci-fi", lib.Slug)
+	}
+}
+
+// TestLibraryService_Create_unknownKind verifies that an unrecognised kind
+// returns an error.
+func TestLibraryService_Create_unknownKind(t *testing.T) {
+	svc := newLibSvc(t, "sqlite", service.LibraryServiceDeps{})
+	ctx := context.Background()
+
+	_, err := svc.Create(ctx, "Bad Kind", "nfs", "/tmp/bad")
+	if err == nil {
+		t.Fatal("expected error for unknown kind, got nil")
+	}
+}

--- a/internal/task/covers_backfill_test.go
+++ b/internal/task/covers_backfill_test.go
@@ -42,7 +42,7 @@ func createBookWithLegacyCover(
 	t.Helper()
 	ctx := context.Background()
 
-	lib, err := lr.CreateLibrary(ctx, "Cover Backfill Lib", "cover-backfill-lib", "/tmp/cbl")
+	lib, err := lr.CreateLibrary(ctx, "Cover Backfill Lib", "cover-backfill-lib", "/tmp/cbl", nil)
 	if err != nil {
 		t.Fatalf("CreateLibrary: %v", err)
 	}
@@ -129,7 +129,7 @@ func TestRunCoversBackfill_missingLegacyFileSkipped(t *testing.T) {
 	deps, lr, _ := newCoversBackfillDeps(t)
 	ctx := context.Background()
 
-	lib, err := lr.CreateLibrary(ctx, "Skip Lib", "skip-lib", "/tmp/sl")
+	lib, err := lr.CreateLibrary(ctx, "Skip Lib", "skip-lib", "/tmp/sl", nil)
 	if err != nil {
 		t.Fatalf("CreateLibrary: %v", err)
 	}

--- a/internal/task/files_backfill_test.go
+++ b/internal/task/files_backfill_test.go
@@ -42,7 +42,7 @@ func newTestDeps(t *testing.T) (task.FilesBackfillDeps, *repo.LibraryRepo) {
 // file locations against that directory.
 func seedLibrary(t *testing.T, lr *repo.LibraryRepo, tmpDir string) model.Library {
 	t.Helper()
-	lib, err := lr.CreateLibrary(context.Background(), "Test Library", "test-lib", tmpDir)
+	lib, err := lr.CreateLibrary(context.Background(), "Test Library", "test-lib", tmpDir, nil)
 	if err != nil {
 		t.Fatalf("CreateLibrary: %v", err)
 	}

--- a/internal/task/missing_purge_test.go
+++ b/internal/task/missing_purge_test.go
@@ -55,7 +55,7 @@ func TestRunMissingPurge_nilFiles(t *testing.T) {
 func TestRunMissingPurge_noMissingRows(t *testing.T) {
 	fr, lr := newPurgeTestRepo(t)
 	ctx := context.Background()
-	lib, err := lr.CreateLibrary(ctx, "Purge Test", "purge-test", "/tmp/purge")
+	lib, err := lr.CreateLibrary(ctx, "Purge Test", "purge-test", "/tmp/purge", nil)
 	if err != nil {
 		t.Fatalf("CreateLibrary: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestRunMissingPurge_noMissingRows(t *testing.T) {
 func TestRunMissingPurge_withinTTL(t *testing.T) {
 	fr, lr := newPurgeTestRepo(t)
 	ctx := context.Background()
-	lib, err := lr.CreateLibrary(ctx, "Purge Test TTL", "purge-ttl", "/tmp/purge-ttl")
+	lib, err := lr.CreateLibrary(ctx, "Purge Test TTL", "purge-ttl", "/tmp/purge-ttl", nil)
 	if err != nil {
 		t.Fatalf("CreateLibrary: %v", err)
 	}
@@ -117,7 +117,7 @@ func TestRunMissingPurge_withinTTL(t *testing.T) {
 func TestRunMissingPurge_beyondTTL(t *testing.T) {
 	fr, lr := newPurgeTestRepo(t)
 	ctx := context.Background()
-	lib, err := lr.CreateLibrary(ctx, "Purge Test Old", "purge-old", "/tmp/purge-old")
+	lib, err := lr.CreateLibrary(ctx, "Purge Test Old", "purge-old", "/tmp/purge-old", nil)
 	if err != nil {
 		t.Fatalf("CreateLibrary: %v", err)
 	}
@@ -148,7 +148,7 @@ func TestRunMissingPurge_beyondTTL(t *testing.T) {
 func TestRunMissingPurge_mixed(t *testing.T) {
 	fr, lr := newPurgeTestRepo(t)
 	ctx := context.Background()
-	lib, err := lr.CreateLibrary(ctx, "Purge Test Mix", "purge-mix", "/tmp/purge-mix")
+	lib, err := lr.CreateLibrary(ctx, "Purge Test Mix", "purge-mix", "/tmp/purge-mix", nil)
 	if err != nil {
 		t.Fatalf("CreateLibrary: %v", err)
 	}
@@ -198,7 +198,7 @@ func TestLoopMissingPurge_nilFiles(t *testing.T) {
 func TestLoopMissingPurge_cancellation(t *testing.T) {
 	fr, lr := newPurgeTestRepo(t)
 	ctx := context.Background()
-	lib, err := lr.CreateLibrary(ctx, "Loop Test", "loop-test", "/tmp/loop-test")
+	lib, err := lr.CreateLibrary(ctx, "Loop Test", "loop-test", "/tmp/loop-test", nil)
 	if err != nil {
 		t.Fatalf("CreateLibrary: %v", err)
 	}

--- a/internal/task/s3events_test.go
+++ b/internal/task/s3events_test.go
@@ -107,7 +107,7 @@ func TestS3EventLoop_ObjectCreated_Insert(t *testing.T) {
 	fr, lr := newEventTestRepo(t)
 	ctx := context.Background()
 
-	lib, err := lr.CreateLibrary(ctx, "Lib", "lib", "/tmp/lib")
+	lib, err := lr.CreateLibrary(ctx, "Lib", "lib", "/tmp/lib", nil)
 	if err != nil {
 		t.Fatalf("CreateLibrary: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestS3EventLoop_ObjectRemoved_MarkMissing(t *testing.T) {
 	fr, lr := newEventTestRepo(t)
 	ctx := context.Background()
 
-	lib, err := lr.CreateLibrary(ctx, "Lib2", "lib2", "/tmp/lib2")
+	lib, err := lr.CreateLibrary(ctx, "Lib2", "lib2", "/tmp/lib2", nil)
 	if err != nil {
 		t.Fatalf("CreateLibrary: %v", err)
 	}
@@ -195,7 +195,7 @@ func TestS3EventLoop_ObjectRemoved_UnknownFile(t *testing.T) {
 	fr, lr := newEventTestRepo(t)
 	ctx := context.Background()
 
-	lib, err := lr.CreateLibrary(ctx, "Lib3", "lib3", "/tmp/lib3")
+	lib, err := lr.CreateLibrary(ctx, "Lib3", "lib3", "/tmp/lib3", nil)
 	if err != nil {
 		t.Fatalf("CreateLibrary: %v", err)
 	}
@@ -231,7 +231,7 @@ func TestS3EventLoop_ObjectCreated_ClearMissing(t *testing.T) {
 	fr, lr := newEventTestRepo(t)
 	ctx := context.Background()
 
-	lib, err := lr.CreateLibrary(ctx, "Lib4", "lib4", "/tmp/lib4")
+	lib, err := lr.CreateLibrary(ctx, "Lib4", "lib4", "/tmp/lib4", nil)
 	if err != nil {
 		t.Fatalf("CreateLibrary: %v", err)
 	}
@@ -282,7 +282,7 @@ func TestS3EventLoop_EmptyRecords(t *testing.T) {
 	fr, lr := newEventTestRepo(t)
 	ctx := context.Background()
 
-	_, err := lr.CreateLibrary(ctx, "Lib5", "lib5", "/tmp/lib5")
+	_, err := lr.CreateLibrary(ctx, "Lib5", "lib5", "/tmp/lib5", nil)
 	if err != nil {
 		t.Fatalf("CreateLibrary: %v", err)
 	}

--- a/ui/src/api/settings.ts
+++ b/ui/src/api/settings.ts
@@ -22,16 +22,23 @@ export async function fetchSettingsLibraries(): Promise<
   return libraries
 }
 
-export async function createLibrary(body: {
+export type LibraryKind = "local" | "s3"
+
+export type CreateLibraryInput = {
   name: string
-  path: string
+  kind: LibraryKind
+  path?: string // required for kind='local'; omitted for 's3'
   scan?: boolean
-}): Promise<SettingsLibrary> {
+}
+
+export async function createLibrary(
+  input: CreateLibraryInput
+): Promise<SettingsLibrary> {
   const { library } = await api<{ library: SettingsLibrary }>(
     "/api/v1/settings/libraries",
     {
       method: "POST",
-      body: JSON.stringify(body),
+      body: JSON.stringify(input),
     }
   )
   return library
@@ -53,8 +60,14 @@ export async function prescanLibraryPaths(
 // deleteLibrary tears down a library and every book/annotation/etc
 // that depends on it. Source files on disk are left alone (they live
 // under the user-managed root); cover images and DB rows are removed.
-export async function deleteLibrary(id: string): Promise<void> {
-  await api<void>(`/api/v1/settings/libraries/${id}`, {
+// When opts.purge is true and the library is backed by an S3 backend,
+// all objects under the library's prefix are also deleted.
+export async function deleteLibrary(
+  id: string,
+  opts?: { purge?: boolean }
+): Promise<void> {
+  const qs = opts?.purge ? "?purge=true" : ""
+  await api<void>(`/api/v1/settings/libraries/${id}${qs}`, {
     method: "DELETE",
   })
 }
@@ -142,6 +155,17 @@ export const defaultNamingPatternQueryKey = [
 ] as const
 
 export const settingsLibrariesQueryKey = ["settings", "libraries"] as const
+
+// AppConfig is the lightweight feature-flag payload from GET /api/v1/config.
+export type AppConfig = {
+  s3Available: boolean
+}
+
+export async function fetchAppConfig(): Promise<AppConfig> {
+  return api<AppConfig>("/api/v1/config")
+}
+
+export const appConfigQueryKey = ["app", "config"] as const
 
 // --- Instance info ---------------------------------------------------------
 

--- a/ui/src/routes/_app.settings.tsx
+++ b/ui/src/routes/_app.settings.tsx
@@ -6,6 +6,7 @@ import type { CSSProperties, ReactNode } from "react"
 
 import type { ApiError } from "@/api/client"
 import type {
+  LibraryKind,
   MetadataSettings,
   ProviderConfigField,
   ProviderInfo,
@@ -20,12 +21,14 @@ import type {
 } from "@/api/oidc"
 import type { AuthUser } from "@/api/auth"
 import {
+  appConfigQueryKey,
   approveSettingsUser,
   createLibrary,
   createSettingsUser,
   deleteLibrary,
   deleteSettingsUser,
   denySettingsUser,
+  fetchAppConfig,
   fetchInstanceInfo,
   fetchMetadataSettings,
   fetchProviderSettings,
@@ -178,6 +181,11 @@ function LibrariesPanel({ isAdmin }: { isAdmin: boolean }) {
     enabled: isAdmin,
   })
 
+  const appConfig = useQuery({
+    queryKey: appConfigQueryKey,
+    queryFn: fetchAppConfig,
+  })
+
   const invalidate = () => {
     queryClient.invalidateQueries({ queryKey: settingsLibrariesQueryKey })
     queryClient.invalidateQueries({ queryKey: ["libraries"] })
@@ -192,7 +200,8 @@ function LibrariesPanel({ isAdmin }: { isAdmin: boolean }) {
     onError: (e) => toast.error((e as unknown as ApiError).message),
   })
   const deleteLibraryMut = useMutation({
-    mutationFn: (id: string) => deleteLibrary(id),
+    mutationFn: ({ id, purge }: { id: string; purge: boolean }) =>
+      deleteLibrary(id, { purge }),
     onSuccess: () => {
       invalidate()
       toast.success("Library removed.")
@@ -240,7 +249,9 @@ function LibrariesPanel({ isAdmin }: { isAdmin: boolean }) {
           rescanBusy={rescanMut.isPending}
           deleteBusy={deleteLibraryMut.isPending}
           onRescan={() => rescanMut.mutate(lib.id)}
-          onDeleteLibrary={() => deleteLibraryMut.mutate(lib.id)}
+          onDeleteLibrary={(purge) =>
+            deleteLibraryMut.mutate({ id: lib.id, purge })
+          }
         />
       ))}
 
@@ -248,6 +259,7 @@ function LibrariesPanel({ isAdmin }: { isAdmin: boolean }) {
         open={creatorOpen}
         onOpenChange={setCreatorOpen}
         existingNames={existingNames}
+        s3Available={appConfig.data?.s3Available ?? false}
         onCreated={() => {
           invalidate()
           setCreatorOpen(false)
@@ -261,19 +273,41 @@ type LibraryCreatorDialogProps = {
   open: boolean
   onOpenChange: (open: boolean) => void
   existingNames: Array<string>
+  s3Available: boolean
   onCreated: () => void
+}
+
+// slugify mirrors the Go service implementation so the prefix preview is
+// consistent with what the server will derive.
+function slugify(name: string): string {
+  const lower = name.toLowerCase()
+  let slug = ""
+  let dash = true
+  for (const ch of lower) {
+    if (/[a-z0-9]/.test(ch)) {
+      slug += ch
+      dash = false
+    } else if (!dash) {
+      slug += "-"
+      dash = true
+    }
+  }
+  return slug.replace(/^-+|-+$/g, "")
 }
 
 // Modeled after spec/library-creation.spec.md §3 + §4. Embookshelf's library
 // model is simpler than BookLore's (no icon/watch/format policy yet), so the
-// form collapses to name + paths + an opt-in "scan immediately" toggle.
+// form collapses to name + kind selector + paths + an opt-in "scan immediately"
+// toggle.
 function LibraryCreatorDialog({
   open,
   onOpenChange,
   existingNames,
+  s3Available,
   onCreated,
 }: LibraryCreatorDialogProps) {
   const [name, setName] = useState("")
+  const [kind, setKind] = useState<LibraryKind>("local")
   const [path, setPath] = useState("")
   const [scanOnCreate, setScanOnCreate] = useState(true)
   const [prescan, setPrescan] = useState<{
@@ -287,6 +321,7 @@ function LibraryCreatorDialog({
     // Prop→state sync on close; not a cascading render.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setName("")
+    setKind("local")
     setPath("")
     setScanOnCreate(true)
     setPrescan(null)
@@ -298,7 +333,13 @@ function LibraryCreatorDialog({
     (existing) => existing.toLowerCase() === trimmedName.toLowerCase()
   )
   const nameValid = trimmedName !== "" && !nameCollision
-  const pathValid = trimmedPath !== ""
+  // path is required only for local libraries
+  const pathValid = kind === "s3" || trimmedPath !== ""
+
+  const derivedPrefix =
+    kind === "s3" && trimmedName !== ""
+      ? `libraries/${slugify(trimmedName)}/`
+      : null
 
   const prescanMut = useMutation({
     mutationFn: (value: string) => prescanLibraryPaths([value]),
@@ -309,7 +350,8 @@ function LibraryCreatorDialog({
     mutationFn: () =>
       createLibrary({
         name: trimmedName,
-        path: trimmedPath,
+        kind,
+        path: kind === "s3" ? undefined : trimmedPath,
         scan: scanOnCreate,
       }),
     onSuccess: () => {
@@ -331,9 +373,8 @@ function LibraryCreatorDialog({
         <DialogHeader>
           <DialogTitle>New library</DialogTitle>
           <DialogDescription>
-            Point embookshelf at one folder on disk. Approved books are moved
-            under that folder on accept, renamed via the library&apos;s
-            file-naming pattern. The path is fixed at creation time.
+            Create a new library backed by a local filesystem folder or an S3
+            bucket prefix. The storage choice is fixed at creation time.
           </DialogDescription>
         </DialogHeader>
 
@@ -363,61 +404,152 @@ function LibraryCreatorDialog({
           </div>
 
           <div>
-            <Label
-              htmlFor="lib-path"
-              style={{ display: "block", marginBottom: 6 }}
-            >
-              Folder
-            </Label>
-            <Input
-              id="lib-path"
-              value={path}
-              onChange={(e) => {
-                setPath(e.target.value)
-                setPrescan(null)
-              }}
-              placeholder="/absolute/path/to/books"
-              className="mono text-[12.5px]"
-            />
-            <div
-              className="t-micro"
-              style={{ marginTop: 6, fontStyle: "italic" }}
-            >
-              This folder is fixed once the library is created and cannot be
-              changed later.
+            <Label style={{ display: "block", marginBottom: 6 }}>Storage</Label>
+            <div style={{ display: "flex", gap: 8 }}>
+              <button
+                type="button"
+                onClick={() => setKind("local")}
+                style={{
+                  flex: 1,
+                  padding: "8px 12px",
+                  border: `1px solid ${kind === "local" ? "var(--color-accent)" : "var(--color-rule-soft)"}`,
+                  borderRadius: 4,
+                  background:
+                    kind === "local"
+                      ? "var(--color-accent-subtle)"
+                      : "var(--color-paper-0)",
+                  cursor: "pointer",
+                  textAlign: "left" as const,
+                }}
+              >
+                <div className="t-small" style={{ fontWeight: 500 }}>
+                  Local filesystem
+                </div>
+                <div className="t-micro" style={{ fontStyle: "italic" }}>
+                  Books stored on disk
+                </div>
+              </button>
+              <button
+                type="button"
+                onClick={() => s3Available && setKind("s3")}
+                disabled={!s3Available}
+                title={
+                  s3Available ? undefined : "Set EMBOOKSHELF_S3_BUCKET to enable"
+                }
+                style={{
+                  flex: 1,
+                  padding: "8px 12px",
+                  border: `1px solid ${kind === "s3" ? "var(--color-accent)" : "var(--color-rule-soft)"}`,
+                  borderRadius: 4,
+                  background:
+                    kind === "s3"
+                      ? "var(--color-accent-subtle)"
+                      : "var(--color-paper-0)",
+                  cursor: s3Available ? "pointer" : "not-allowed",
+                  opacity: s3Available ? 1 : 0.5,
+                  textAlign: "left" as const,
+                }}
+              >
+                <div className="t-small" style={{ fontWeight: 500 }}>
+                  S3 bucket
+                </div>
+                <div className="t-micro" style={{ fontStyle: "italic" }}>
+                  {s3Available
+                    ? "Books stored in shared bucket"
+                    : "EMBOOKSHELF_S3_BUCKET not set"}
+                </div>
+              </button>
             </div>
           </div>
 
-          {pathValid && (
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 12,
-                padding: "10px 12px",
-                border: "1px dashed var(--color-rule-soft)",
-                borderRadius: 2,
-              }}
-            >
-              <div className="grow">
-                <div className="t-small" style={{ fontWeight: 500 }}>
-                  Pre-create scan
-                </div>
-                <div className="t-micro" style={{ fontStyle: "italic" }}>
-                  {prescanFresh
-                    ? `${prescan.count.toLocaleString()} supported file${prescan.count === 1 ? "" : "s"} found`
-                    : "Counts files before creation so you can spot typos."}
+          {kind === "local" ? (
+            <>
+              <div>
+                <Label
+                  htmlFor="lib-path"
+                  style={{ display: "block", marginBottom: 6 }}
+                >
+                  Folder
+                </Label>
+                <Input
+                  id="lib-path"
+                  value={path}
+                  onChange={(e) => {
+                    setPath(e.target.value)
+                    setPrescan(null)
+                  }}
+                  placeholder="/absolute/path/to/books"
+                  className="mono text-[12.5px]"
+                />
+                <div
+                  className="t-micro"
+                  style={{ marginTop: 6, fontStyle: "italic" }}
+                >
+                  This folder is fixed once the library is created and cannot be
+                  changed later.
                 </div>
               </div>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => prescanMut.mutate(trimmedPath)}
-                disabled={prescanMut.isPending}
+
+              {pathValid && trimmedPath !== "" && (
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 12,
+                    padding: "10px 12px",
+                    border: "1px dashed var(--color-rule-soft)",
+                    borderRadius: 2,
+                  }}
+                >
+                  <div className="grow">
+                    <div className="t-small" style={{ fontWeight: 500 }}>
+                      Pre-create scan
+                    </div>
+                    <div className="t-micro" style={{ fontStyle: "italic" }}>
+                      {prescanFresh
+                        ? `${prescan.count.toLocaleString()} supported file${prescan.count === 1 ? "" : "s"} found`
+                        : "Counts files before creation so you can spot typos."}
+                    </div>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => prescanMut.mutate(trimmedPath)}
+                    disabled={prescanMut.isPending}
+                  >
+                    {prescanMut.isPending ? "Counting…" : "Count files"}
+                  </Button>
+                </div>
+              )}
+            </>
+          ) : (
+            <div>
+              <Label style={{ display: "block", marginBottom: 6 }}>
+                Bucket prefix (auto-derived)
+              </Label>
+              <div
+                className="mono"
+                style={{
+                  padding: "8px 12px",
+                  background: "var(--color-paper-2)",
+                  borderRadius: 4,
+                  fontSize: 12.5,
+                  color: derivedPrefix
+                    ? "inherit"
+                    : "var(--color-ink-3)",
+                  fontStyle: derivedPrefix ? "normal" : "italic",
+                }}
               >
-                {prescanMut.isPending ? "Counting…" : "Count files"}
-              </Button>
+                {derivedPrefix ?? "Enter a name above to preview"}
+              </div>
+              <div
+                className="t-micro"
+                style={{ marginTop: 6, fontStyle: "italic" }}
+              >
+                Prefix is derived from the library name and cannot be changed
+                later. Files sync to this prefix in the shared bucket.
+              </div>
             </div>
           )}
 
@@ -433,9 +565,7 @@ function LibraryCreatorDialog({
               checked={scanOnCreate}
               onCheckedChange={(v) => setScanOnCreate(Boolean(v))}
             />
-            <span className="t-small">
-              Scan folder immediately after creating
-            </span>
+            <span className="t-small">Scan immediately after creating</span>
           </label>
         </div>
 
@@ -466,7 +596,14 @@ type LibraryCardProps = {
   rescanBusy: boolean
   deleteBusy: boolean
   onRescan: () => void
-  onDeleteLibrary: () => void
+  onDeleteLibrary: (purge: boolean) => void
+}
+
+// isS3Library is a heuristic: s3 libraries have an empty path but a
+// non-empty backend_id. The SettingsLibrary DTO doesn't expose backend_id
+// directly, but we can infer it from the empty path.
+function isS3Library(lib: SettingsLibrary) {
+  return lib.path === ""
 }
 
 function LibraryCard({
@@ -529,9 +666,10 @@ function LibraryCard({
         open={confirmOpen}
         onOpenChange={setConfirmOpen}
         library={library}
+        isS3={isS3Library(library)}
         busy={deleteBusy}
-        onConfirm={() => {
-          onDeleteLibrary()
+        onConfirm={(purge) => {
+          onDeleteLibrary(purge)
           setConfirmOpen(false)
         }}
       />
@@ -596,21 +734,27 @@ function DeleteLibraryDialog({
   open,
   onOpenChange,
   library,
+  isS3,
   busy,
   onConfirm,
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
   library: SettingsLibrary
+  isS3: boolean
   busy: boolean
-  onConfirm: () => void
+  onConfirm: (purge: boolean) => void
 }) {
   const [confirmInput, setConfirmInput] = useState("")
+  const [purge, setPurge] = useState(false)
 
   useEffect(() => {
-    // Reset the typed confirmation on close — prop→state sync.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    if (!open) setConfirmInput("")
+    // Reset the typed confirmation and purge flag on close — prop→state sync.
+    if (!open) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setConfirmInput("")
+      setPurge(false)
+    }
   }, [open])
 
   const matches = confirmInput.trim() === library.name
@@ -623,8 +767,10 @@ function DeleteLibraryDialog({
           <DialogDescription>
             This removes <strong>{library.name}</strong>, all{" "}
             {library.bookCount} book records, their cover images, and every
-            annotation, reading session, and shelf assignment inside it. Source
-            files on disk are left alone.
+            annotation, reading session, and shelf assignment inside it.{" "}
+            {isS3
+              ? "S3 objects are left alone unless you check the purge option below."
+              : "Source files on disk are left alone."}
           </DialogDescription>
         </DialogHeader>
 
@@ -640,6 +786,22 @@ function DeleteLibraryDialog({
           />
         </div>
 
+        {isS3 && (
+          <label
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 10,
+              cursor: "pointer",
+            }}
+          >
+            <Switch checked={purge} onCheckedChange={(v) => setPurge(Boolean(v))} />
+            <span className="t-small">
+              Also delete all files in the S3 bucket prefix
+            </span>
+          </label>
+        )}
+
         <DialogFooter>
           <Button
             type="button"
@@ -652,7 +814,7 @@ function DeleteLibraryDialog({
           <Button
             type="button"
             variant="destructive"
-            onClick={onConfirm}
+            onClick={() => onConfirm(purge)}
             disabled={!matches || busy}
           >
             {busy ? "Deleting…" : "Delete library"}


### PR DESCRIPTION
## Summary

Operator configures one S3 bucket via env (\`EMBOOKSHELF_S3_BUCKET\` + auth). Library creation gains a kind selector — \"Local filesystem\" or \"S3 bucket\". Choosing s3 auto-allocates the prefix \`libraries/{slug}/\`, materializes a \`storage_backends\` row from env, and points the new library at it. Library deletion accepts an optional \"also delete files in the S3 bucket prefix\" toggle that cascade-deletes every object under the prefix.

### What changed

**Config**
- \`EMBOOKSHELF_S3_BUCKET\`, \`_REGION\`, \`_ENDPOINT\`, \`_ACCESS_KEY_ID\`, \`_SECRET_ACCESS_KEY\`, \`_FORCE_PATH_STYLE\` populate a new \`SharedS3Config\` struct. \`Configured()\` flips on bucket non-empty.
- \`.env.example\` replaces the obsolete \"insert a storage_backends row\" doc block (PR #69) with the working env vars.

**API + service**
- \`POST /api/libraries\` accepts \`kind: \"local\" | \"s3\"\` (default \`local\`). For \`s3\`, path is ignored; service inserts a \`storage_backends\` row from \`SharedS3Config\` + computed prefix and a library row pointing at it. Returns \`ErrS3NotConfigured\` (HTTP 400) when bucket isn't set, \`ErrSQLiteIncompatible\` when running on SQLite.
- \`DELETE /api/libraries/:id?purge=true\` cascade-deletes the bucket prefix and the backend row after the library row goes. Default \`purge=false\` is soft-delete.
- New \`GET /api/v1/config\` returns \`{ s3Available: boolean }\` so the UI can pre-emptively enable / disable the s3 option.

**UI**
- Library-create dialog: kind toggle (Local / S3). S3 disabled with tooltip when env not set. For s3 the path field is replaced by a read-only \`libraries/{slug}/\` preview that updates as the user types the name.
- Library-delete dialog: for s3 libraries shows a \"Also delete files in the S3 bucket prefix\" switch; default off.

### What this does NOT change

- **Approve → upload to S3 is still missing.** A user creating an s3 library can't import via the bookdrop yet — the staged file stays in BOOKDROP_PATH. Workaround: \`aws s3 sync\` files into the prefix; library scan picks them up. Real fix is a follow-up plan.
- Migrating an existing local library to s3.
- Per-library credential overrides — the env config is the only knob.
- Settings UI for the shared bucket — env-only by design.

### Why this design

Spec §3.2: \"One bucket per environment, libraries are prefixes.\" The implementation preserves Plan F's per-library backend rows (one row = one prefix) but populates them from env on demand rather than requiring the operator to write JSON into the DB.

## Test plan
- [x] \`make ci-local\` — exit 0; 0 lint, all Go packages pass, UI 42/42, build clean
- [x] \`TestLibraryService_Create_local\` (existing local path)
- [x] \`TestLibraryService_Create_emptyKind\` (kind missing → defaults to local)
- [x] \`TestLibraryService_Create_s3_notConfigured\` → ErrS3NotConfigured
- [x] \`TestLibraryService_Create_s3_sqliteGuard\` → ErrSQLiteIncompatible
- [x] \`TestLibraryService_Create_s3_postgres\` (real backend row inserted, library wired)
- [ ] Manual smoke against a real S3 bucket: set env, create library via UI, \`aws s3 sync\` files in, scan finds them, file-serve presigns, delete with purge=true cleans up

## Plan
\`docs/superpowers/plans/2026-04-30-s3-libraries-via-shared-bucket.md\`.
Spec: \`docs/spec/storage.spec.md\` §3.2.

## Commits

\`\`\`
36a663c docs(plan): S3 libraries via shared bucket
a801796 feat(config): SharedS3Config from EMBOOKSHELF_S3_* env vars
66166df feat(repo): CreateLibrary takes optional backend_id + root
5900ebc feat(service): library Create dispatches by kind (local|s3)
9b62c0b feat(service+handler): library delete with optional ?purge=true
7d451df feat(handler): POST /api/libraries accepts kind field + GET /api/config
c616f06 feat(ui): library create form + delete confirm support s3 kind
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)