### PR TITLE
feat(account): UI for multi-provider OIDC linking (PR-2)

### DIFF
--- a/ui/src/api/account.ts
+++ b/ui/src/api/account.ts
@@ -1,0 +1,43 @@
+import { api } from "./client"
+
+// Mirrors internal/handler/account_identities.go accountIdentitiesDTO.
+export type AccountIdentityProvider = {
+  provider: "google" | "github" | "generic"
+  displayName: string
+  linked: boolean
+  email?: string
+  linkedAt?: string
+  lastLoginAt?: string
+}
+
+export type AccountIdentities = {
+  hasPassword: boolean
+  providers: Array<AccountIdentityProvider>
+}
+
+export const accountIdentitiesQueryKey = ["account-identities"] as const
+
+export async function fetchAccountIdentities(): Promise<AccountIdentities> {
+  return api<AccountIdentities>("/api/v1/account/identities")
+}
+
+// linkOIDC navigates the browser to the link-flow start endpoint.
+// The endpoint redirects to the IdP; on return the callback hands
+// the user back to /account?linked=...&error=... so the panel can
+// render the outcome.
+export function linkOIDC(slug: AccountIdentityProvider["provider"]): void {
+  window.location.assign(`/api/v1/account/oidc/link/${slug}`)
+}
+
+export async function unlinkOIDC(
+  provider: AccountIdentityProvider["provider"],
+): Promise<void> {
+  await api<void>(`/api/v1/account/oidc/${provider}`, { method: "DELETE" })
+}
+
+export async function setInitialPassword(next: string): Promise<void> {
+  await api<void>("/api/v1/account/password/set", {
+    method: "POST",
+    body: JSON.stringify({ next }),
+  })
+}

--- a/ui/src/components/account/AccountPanel.tsx
+++ b/ui/src/components/account/AccountPanel.tsx
@@ -1,8 +1,18 @@
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useNavigate, useSearch } from "@tanstack/react-router"
 import { toast } from "sonner"
 
 import type { ApiError } from "@/api/client"
+import type {AccountIdentityProvider} from "@/api/account";
+import {
+  
+  accountIdentitiesQueryKey,
+  fetchAccountIdentities,
+  linkOIDC,
+  setInitialPassword,
+  unlinkOIDC
+} from "@/api/account"
 import {
   changePassword,
   fetchMe,
@@ -13,19 +23,49 @@ import { Avatar, Card, Field } from "@/components/SettingsShared"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 
-const AUTH_METHODS: ReadonlyArray<{ n: string; on: boolean; sub: string }> = [
-  { n: "Local (session)", on: true, sub: "Username + password" },
-  { n: "OIDC", on: false, sub: "Pending" },
-]
+const LINK_ERROR_MESSAGES: Record<string, string> = {
+  session_expired: "Your session expired before the link finished. Sign in and try again.",
+  already_linked_elsewhere:
+    "That sign-in method is already linked to another account.",
+  provider_already_linked:
+    "Another sign-in for this provider is already linked. Unlink it first.",
+}
 
 export function AccountPanel() {
   const queryClient = useQueryClient()
+  const navigate = useNavigate({ from: "/account" })
+  const search = useSearch({ from: "/_app/account" })
+
+  // Toast and clear redirect-back signals from the OIDC link callback.
+  // Running once per (linked, error) pair keeps refresh from re-firing
+  // the toast.
+  useEffect(() => {
+    if (!search.linked && !search.error) return
+    if (search.linked) {
+      toast.success(`${prettyProvider(search.linked)} connected.`)
+    }
+    if (search.error) {
+      toast.error(LINK_ERROR_MESSAGES[search.error] ?? "Linking failed.")
+    }
+    navigate({
+      to: "/account",
+      search: search.section ? { section: search.section } : {},
+      replace: true,
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search.linked, search.error])
+
   const me = useQuery({
     queryKey: meQueryKey,
     queryFn: fetchMe,
     staleTime: 60_000,
   })
   const user = me.data
+  const identities = useQuery({
+    queryKey: accountIdentitiesQueryKey,
+    queryFn: fetchAccountIdentities,
+    staleTime: 30_000,
+  })
 
   const [editing, setEditing] = useState(false)
   const [nameDraft, setNameDraft] = useState("")
@@ -33,6 +73,12 @@ export function AccountPanel() {
   const [pwCurrent, setPwCurrent] = useState("")
   const [pwNext, setPwNext] = useState("")
   const [pwConfirm, setPwConfirm] = useState("")
+
+  // First-password modal for OIDC-only users. Separate from the
+  // change-password form because it skips the "current password" step.
+  const [initPwOpen, setInitPwOpen] = useState(false)
+  const [initPwNext, setInitPwNext] = useState("")
+  const [initPwConfirm, setInitPwConfirm] = useState("")
 
   const nameMut = useMutation({
     mutationFn: (next: string) => updateDisplayName(next),
@@ -57,6 +103,28 @@ export function AccountPanel() {
     onError: (e) => toast.error((e as unknown as ApiError).message),
   })
 
+  const initPwMut = useMutation({
+    mutationFn: (next: string) => setInitialPassword(next),
+    onSuccess: () => {
+      setInitPwOpen(false)
+      setInitPwNext("")
+      setInitPwConfirm("")
+      queryClient.invalidateQueries({ queryKey: accountIdentitiesQueryKey })
+      toast.success("Password set. You can now unlink sign-in methods.")
+    },
+    onError: (e) => toast.error((e as unknown as ApiError).message),
+  })
+
+  const unlinkMut = useMutation({
+    mutationFn: (provider: AccountIdentityProvider["provider"]) =>
+      unlinkOIDC(provider),
+    onSuccess: (_, provider) => {
+      queryClient.invalidateQueries({ queryKey: accountIdentitiesQueryKey })
+      toast.success(`${prettyProvider(provider)} disconnected.`)
+    },
+    onError: (e) => toast.error((e as unknown as ApiError).message),
+  })
+
   const joined = user?.createdAt
     ? new Date(user.createdAt).toLocaleDateString(undefined, {
         month: "short",
@@ -64,6 +132,10 @@ export function AccountPanel() {
       })
     : "—"
   const roleLabel = user?.role === "admin" ? "Admin" : "User"
+
+  const data = identities.data
+  const linkedCount = data?.providers.filter((p) => p.linked).length ?? 0
+  const hasPassword = data?.hasPassword ?? false
 
   return (
     <>
@@ -125,13 +197,23 @@ export function AccountPanel() {
               >
                 Edit name
               </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setPwOpen((v) => !v)}
-              >
-                Change password
-              </Button>
+              {hasPassword ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setPwOpen((v) => !v)}
+                >
+                  Change password
+                </Button>
+              ) : (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setInitPwOpen(true)}
+                >
+                  Set password
+                </Button>
+              )}
             </>
           )}
         </div>
@@ -201,42 +283,176 @@ export function AccountPanel() {
             </div>
           </form>
         )}
+
+        {initPwOpen && (
+          <form
+            onSubmit={(e) => {
+              e.preventDefault()
+              if (initPwNext !== initPwConfirm) {
+                toast.error("Passwords do not match.")
+                return
+              }
+              initPwMut.mutate(initPwNext)
+            }}
+            style={{
+              marginTop: 16,
+              paddingTop: 16,
+              borderTop: "1px dashed var(--color-rule-soft)",
+              display: "flex",
+              flexDirection: "column",
+              gap: 10,
+            }}
+          >
+            <div className="t-small" style={{ fontSize: 12 }}>
+              You signed up via a sign-in provider, so you don't have a
+              password yet. Setting one lets you sign in directly and
+              unlink providers without losing access.
+            </div>
+            <Field label="New password">
+              <Input
+                type="password"
+                value={initPwNext}
+                onChange={(e) => setInitPwNext(e.target.value)}
+                autoComplete="new-password"
+                minLength={8}
+                required
+              />
+            </Field>
+            <Field label="Confirm password">
+              <Input
+                type="password"
+                value={initPwConfirm}
+                onChange={(e) => setInitPwConfirm(e.target.value)}
+                autoComplete="new-password"
+                minLength={8}
+                required
+              />
+            </Field>
+            <div
+              style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}
+            >
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => setInitPwOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" size="sm" disabled={initPwMut.isPending}>
+                {initPwMut.isPending ? "Saving…" : "Set password"}
+              </Button>
+            </div>
+          </form>
+        )}
       </Card>
 
       <div className="t-label" style={{ marginTop: 24, marginBottom: 10 }}>
-        Authentication
+        Sign-in methods
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-        {AUTH_METHODS.map((a) => (
-          <div
-            key={a.n}
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 14,
-              padding: "10px 14px",
-              border: "1px solid var(--color-rule-soft)",
-              background: "var(--color-paper-0)",
-            }}
-          >
-            <span
-              style={{
-                width: 8,
-                height: 8,
-                borderRadius: "50%",
-                background: a.on
-                  ? "oklch(0.58 0.12 140)"
-                  : "var(--color-ink-4)",
-              }}
+        <SignInRow
+          title="Local password"
+          subtitle={hasPassword ? "Set" : "Not set"}
+          on={hasPassword}
+        />
+        {data?.providers.map((p) => {
+          // Lockout: user with no password and exactly one linked
+          // identity cannot remove their last credential.
+          const isLastCredential =
+            p.linked && !hasPassword && linkedCount === 1
+          return (
+            <SignInRow
+              key={p.provider}
+              title={p.displayName}
+              subtitle={p.linked ? (p.email ?? "Linked") : "Not connected"}
+              on={p.linked}
+              action={
+                p.linked ? (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={isLastCredential || unlinkMut.isPending}
+                    title={
+                      isLastCredential
+                        ? "Set a password before unlinking your last sign-in method."
+                        : undefined
+                    }
+                    onClick={() => unlinkMut.mutate(p.provider)}
+                  >
+                    Unlink
+                  </Button>
+                ) : (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => linkOIDC(p.provider)}
+                  >
+                    Connect
+                  </Button>
+                )
+              }
             />
-            <div className="grow">
-              <div className="t-item-title">{a.n}</div>
-              <div className="t-item-sub">{a.sub}</div>
-            </div>
-            <span className="t-micro">{a.on ? "enabled" : "disabled"}</span>
+          )
+        })}
+        {identities.isLoading && (
+          <div className="t-small" style={{ fontSize: 12, padding: 8 }}>
+            Loading sign-in methods…
           </div>
-        ))}
+        )}
       </div>
     </>
   )
+}
+
+function SignInRow({
+  title,
+  subtitle,
+  on,
+  action,
+}: {
+  title: string
+  subtitle: string
+  on: boolean
+  action?: React.ReactNode
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 14,
+        padding: "10px 14px",
+        border: "1px solid var(--color-rule-soft)",
+        background: "var(--color-paper-0)",
+      }}
+    >
+      <span
+        style={{
+          width: 8,
+          height: 8,
+          borderRadius: "50%",
+          background: on ? "oklch(0.58 0.12 140)" : "var(--color-ink-4)",
+        }}
+      />
+      <div className="grow">
+        <div className="t-item-title">{title}</div>
+        <div className="t-item-sub">{subtitle}</div>
+      </div>
+      {action}
+    </div>
+  )
+}
+
+function prettyProvider(slug: string): string {
+  switch (slug) {
+    case "google":
+      return "Google"
+    case "github":
+      return "GitHub"
+    case "generic":
+      return "Single sign-on"
+    default:
+      return slug
+  }
 }

--- a/ui/src/routes/_app.account.tsx
+++ b/ui/src/routes/_app.account.tsx
@@ -10,6 +10,11 @@ type SectionKey = "account" | "reading" | "devices"
 
 type AccountSearch = {
   section?: SectionKey
+  // Redirect-back signals from the OIDC link callback. The panel
+  // renders a toast and clears these via router.navigate so the URL
+  // doesn't keep firing the toast on refresh.
+  linked?: string
+  error?: string
 }
 
 const SECTIONS: ReadonlyArray<{ key: SectionKey; label: string }> = [
@@ -25,6 +30,8 @@ function isSectionKey(v: unknown): v is SectionKey {
 export const Route = createFileRoute("/_app/account")({
   validateSearch: (raw: Record<string, unknown>): AccountSearch => ({
     section: isSectionKey(raw.section) ? raw.section : undefined,
+    linked: typeof raw.linked === "string" ? raw.linked : undefined,
+    error: typeof raw.error === "string" ? raw.error : undefined,
   }),
   component: AccountPage,
 })


### PR DESCRIPTION
## Summary

PR-2 of two-PR rollout. Stacked on top of #78 (`feat/user-identities-backend`).

- `ui/src/api/account.ts`: typed client for `/api/v1/account/identities`, link (browser navigation), unlink, set-initial-password.
- `ui/src/components/account/AccountPanel.tsx`: replaces the static `AUTH_METHODS` placeholder. Renders one row per admin-enabled provider with **Connect** / **Unlink** buttons; the lockout-disabled Unlink shows the "Set a password before unlinking…" tooltip when applicable. Adds a **Set password** form for OIDC-provisioned users (no current password to enter).
- `ui/src/routes/_app.account.tsx`: `validateSearch` now accepts the `?linked=…` and `?error=…` query params set by the OIDC callback redirect; the panel fires a toast, then `router.navigate({ replace: true })` clears the URL so refresh doesn't re-fire.

## UI states

- has password + N identities: password row + linked rows (each "Unlink") + connect buttons for unlinked
- **no password** + 1 identity: linked row, Unlink disabled with tooltip + "Set password" CTA
- no password + 2+ identities: linked rows; first unlink allowed; last triggers same disabled state

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run test` 42 passing
- [x] `bun run build` produces working bundle
- [ ] Manual smoke after merge: enable a provider in admin settings, click Connect from account panel, confirm OAuth round-trip lands back at `/account` with toast + linked row.
- [ ] Manual smoke: unlink last identity for OIDC-only user → blocked with tooltip; Set password → succeeds → unlink now allowed.

## Depends on

- #78 (PR-1, backend) — merge that first; this PR's base will switch to `main` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)