### PR TITLE
feat(orphan-management): implement pending orphans for S3 folder renames

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -56,6 +56,17 @@ Off by default after the first user; the first OIDC login on an
 empty instance is always admitted as admin to avoid an unrecoverable
 state.
 
+## Pending orphan
+
+A storage key whose Book is no longer referenced by `files.location`
+(or sidecar/cover at `{folder_path}/`) and which is queued for
+deletion after a grace window. Materialised as a row in
+`pending_orphans` (library_id, key, eligible_at, reason, book_id).
+Created on every S3 edit-time folder rename: old keys go in with
+full grace; new keys from a half-failed rename go in with a short
+grace. A background sweeper deletes keys past `eligible_at`. Local
+backends do not produce pending orphans — `os.Rename` is atomic.
+
 ## Force-only mode
 
 Admin toggle `oidc_force_only_mode` that hides the local-password

--- a/cmd/embookshelf/main.go
+++ b/cmd/embookshelf/main.go
@@ -236,12 +236,22 @@ func main() {
 	// auto-enrich background path passes TriggerAutoEnrichment to skip
 	// the side-effect steps and only persist the DB row.
 	sidecarWriter := sidecar.NewWriter()
+	pendingOrphansRepo := repo.NewPendingOrphanRepo(dbh)
+	renameGrace := cfg.S3RenameGrace
+	if renameGrace <= 0 {
+		// ADR-0005: 2× PresignTTL covers any URL the client could
+		// still hold. Floor at 1h so very short PresignTTL (manual
+		// override) doesn't make the sweeper too aggressive.
+		renameGrace = max(2*cfg.PresignTTL, time.Hour)
+	}
 	metadataWriter := service.NewMetadataWriter(service.MetadataWriterDeps{
-		Books:    bookRepo,
-		LibStore: libStore,
-		Sidecar:  sidecarWriter,
-		Dispatch: fileproc.DispatchEmbedder,
-		Files:    fileRepo,
+		Books:       bookRepo,
+		LibStore:    libStore,
+		Sidecar:     sidecarWriter,
+		Dispatch:    fileproc.DispatchEmbedder,
+		Files:       fileRepo,
+		Orphans:     pendingOrphansRepo,
+		RenameGrace: renameGrace,
 	})
 	libSvc.WithMetadataWriter(metadataWriter)
 	enrichSvc.WithMetadataWriter(metadataWriter)
@@ -337,6 +347,16 @@ func main() {
 	// Missing-files purge sweeper: deletes files rows whose missing_since
 	// is older than 24h. Runs hourly until the application shuts down.
 	go task.LoopMissingPurge(ctx, fileRepo, time.Hour)
+
+	// Orphaned-keys sweeper: drains pending_orphans rows whose grace
+	// window has passed, deleting the underlying storage keys. Sources:
+	// post-rename old keys (full RenameGrace) and rollback half-rename
+	// new keys (RenameRollbackGrace). ADR-0005.
+	go task.LoopOrphanedKeys(ctx, task.OrphanedKeysDeps{
+		Orphans:  pendingOrphansRepo,
+		Libs:     libRepo,
+		Resolver: storageResolver,
+	}, time.Hour)
 
 	// S3 event loop: poll an SQS queue for S3 event notifications and
 	// reconcile them into the files table without waiting for the next

--- a/docs/adr/0005-s3-edit-time-folder-rename.md
+++ b/docs/adr/0005-s3-edit-time-folder-rename.md
@@ -1,0 +1,154 @@
+# S3 edit-time folder rename via copy + sweeper-deferred delete
+
+S3-backed libraries now follow the same `{Author}/{Title}/` rename-on-edit rule as local libraries (ADR-0003 §6). On a user-driven Author/Title edit, `MetadataWriter` issues server-side `CopyObject` for every key under the Book's old prefix, swaps DB pointers in a single transaction, and enqueues the old keys into a new `pending_orphans` table that a background sweeper drains after a grace window. Supersedes ADR-0003 §7.
+
+## Status
+
+accepted (2026-05-03)
+
+Supersedes ADR-0003 §7 ("S3 backends: layout at place-time, never on edit"). All other sections of ADR-0003 stand.
+
+## Context
+
+ADR-0003 §7 deliberately excluded S3 from edit-time folder rename, with two stated reasons:
+
+1. **Cost.** Rejected eager S3 migration cited "$$$ on S3" in §Considered alternatives.
+2. **Atomicity.** S3 has no atomic directory rename; copy + delete is multi-op and partial-failure-prone.
+
+The cost premise was wrong for the backends embookshelf actually targets. Server-side `CopyObject` is **free intra-bucket** on AWS (same region), Cloudflare R2, MinIO, and Tigris. The cost objection was inherited from generic S3 wisdom that doesn't apply to single-bucket, library-prefix deployments. (`internal/storage/s3/s3.go` enforces single-bucket per backend; `internal/storage/s3/methods.go:149` already implements server-side Copy.)
+
+The atomicity objection remains real but is solvable with a deferred-delete sweeper. The "S3 is captured by sidecar full-mirror" fallback in §7's Consequences turned out unsatisfying in practice: external readers (Kobo, KOReader, OPDS clients) browse and bookmark by key path, not by sidecar contents. Drift between approve-time titles and current metadata is user-visible.
+
+## Decision
+
+### 1. Drop the `BackendID == nil` guard around `FolderRename` in `DecideEffects`.
+
+`internal/service/decide_effects.go` currently sets `FolderRename` only when the library has no backend. New shape:
+
+```go
+e := Effects{DB: true, Sidecar: true}
+if folderChanged {
+    e.FolderRename = true   // both backends
+}
+if handle.Library.BackendID == nil {
+    e.InFile = true         // local-only, unchanged
+}
+```
+
+The trigger gate from ADR-0003 §6 is preserved: only `manual_edit` and `apply_enrichment` can set `FolderRename`. `auto_enrichment`, scan re-extract, and bookdrop approve never trigger a rename — same on both backends.
+
+### 2. `MetadataWriter.renameFolder` branches by backend.
+
+```go
+func (w *MetadataWriter) renameFolder(...) (bool, string) {
+    if handle.Library.BackendID == nil {
+        return w.renameFolderLocal(...)
+    }
+    return w.renameFolderBackend(...)
+}
+```
+
+The two arms have different error shapes, different recovery models, and different dependencies (the backend arm needs the orphan-table repo). Hiding the asymmetry behind a `Storage.RenamePrefix` method would mislead callers about atomicity. We keep the split visible.
+
+### 3. Backend rename pipeline.
+
+Per-rename flow on S3:
+
+1. **Enumerate keys to move** (hybrid, ADR-0003 §8/§9 catch-all). Issue `ListObjectsV2(Prefix={old_folder}/)` paginated. Captures the multi-format files, the folder-root sidecar (`metadata.embookshelf.json`), folder-root covers (`cover.{jpg,jpeg,png,webp}`), and any user/system artifact. The DB list (`files.location` rows for the Book) drives the post-move `files.location` UPDATE — only DB-tracked files get a row update; arbitrary co-located keys ride along under the new prefix.
+
+2. **Collision check.** `ListObjectsV2(Prefix={new_folder}/, MaxKeys=1)`. Non-empty → suffix ` (2)`, ` (3)`, re-probe. Same suffix rule as local's `uniqueDirectoryUnless`. Race window is narrow — same hazard as local concurrent edits, accepted.
+
+3. **5GB+ files.** Above the `CopyObject` 5GB hard limit, copy returns the AWS `EntityTooLarge` error; rename aborts cleanly, DB unchanged, sidecar full-mirror still records the metadata. User sees "Title updated; folder rename skipped (file too large)." Multipart-copy (`UploadPartCopy`) deferred until a user actually hits this.
+
+4. **Phase-1: copy-loop.** For each enumerated key, `Copy(srcKey, dstKey)` server-side. Each copy retried with bounded backoff (3× exponential). Failure after retry: roll back. Roll back = insert every successfully-copied **new** key into `pending_orphans` with short grace (5 min) so the sweeper reaps half-rename garbage. DB stays unchanged. Caller sees error.
+
+5. **Phase-2: DB swap.** Single transaction:
+   ```sql
+   UPDATE files SET location = $new_prefix || substring(location from length($old_prefix)+1)
+   WHERE book_id = $1;
+   UPDATE books SET folder_path = $2, path = $3 WHERE id = $1;
+   INSERT INTO pending_orphans (library_id, key, eligible_at, reason, book_id)
+   VALUES ... -- one row per old enumerated key
+   ```
+   Atomic visibility: sweeper either sees all old or all new. The DB is the canonical point of truth on S3 — there is no filesystem anchor.
+
+6. **Phase-3: deletes happen later, not here.** No inline delete. The sweeper handles all source-key deletes after the grace window. Drops the failure mode where the rename error-path has to clean up after itself.
+
+### 4. `pending_orphans` table (migration 000031).
+
+```sql
+CREATE TABLE pending_orphans (
+    id           BIGSERIAL PRIMARY KEY,
+    library_id   UUID NOT NULL REFERENCES libraries(id) ON DELETE CASCADE,
+    key          TEXT NOT NULL,
+    eligible_at  TIMESTAMPTZ NOT NULL,
+    reason       TEXT NOT NULL,
+    book_id      UUID,                                 -- FK-less; book may delete later
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (library_id, key)
+);
+CREATE INDEX pending_orphans_due ON pending_orphans (eligible_at);
+```
+
+`reason` future-proofs for non-rename uses (`delete`, `library-removed`).
+`UNIQUE (library_id, key)` prevents double-insert if a rename re-runs on the same Book.
+`book_id` nullable + no FK so book deletion doesn't block sweeper.
+
+### 5. Sweeper: `LoopOrphanedKeys` ticker.
+
+New goroutine in `internal/task/orphaned_keys.go`, mirrors `task.LoopMissingPurge` shape. Wakes hourly. Each pass:
+
+```sql
+SELECT id, library_id, key FROM pending_orphans
+WHERE eligible_at <= now()
+ORDER BY eligible_at
+LIMIT 500;
+```
+
+For each row: resolve the library's `Storage`, call `Delete(ctx, key)`, then `DELETE FROM pending_orphans WHERE id = $1`. `storage.ErrNotFound` is treated as success. Other errors leave the row for the next pass.
+
+Bounded work per pass — O(rename count), not O(library size). Skips full library list-prefix scans entirely.
+
+### 6. Grace window.
+
+`max(2 × cfg.PresignTTL, 1h)`. Default `PresignTTL` is 10min so default grace is 1h. New env `EMBOOKSHELF_S3_RENAME_GRACE` overrides for operators with longer presign TTLs.
+
+The grace window is the contract with already-issued presigned URLs: any URL handed to a client for the old key is honored for at least `2 × PresignTTL`, which exceeds the URL's natural expiry.
+
+### 7. Existing-drift backfill: none.
+
+Mirrors ADR-0003 §5 lazy migration. S3 books whose stored `folder_path` doesn't match `{Author}/{Title}` at ship-time stay drifted until the user touches each one. No boot-time reconcile, no auto-relocate. A future operator-triggered reconcile job is buildable but not in scope.
+
+## Considered alternatives
+
+- **Per-file rename with per-file DB tx.** Each file: copy, update `files.location`, delete. Failure mid-loop leaves rows pointing at mixed prefixes. Rejected — defeats "folder = Book" identity.
+- **Inline phase-2 delete after DB swap.** Cleaner mental model (rename returns when fully done), but breaks already-issued presigned URLs immediately and requires the rename code path to retry deletes itself. Rejected — sweeper-deferred delete decouples concerns and naturally bounds blast radius.
+- **`Storage.RenamePrefix(ctx, old, new) error` interface method.** Tempting one-liner at the caller. Rejected — local impl is `os.Rename` (atomic), S3 impl is multi-stage with deferred delete; the asymmetry matters to callers and shouldn't be hidden behind a uniform signature.
+- **River job per rename instead of inline.** Operator-visible job state, retries for free. Rejected for now — current per-Book file count fits inside an HTTP handler timeout. Revisit if multi-chapter audiobook renames start blocking the request thread.
+- **Tag-on-copy with `x-amz-meta-embookshelf-pending` instead of `pending_orphans` table.** Sweeper would list-prefix per library and check tags. Rejected — full library scan per pass vs. bounded DB query; also couples to a per-backend metadata feature.
+- **Multipart-copy for >5GB files.** Real edge case but real implementation cost. Deferred to first user complaint per ADR-0003's "fully captured in sidecar" fallback.
+
+## Consequences
+
+**Positive:**
+- S3 + local converge behaviorally on edit-time rename; one mental model across backends.
+- External readers / OPDS bookmarks / download URLs reflect current Author/Title for actively-edited books (after grace period).
+- The `pending_orphans` table gives a clear audit trail: when did each key get abandoned, why, by which book.
+
+**Negative / surprising:**
+- `MetadataWriter` now depends on a `PendingOrphansRepo`. Wiring change in the service constructor.
+- New env var (`EMBOOKSHELF_S3_RENAME_GRACE`), new background goroutine (`LoopOrphanedKeys`).
+- Bucket versioning growth: every rename produces N new version chains and N delete-markers under the old prefix. Lifecycle policy on the bucket is the operator's job; we warn on missing versioning at startup but don't manage retention.
+- Half-failed renames briefly leave orphans under the *new* prefix that get reaped within 5 min. A user listing the bucket directly during that window will see ghost folders. Internal code never sees them — DB doesn't reference them.
+- Glacier-class objects can't be `CopyObject`'d without restore. Same failure mode as 5GB+: copy fails, rename aborts cleanly, sidecar carries the metadata.
+- Existing-drift S3 libraries stay drifted; pre-ship edits do not retroactively fix.
+
+## Implementation phasing
+
+1. Migration 000031: `pending_orphans` table + `pending_orphans_due` index.
+2. `internal/repo/pending_orphans.go`: insert / select-due / delete.
+3. `internal/task/orphaned_keys.go`: `LoopOrphanedKeys` ticker + `RunOrphanedKeysOnce` for tests.
+4. `internal/service/decide_effects.go`: drop the `BackendID == nil` guard around `FolderRename`.
+5. `internal/service/metadata_writer.go`: add `renameFolderBackend`, branch in `renameFolder`. New deps: `PendingOrphansRepo`, grace duration.
+6. `cmd/embookshelf`: wire deps, start `LoopOrphanedKeys` alongside `LoopMissingPurge`. Read `EMBOOKSHELF_S3_RENAME_GRACE`.
+7. Update `decide_effects_test.go` and `metadata_writer_test.go`: flip `TestMetadataWriter_FolderRename_S3SkipsRename` into `TestMetadataWriter_FolderRename_S3Renames`; add tests for partial-failure rollback, collision-suffix, grace-window deferral, sweeper draining.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -71,6 +71,12 @@ type Config struct {
 	// files. Default is 10 minutes. Configurable via EMBOOKSHELF_PRESIGN_TTL
 	// (any value parseable by time.ParseDuration, e.g. "15m", "1h").
 	PresignTTL time.Duration
+	// S3RenameGrace is the grace window before the orphaned-keys
+	// sweeper deletes old keys left behind by an S3 folder rename
+	// (ADR-0005). Zero means "compute at boot as max(2 × PresignTTL,
+	// 1h)". Override via EMBOOKSHELF_S3_RENAME_GRACE.
+	S3RenameGrace time.Duration
+
 	// PresignFallback selects the delivery mode for book files when
 	// the backend supports presign. Set to "presign" to opt into 302
 	// redirects to a pre-signed URL — requires the bucket to allow the
@@ -138,6 +144,7 @@ func Load() (Config, error) {
 
 		PresignTTL:      envDuration("EMBOOKSHELF_PRESIGN_TTL", 10*time.Minute),
 		PresignFallback: envStr("EMBOOKSHELF_PRESIGN_FALLBACK", ""),
+		S3RenameGrace:   envDuration("EMBOOKSHELF_S3_RENAME_GRACE", 0),
 
 		OIDCIssuerURL:    envStr("OIDC_ISSUER_URL", ""),
 		OIDCClientID:     envStr("OIDC_CLIENT_ID", ""),

--- a/internal/extractor/extract.go
+++ b/internal/extractor/extract.go
@@ -17,14 +17,14 @@ import (
 // overlay. It is the single contract shared by the bookdrop ingest
 // path and the (future) scan-direct ScanImportJob, per ADR-0004 §2.
 type ExtractResult struct {
-	Format          string
-	Title           string
-	Author          string
-	Description     string
-	Language        string
-	HasCover        bool
-	CoverBytes      []byte
-	CoverMime       string
+	Format      string
+	Title       string
+	Author      string
+	Description string
+	Language    string
+	HasCover    bool
+	CoverBytes  []byte
+	CoverMime   string
 	// DurationSeconds is non-nil only for audio formats with a
 	// readable header.
 	DurationSeconds *int

--- a/internal/migrator/migrations/postgres/000032_pending_orphans.down.sql
+++ b/internal/migrator/migrations/postgres/000032_pending_orphans.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS pending_orphans_due;
+DROP TABLE IF EXISTS pending_orphans;

--- a/internal/migrator/migrations/postgres/000032_pending_orphans.up.sql
+++ b/internal/migrator/migrations/postgres/000032_pending_orphans.up.sql
@@ -1,0 +1,16 @@
+-- ADR-0005: S3 edit-time folder rename uses copy + sweeper-deferred
+-- delete. pending_orphans queues old keys (and half-rename garbage)
+-- for a background sweeper to delete after the grace window.
+
+CREATE TABLE pending_orphans (
+    id           BIGSERIAL PRIMARY KEY,
+    library_id   UUID NOT NULL REFERENCES libraries(id) ON DELETE CASCADE,
+    key          TEXT NOT NULL,
+    eligible_at  TIMESTAMPTZ NOT NULL,
+    reason       TEXT NOT NULL,
+    book_id      UUID,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (library_id, key)
+);
+
+CREATE INDEX pending_orphans_due ON pending_orphans (eligible_at);

--- a/internal/migrator/migrations/sqlite/000032_pending_orphans.down.sql
+++ b/internal/migrator/migrations/sqlite/000032_pending_orphans.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS pending_orphans_due;
+DROP TABLE IF EXISTS pending_orphans;

--- a/internal/migrator/migrations/sqlite/000032_pending_orphans.up.sql
+++ b/internal/migrator/migrations/sqlite/000032_pending_orphans.up.sql
@@ -1,0 +1,21 @@
+-- ADR-0005: pending_orphans queues old keys for the S3 rename
+-- sweeper. SQLite mirror of postgres/000032.
+--
+-- Type translations:
+--   BIGSERIAL                   → INTEGER PRIMARY KEY AUTOINCREMENT
+--   UUID                        → TEXT
+--   TIMESTAMPTZ                 → TEXT, ISO8601 via strftime
+--   NOW()                       → strftime('%Y-%m-%dT%H:%M:%fZ','now')
+
+CREATE TABLE IF NOT EXISTS pending_orphans (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    library_id   TEXT NOT NULL REFERENCES libraries(id) ON DELETE CASCADE,
+    key          TEXT NOT NULL,
+    eligible_at  TEXT NOT NULL,
+    reason       TEXT NOT NULL,
+    book_id      TEXT,
+    created_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    UNIQUE (library_id, key)
+);
+
+CREATE INDEX IF NOT EXISTS pending_orphans_due ON pending_orphans (eligible_at);

--- a/internal/model/pending_orphan.go
+++ b/internal/model/pending_orphan.go
@@ -1,0 +1,18 @@
+package model
+
+import "time"
+
+// PendingOrphan is a storage key queued for deletion by the
+// LoopOrphanedKeys sweeper after EligibleAt has passed. Created by
+// the S3 edit-time folder rename pipeline (ADR-0005) for old keys
+// that the rename moved past, and for new keys left behind by a
+// half-failed rename.
+type PendingOrphan struct {
+	ID         int64
+	LibraryID  string
+	Key        string
+	EligibleAt time.Time
+	Reason     string
+	BookID     *string
+	CreatedAt  time.Time
+}

--- a/internal/repo/book.go
+++ b/internal/repo/book.go
@@ -427,6 +427,93 @@ func (r *BookRepo) SetFolderPath(ctx context.Context, bookID, folderPath, path s
 	return nil
 }
 
+// FileLocationUpdate is one row mutation for RenameFolderTx: the
+// files.id whose location should be rewritten and the new
+// library-relative location to store.
+type FileLocationUpdate struct {
+	FileID   string
+	Location string
+}
+
+// RenameFolderTxArgs bundles the inputs for RenameFolderTx — the
+// single-transaction DB swap that finalises an S3 folder rename per
+// ADR-0005. Files are updated row-by-row inside the tx; orphans are
+// inserted in the same tx so the sweeper either sees the post-rename
+// state or none of it.
+type RenameFolderTxArgs struct {
+	BookID    string
+	NewFolder string
+	NewPath   string
+	Files     []FileLocationUpdate
+	Orphans   []PendingOrphanInsert
+}
+
+// RenameFolderTx applies the post-copy DB swap atomically:
+//   - rewrites every files.location supplied,
+//   - sets books.folder_path + books.path,
+//   - enqueues old keys into pending_orphans for the sweeper.
+//
+// All three happen in one COMMIT so the sweeper either sees the
+// post-rename state or never sees the orphan rows at all. On any
+// step error the tx rolls back; the caller is responsible for
+// scheduling cleanup of half-rename garbage on the storage side
+// via a separate short-grace orphan insert.
+func (r *BookRepo) RenameFolderTx(ctx context.Context, args RenameFolderTxArgs) error {
+	tx, err := r.db.SQL.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	const qFilePG = `UPDATE files SET location = $1 WHERE id = $2`
+	const qFileSQLite = `UPDATE files SET location = ? WHERE id = ?`
+	for _, f := range args.Files {
+		if _, err := tx.ExecContext(ctx,
+			db.SelectQ(r.db.Dialect, qFilePG, qFileSQLite),
+			f.Location, f.FileID,
+		); err != nil {
+			return fmt.Errorf("update files.location for %s: %w", f.FileID, err)
+		}
+	}
+
+	var folderArg any
+	if args.NewFolder != "" {
+		folderArg = args.NewFolder
+	}
+	const qBookPG = `
+		UPDATE books SET folder_path = $2, path = $3, updated_at = now()
+		WHERE id = $1 AND deleted_at IS NULL
+	`
+	const qBookSQLite = `
+		UPDATE books SET folder_path = ?, path = ?, updated_at = CURRENT_TIMESTAMP
+		WHERE id = ? AND deleted_at IS NULL
+	`
+	var res sql.Result
+	if r.db.Dialect == db.DialectSQLite {
+		res, err = tx.ExecContext(ctx, qBookSQLite, folderArg, args.NewPath, args.BookID)
+	} else {
+		res, err = tx.ExecContext(ctx, qBookPG, args.BookID, folderArg, args.NewPath)
+	}
+	if err != nil {
+		return fmt.Errorf("update books folder_path: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("rows affected: %w", err)
+	}
+	if n == 0 {
+		return ErrNotFound
+	}
+
+	if len(args.Orphans) > 0 {
+		if err := insertPendingOrphansInTx(ctx, tx, r.db.Dialect, args.Orphans); err != nil {
+			return fmt.Errorf("enqueue pending_orphans: %w", err)
+		}
+	}
+
+	return tx.Commit()
+}
+
 // UpdateMetadata applies the user-editable metadata fields for a book,
 // including the per-field lock flags. Manual edits (PATCH /books/:id)
 // flow through here; the apply-metadata path (PUT /books/:id/metadata)

--- a/internal/repo/pending_orphan.go
+++ b/internal/repo/pending_orphan.go
@@ -1,0 +1,193 @@
+package repo
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/blackforge/embookshelf/internal/db"
+	"github.com/blackforge/embookshelf/internal/model"
+)
+
+// ReasonOrphanRename is the reason value written by the S3 folder
+// rename pipeline (ADR-0005). Future reasons (delete, library-removed)
+// will live alongside this constant.
+const ReasonOrphanRename = "rename"
+
+// PendingOrphanRepo provides write/select access to the
+// pending_orphans table.
+type PendingOrphanRepo struct {
+	db *db.DB
+}
+
+// NewPendingOrphanRepo constructs a PendingOrphanRepo backed by d.
+func NewPendingOrphanRepo(d *db.DB) *PendingOrphanRepo {
+	return &PendingOrphanRepo{db: d}
+}
+
+// PendingOrphanInsert is one row to enqueue. EligibleAt + Reason +
+// LibraryID are required; BookID may be nil.
+type PendingOrphanInsert struct {
+	LibraryID  string
+	Key        string
+	EligibleAt time.Time
+	Reason     string
+	BookID     *string
+}
+
+// Insert enqueues rows. Conflict on (library_id, key) is treated as
+// "already enqueued" and silently skipped — a re-run of the same
+// rename should not error.
+func (r *PendingOrphanRepo) Insert(ctx context.Context, rows []PendingOrphanInsert) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	switch r.db.Dialect {
+	case db.DialectSQLite:
+		return r.insertSQLite(ctx, rows)
+	default:
+		return r.insertPG(ctx, rows)
+	}
+}
+
+func (r *PendingOrphanRepo) insertPG(ctx context.Context, rows []PendingOrphanInsert) error {
+	q, args := buildPendingOrphanInsertPG(rows)
+	_, err := r.db.SQL.ExecContext(ctx, q, args...)
+	return err
+}
+
+func (r *PendingOrphanRepo) insertSQLite(ctx context.Context, rows []PendingOrphanInsert) error {
+	q, args := buildPendingOrphanInsertSQLite(rows)
+	_, err := r.db.SQL.ExecContext(ctx, q, args...)
+	return err
+}
+
+// insertPendingOrphansInTx is the tx-bound counterpart to
+// PendingOrphanRepo.Insert. Used by the BookRepo rename-folder tx so
+// orphan inserts commit (or roll back) atomically with the
+// files+books updates.
+func insertPendingOrphansInTx(ctx context.Context, tx *sql.Tx, dialect db.Dialect, rows []PendingOrphanInsert) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	var (
+		q    string
+		args []any
+	)
+	if dialect == db.DialectSQLite {
+		q, args = buildPendingOrphanInsertSQLite(rows)
+	} else {
+		q, args = buildPendingOrphanInsertPG(rows)
+	}
+	_, err := tx.ExecContext(ctx, q, args...)
+	return err
+}
+
+func buildPendingOrphanInsertPG(rows []PendingOrphanInsert) (string, []any) {
+	placeholders := make([]string, 0, len(rows))
+	args := make([]any, 0, len(rows)*5)
+	for i, row := range rows {
+		base := i * 5
+		placeholders = append(placeholders, fmt.Sprintf(
+			"($%d, $%d, $%d, $%d, $%d)",
+			base+1, base+2, base+3, base+4, base+5,
+		))
+		args = append(args, row.LibraryID, row.Key, row.EligibleAt, row.Reason, row.BookID)
+	}
+	q := `
+		INSERT INTO pending_orphans (library_id, key, eligible_at, reason, book_id)
+		VALUES ` + strings.Join(placeholders, ", ") + `
+		ON CONFLICT (library_id, key) DO NOTHING
+	`
+	return q, args
+}
+
+func buildPendingOrphanInsertSQLite(rows []PendingOrphanInsert) (string, []any) {
+	placeholders := make([]string, 0, len(rows))
+	args := make([]any, 0, len(rows)*5)
+	for _, row := range rows {
+		placeholders = append(placeholders, "(?, ?, ?, ?, ?)")
+		args = append(args,
+			row.LibraryID,
+			row.Key,
+			row.EligibleAt.UTC().Format(time.RFC3339Nano),
+			row.Reason,
+			row.BookID,
+		)
+	}
+	q := `
+		INSERT INTO pending_orphans (library_id, key, eligible_at, reason, book_id)
+		VALUES ` + strings.Join(placeholders, ", ") + `
+		ON CONFLICT (library_id, key) DO NOTHING
+	`
+	return q, args
+}
+
+// SelectDue returns up to limit rows whose EligibleAt has passed,
+// ordered by EligibleAt ASC. Used by the sweeper to pull a batch
+// of work each tick.
+func (r *PendingOrphanRepo) SelectDue(ctx context.Context, now time.Time, limit int) ([]model.PendingOrphan, error) {
+	const qPG = `
+		SELECT id, library_id, key, eligible_at, reason, book_id, created_at
+		FROM pending_orphans
+		WHERE eligible_at <= $1
+		ORDER BY eligible_at ASC
+		LIMIT $2
+	`
+	const qSQLite = `
+		SELECT id, library_id, key, eligible_at, reason, book_id, created_at
+		FROM pending_orphans
+		WHERE eligible_at <= ?
+		ORDER BY eligible_at ASC
+		LIMIT ?
+	`
+	var nowArg any
+	if r.db.Dialect == db.DialectSQLite {
+		nowArg = now.UTC().Format(time.RFC3339Nano)
+	} else {
+		nowArg = now
+	}
+	rows, err := r.db.SQL.QueryContext(ctx,
+		db.SelectQ(r.db.Dialect, qPG, qSQLite),
+		nowArg, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []model.PendingOrphan
+	for rows.Next() {
+		var (
+			po           model.PendingOrphan
+			eligibleAny  any
+			createdAny   any
+			bookIDNullSt *string
+		)
+		if err := rows.Scan(&po.ID, &po.LibraryID, &po.Key, &eligibleAny, &po.Reason, &bookIDNullSt, &createdAny); err != nil {
+			return nil, err
+		}
+		if err := db.ScanTime(r.db.Dialect, eligibleAny, &po.EligibleAt); err != nil {
+			return nil, fmt.Errorf("scan eligible_at: %w", err)
+		}
+		if err := db.ScanTime(r.db.Dialect, createdAny, &po.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan created_at: %w", err)
+		}
+		po.BookID = bookIDNullSt
+		out = append(out, po)
+	}
+	return out, rows.Err()
+}
+
+// Delete removes a row by id. Used by the sweeper after the key has
+// been deleted from the backend (or confirmed already gone).
+// Deleting a non-existent id is not an error — concurrent sweepers
+// or operator deletes can race; the absence is the desired state.
+func (r *PendingOrphanRepo) Delete(ctx context.Context, id int64) error {
+	const qPG = `DELETE FROM pending_orphans WHERE id = $1`
+	const qSQLite = `DELETE FROM pending_orphans WHERE id = ?`
+	_, err := r.db.SQL.ExecContext(ctx, db.SelectQ(r.db.Dialect, qPG, qSQLite), id)
+	return err
+}

--- a/internal/repo/pending_orphan_test.go
+++ b/internal/repo/pending_orphan_test.go
@@ -1,0 +1,83 @@
+package repo_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/blackforge/embookshelf/internal/repo"
+	"github.com/blackforge/embookshelf/internal/repo/repotest"
+)
+
+// TestPendingOrphanRepo_RoundTrip exercises the basic insert / select-due
+// / delete cycle on both dialects.
+func TestPendingOrphanRepo_RoundTrip(t *testing.T) {
+	for _, dialect := range []string{"sqlite", "postgres"} {
+		dialect := dialect
+		t.Run(dialect, func(t *testing.T) {
+			d := repotest.NewWithDialect(t, dialect)
+			lr := repo.NewLibraryRepo(d)
+			pr := repo.NewPendingOrphanRepo(d)
+			ctx := context.Background()
+
+			lib, err := lr.CreateLibrary(ctx, "Orphan Test", "orphan-test", "/tmp/ot", nil)
+			if err != nil {
+				t.Fatalf("CreateLibrary: %v", err)
+			}
+
+			now := time.Now().UTC()
+			past := now.Add(-time.Hour)
+			future := now.Add(time.Hour)
+			bookID := "book-1"
+			rows := []repo.PendingOrphanInsert{
+				{LibraryID: lib.ID, Key: "Old/Folder/file.epub", EligibleAt: past, Reason: repo.ReasonOrphanRename, BookID: &bookID},
+				{LibraryID: lib.ID, Key: "Old/Folder/cover.jpg", EligibleAt: past, Reason: repo.ReasonOrphanRename, BookID: &bookID},
+				{LibraryID: lib.ID, Key: "Other/key.epub", EligibleAt: future, Reason: repo.ReasonOrphanRename, BookID: &bookID},
+			}
+			if err := pr.Insert(ctx, rows); err != nil {
+				t.Fatalf("Insert: %v", err)
+			}
+
+			// Re-insert is a no-op (UNIQUE library_id+key + ON CONFLICT DO NOTHING).
+			if err := pr.Insert(ctx, rows[:1]); err != nil {
+				t.Fatalf("Insert (dup): %v", err)
+			}
+
+			due, err := pr.SelectDue(ctx, now, 10)
+			if err != nil {
+				t.Fatalf("SelectDue: %v", err)
+			}
+			if len(due) != 2 {
+				t.Fatalf("SelectDue returned %d; want 2 (the two past-eligible)", len(due))
+			}
+			for _, po := range due {
+				if po.LibraryID != lib.ID {
+					t.Errorf("library_id=%q want %q", po.LibraryID, lib.ID)
+				}
+				if po.Reason != repo.ReasonOrphanRename {
+					t.Errorf("reason=%q", po.Reason)
+				}
+				if po.BookID == nil || *po.BookID != bookID {
+					t.Errorf("book_id=%v want %q", po.BookID, bookID)
+				}
+			}
+
+			// Delete one; only the other due row remains.
+			if err := pr.Delete(ctx, due[0].ID); err != nil {
+				t.Fatalf("Delete: %v", err)
+			}
+			due2, err := pr.SelectDue(ctx, now, 10)
+			if err != nil {
+				t.Fatalf("SelectDue after delete: %v", err)
+			}
+			if len(due2) != 1 {
+				t.Fatalf("SelectDue post-delete=%d want 1", len(due2))
+			}
+
+			// Deleting a missing id is not an error.
+			if err := pr.Delete(ctx, 999_999); err != nil {
+				t.Errorf("Delete missing: %v", err)
+			}
+		})
+	}
+}

--- a/internal/service/decide_effects.go
+++ b/internal/service/decide_effects.go
@@ -5,9 +5,9 @@ package service
 // call. Pure data; no I/O.
 //
 // The matrix encoded here is ADR-0001 §3 (trigger × backend) plus
-// ADR-0003 §6 (folder rename on author/title edits). When adding a
-// new trigger or backend, update this function and the table test in
-// TestDecideEffects.
+// ADR-0003 §6 + ADR-0005 (folder rename on author/title edits, both
+// backends). When adding a new trigger or backend, update this
+// function and the table test in TestDecideEffects.
 type Effects struct {
 	// DB indicates the canonical books-row update will fire. Always
 	// true for in-scope triggers; the field is explicit so callers
@@ -21,10 +21,10 @@ type Effects struct {
 	// unsupported format collapses to InFileWritten=false at runtime
 	// without changing the plan.
 	InFile bool
-	// FolderRename indicates the on-disk folder for this Book will be
-	// moved to match the new sanitized {Author}/{Title} per ADR-0003.
-	// Only set for local-backed libraries on user-driven triggers
-	// when the sanitized folder name actually changed.
+	// FolderRename indicates the on-disk folder (or S3 prefix) for this
+	// Book will be moved to match the new sanitized {Author}/{Title}
+	// per ADR-0003 §6 + ADR-0005. Set on user-driven triggers when the
+	// sanitized folder name actually changed; backend-agnostic.
 	FolderRename bool
 }
 
@@ -51,11 +51,18 @@ func DecideEffects(trigger Trigger, handle *LibraryHandle, folderChanged bool) E
 		return Effects{DB: true}
 	}
 	e := Effects{DB: true, Sidecar: true}
+	if folderChanged {
+		// Both backends rename on user-driven Author/Title edits.
+		// Local: atomic os.Rename. S3: copy + sweeper-deferred delete
+		// per ADR-0005. Trigger gate is the same (TriggerAutoEnrichment
+		// short-circuited above; only manual_edit + apply_enrichment
+		// reach here).
+		e.FolderRename = true
+	}
 	if handle.Library.BackendID == nil {
+		// In-file embed remains local-only — S3 still skips it per
+		// ADR-0001. Sidecar full-mirror carries the metadata on S3.
 		e.InFile = true
-		if folderChanged {
-			e.FolderRename = true
-		}
 	}
 	return e
 }

--- a/internal/service/decide_effects_test.go
+++ b/internal/service/decide_effects_test.go
@@ -78,11 +78,18 @@ func TestDecideEffects(t *testing.T) {
 			want:    service.Effects{DB: true, Sidecar: true, InFile: false},
 		},
 		{
-			name:          "manual edit on S3 never renames folder even with change",
+			name:          "manual edit on S3 with folder change adds rename (ADR-0005)",
 			trigger:       service.TriggerManualEdit,
 			handle:        s3Handle,
 			folderChanged: true,
-			want:          service.Effects{DB: true, Sidecar: true, InFile: false},
+			want:          service.Effects{DB: true, Sidecar: true, InFile: false, FolderRename: true},
+		},
+		{
+			name:          "apply-enrichment on S3 with folder change adds rename (ADR-0005)",
+			trigger:       service.TriggerApplyEnrichment,
+			handle:        s3Handle,
+			folderChanged: true,
+			want:          service.Effects{DB: true, Sidecar: true, InFile: false, FolderRename: true},
 		},
 		{
 			name:    "manual edit on local library writes DB + sidecar + in-file",

--- a/internal/service/metadata_writer.go
+++ b/internal/service/metadata_writer.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path"
@@ -16,9 +17,27 @@ import (
 	"github.com/blackforge/embookshelf/internal/fileproc"
 	"github.com/blackforge/embookshelf/internal/layout"
 	"github.com/blackforge/embookshelf/internal/model"
+	"github.com/blackforge/embookshelf/internal/repo"
 	"github.com/blackforge/embookshelf/internal/sidecar"
 	"github.com/blackforge/embookshelf/internal/storage"
 )
+
+// RenameRollbackGrace is the grace window applied to half-rename
+// new keys that need to be reaped after a phase-1 copy or DB-tx
+// failure. Short by design: no client ever held a presigned URL for
+// these keys (DB never referenced them), so there's nothing to wait
+// for. ADR-0005 §3.4.
+const RenameRollbackGrace = 5 * time.Minute
+
+// CopyRetryAttempts is the bounded retry budget for a single
+// CopyObject during phase-1. Three attempts with exponential backoff
+// rides out transient 5xx / throttle responses without spinning on a
+// genuinely-broken backend.
+const CopyRetryAttempts = 3
+
+// CopyRetryBaseDelay is the first backoff delay between copy retries.
+// Doubles each attempt: 200ms, 400ms, 800ms.
+const CopyRetryBaseDelay = 200 * time.Millisecond
 
 // Trigger identifies the upstream action that drove a metadata
 // write. Different triggers cause different steps to fire in the
@@ -43,6 +62,18 @@ const (
 type BookMetadataWriter interface {
 	UpdateMetadata(ctx context.Context, b model.Book) error
 	SetFolderPath(ctx context.Context, bookID, folderPath, path string) error
+	// RenameFolderTx is the single-transaction DB swap that finalises
+	// an S3 folder rename per ADR-0005: rewrites every files.location
+	// supplied, sets books.folder_path + books.path, and enqueues the
+	// supplied orphan rows.
+	RenameFolderTx(ctx context.Context, args repo.RenameFolderTxArgs) error
+}
+
+// PendingOrphansEnqueuer is the slice of *repo.PendingOrphanRepo
+// MetadataWriter needs for the rollback path: a phase-1 copy or DB
+// tx failure schedules the half-rename garbage with a short grace.
+type PendingOrphansEnqueuer interface {
+	Insert(ctx context.Context, rows []repo.PendingOrphanInsert) error
 }
 
 // LibraryStoreFor is the slice of LibraryStore we depend on.
@@ -79,6 +110,14 @@ type MetadataWriterDeps struct {
 	Sidecar  SidecarWriterFor
 	Dispatch EmbedderDispatcher
 	Files    FileMetadataRepo
+	// Orphans is the queue used by the S3 folder-rename rollback
+	// path (ADR-0005). Nil disables backend rename — a degraded
+	// MetadataWriter behaves like the pre-ADR-0005 build.
+	Orphans PendingOrphansEnqueuer
+	// RenameGrace is the eligible_at delta applied to the *old*
+	// keys enqueued after a successful S3 rename. Defaults to 1h
+	// when zero. Operators set this to ≥ 2 × PresignTTL.
+	RenameGrace time.Duration
 }
 
 // Outcome reports the post-execution facts of a Write call. Tests
@@ -183,12 +222,27 @@ func (w *MetadataWriter) folderDelta(b model.Book) (changed bool, oldFolder, new
 	return oldFolder != newFolder, oldFolder, newFolder
 }
 
-// renameFolder executes ADR-0003 §6.5 step 5: move the on-disk Book
-// folder to its new {Author}/{Title} location and update every
-// files.location + books.folder_path + books.path to match. Local
-// backends only — DecideEffects gates S3 out of this step.
+// renameFolder dispatches the post-DB rename step by backend kind.
+// Local: atomic os.Rename on the same FS (ADR-0003 §6.5). Backend
+// (S3): list-prefix + server-side copy-loop + single-tx DB swap +
+// sweeper-deferred delete (ADR-0005).
 //
-// Two cases:
+// On any failure the on-disk / backend state is left consistent
+// with the pre-rename world; the DB metadata is already committed
+// (sidecar carries it on S3) and the caller can retry.
+func (w *MetadataWriter) renameFolder(
+	ctx context.Context,
+	b model.Book,
+	handle *LibraryHandle,
+	oldFolder, newFolder string,
+) (bool, string) {
+	if handle.Library.BackendID != nil {
+		return w.renameFolderBackend(ctx, b, handle, oldFolder, newFolder)
+	}
+	return w.renameFolderLocal(ctx, b, handle, oldFolder, newFolder)
+}
+
+// renameFolderLocal is the local-fs arm of renameFolder. Two cases:
 //   - Legacy flat-layout (oldFolder == ""): files sit at library
 //     root. We move only this Book's files (per files.location),
 //     preserving siblings that belong to other flat-layout Books.
@@ -196,11 +250,7 @@ func (w *MetadataWriter) folderDelta(b model.Book) (changed bool, oldFolder, new
 //     rename the directory wholesale via os.Rename — atomic on
 //     same FS, carries the sidecar and any companion files for
 //     free.
-//
-// On any failure the on-disk + DB state is left consistent with the
-// pre-rename world (the DB metadata is already committed; the file
-// is correct at the old path). The caller / scan can retry.
-func (w *MetadataWriter) renameFolder(
+func (w *MetadataWriter) renameFolderLocal(
 	ctx context.Context,
 	b model.Book,
 	handle *LibraryHandle,
@@ -353,6 +403,248 @@ func (w *MetadataWriter) persistRename(
 		return false
 	}
 	return true
+}
+
+// renameFolderBackend is the S3 (any non-local Storage) arm of
+// renameFolder per ADR-0005. Pipeline:
+//
+//  1. List-prefix the old folder to enumerate every key (files +
+//     sidecar + cover + any user artifacts).
+//  2. Resolve a non-colliding new prefix via uniqueBackendFolder.
+//  3. Copy each old key to the new prefix, with bounded retry. On
+//     mid-loop failure, schedule the new keys we already wrote with
+//     RenameRollbackGrace and bail.
+//  4. Compute the per-files location updates for the rows DB knows
+//     about (others ride along under the new prefix without a row).
+//  5. RenameFolderTx: single transaction wraps files updates +
+//     books folder_path/path + INSERT pending_orphans (old keys,
+//     RenameGrace).
+//
+// Inline phase-2 deletes do not happen here — the sweeper drains
+// pending_orphans after the grace window. This keeps already-issued
+// presigned URLs valid for at least 2× PresignTTL.
+func (w *MetadataWriter) renameFolderBackend(
+	ctx context.Context,
+	b model.Book,
+	handle *LibraryHandle,
+	oldFolder, newFolder string,
+) (bool, string) {
+	if handle.Storage == nil {
+		slog.Warn("metadata writer: backend rename skipped (no storage)", "book_id", b.ID)
+		return false, ""
+	}
+	if w.deps.Orphans == nil {
+		// Without an orphan queue we cannot defer the source delete
+		// safely. Fail closed — sidecar full-mirror still carries the
+		// edit per ADR-0001's S3 fallback.
+		slog.Warn("metadata writer: backend rename skipped (no orphan queue)",
+			"book_id", b.ID)
+		return false, ""
+	}
+	if oldFolder == "" {
+		// S3 BackendPlacer has always written {Author}/{Title} prefixes
+		// (ADR-0003 §7) so a folder_path of "" on an S3-backed Book is
+		// either a pre-storage_v2 row or data corruption. Either way
+		// we cannot list the source — bail without a copy attempt.
+		slog.Warn("metadata writer: backend rename skipped (no source folder)",
+			"book_id", b.ID)
+		return false, ""
+	}
+
+	finalFolder := uniqueBackendFolder(ctx, handle.Storage, newFolder)
+	oldPrefix := oldFolder + "/"
+	newPrefix := finalFolder + "/"
+
+	srcKeys, err := listBackendPrefix(ctx, handle.Storage, oldPrefix)
+	if err != nil {
+		slog.Warn("metadata writer: backend rename list source",
+			"book_id", b.ID, "prefix", oldPrefix, "err", err)
+		return false, ""
+	}
+	if len(srcKeys) == 0 {
+		slog.Warn("metadata writer: backend rename source is empty",
+			"book_id", b.ID, "prefix", oldPrefix)
+		return false, ""
+	}
+
+	copied := make([]string, 0, len(srcKeys))
+	for _, src := range srcKeys {
+		dst := newPrefix + strings.TrimPrefix(src, oldPrefix)
+		if err := copyWithRetry(ctx, handle.Storage, src, dst); err != nil {
+			slog.Warn("metadata writer: backend rename copy",
+				"book_id", b.ID, "src", src, "dst", dst, "err", err)
+			w.scheduleOrphans(ctx, handle.Library.ID, copied, RenameRollbackGrace, b.ID)
+			return false, ""
+		}
+		copied = append(copied, dst)
+	}
+
+	fileUpdates, err := w.collectFileLocationUpdates(ctx, b, oldPrefix, newPrefix)
+	if err != nil {
+		slog.Warn("metadata writer: backend rename file enumeration",
+			"book_id", b.ID, "err", err)
+		w.scheduleOrphans(ctx, handle.Library.ID, copied, RenameRollbackGrace, b.ID)
+		return false, ""
+	}
+
+	newBookPath := newPrefix + filepath.Base(b.Path)
+	orphanInserts := buildOrphanInserts(handle.Library.ID, srcKeys, w.renameGrace(), b.ID)
+
+	if err := w.deps.Books.RenameFolderTx(ctx, repo.RenameFolderTxArgs{
+		BookID:    b.ID,
+		NewFolder: finalFolder,
+		NewPath:   newBookPath,
+		Files:     fileUpdates,
+		Orphans:   orphanInserts,
+	}); err != nil {
+		slog.Warn("metadata writer: backend rename db tx",
+			"book_id", b.ID, "err", err)
+		w.scheduleOrphans(ctx, handle.Library.ID, copied, RenameRollbackGrace, b.ID)
+		return false, ""
+	}
+
+	return true, finalFolder
+}
+
+// renameGrace returns the configured grace duration for old keys
+// after a successful rename. Defaults to 1h when unset, matching
+// the ADR-0005 fallback used in cmd/embookshelf wiring.
+func (w *MetadataWriter) renameGrace() time.Duration {
+	if w.deps.RenameGrace > 0 {
+		return w.deps.RenameGrace
+	}
+	return time.Hour
+}
+
+// collectFileLocationUpdates lists the Book's files rows and builds
+// per-row UPDATE inputs for any row whose location lives under the
+// old prefix. Rows that don't (legacy data drift) are skipped — they
+// will not survive the post-tx state but the rename should not fail
+// over a misaligned row.
+func (w *MetadataWriter) collectFileLocationUpdates(
+	ctx context.Context,
+	b model.Book,
+	oldPrefix, newPrefix string,
+) ([]repo.FileLocationUpdate, error) {
+	if w.deps.Files == nil {
+		return nil, nil
+	}
+	files, err := w.deps.Files.ListByBook(ctx, b.ID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]repo.FileLocationUpdate, 0, len(files))
+	for _, f := range files {
+		if !strings.HasPrefix(f.Location, oldPrefix) {
+			slog.Warn("metadata writer: backend rename skipping mis-prefixed file",
+				"book_id", b.ID, "file_id", f.ID, "location", f.Location)
+			continue
+		}
+		out = append(out, repo.FileLocationUpdate{
+			FileID:   f.ID,
+			Location: newPrefix + strings.TrimPrefix(f.Location, oldPrefix),
+		})
+	}
+	return out, nil
+}
+
+// scheduleOrphans is the rollback escape hatch: enqueue the supplied
+// (presumably new-prefix) keys with RenameRollbackGrace so the
+// sweeper deletes the half-rename garbage on its next pass. Best
+// effort — failure to enqueue is logged but does not change the
+// caller's error path.
+func (w *MetadataWriter) scheduleOrphans(
+	ctx context.Context,
+	libraryID string,
+	keys []string,
+	grace time.Duration,
+	bookID string,
+) {
+	if len(keys) == 0 || w.deps.Orphans == nil {
+		return
+	}
+	rows := buildOrphanInserts(libraryID, keys, grace, bookID)
+	if err := w.deps.Orphans.Insert(ctx, rows); err != nil {
+		slog.Warn("metadata writer: schedule rollback orphans",
+			"library_id", libraryID, "count", len(keys), "err", err)
+	}
+}
+
+// buildOrphanInserts converts a slice of keys into the typed insert
+// rows for the pending_orphans table. eligible_at is now+grace.
+func buildOrphanInserts(libraryID string, keys []string, grace time.Duration, bookID string) []repo.PendingOrphanInsert {
+	if len(keys) == 0 {
+		return nil
+	}
+	now := time.Now().UTC()
+	out := make([]repo.PendingOrphanInsert, 0, len(keys))
+	bid := bookID
+	for _, k := range keys {
+		out = append(out, repo.PendingOrphanInsert{
+			LibraryID:  libraryID,
+			Key:        k,
+			EligibleAt: now.Add(grace),
+			Reason:     repo.ReasonOrphanRename,
+			BookID:     &bid,
+		})
+	}
+	return out
+}
+
+// listBackendPrefix walks store under prefix and returns every key
+// found (paginated iterators handled by storage.Iterator). Returned
+// keys preserve the prefix so callers can compute new keys via
+// strings.TrimPrefix without re-joining.
+func listBackendPrefix(ctx context.Context, store storage.Storage, prefix string) ([]string, error) {
+	it, err := store.List(ctx, prefix)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = it.Close() }()
+	var keys []string
+	for {
+		obj, err := it.Next(ctx)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, err
+		}
+		keys = append(keys, obj.Key)
+	}
+	return keys, nil
+}
+
+// copyWithRetry runs Storage.Copy with bounded exponential backoff.
+// Context cancellation aborts immediately; other errors are retried
+// up to CopyRetryAttempts times. Returns the final error on
+// exhaustion. Backends that surface ErrNotFound are treated as
+// terminal — there is nothing to retry on a missing source.
+func copyWithRetry(ctx context.Context, store storage.Storage, src, dst string) error {
+	delay := CopyRetryBaseDelay
+	var lastErr error
+	for attempt := 0; attempt < CopyRetryAttempts; attempt++ {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		_, err := store.Copy(ctx, src, dst)
+		if err == nil {
+			return nil
+		}
+		if errors.Is(err, storage.ErrNotFound) {
+			return err
+		}
+		lastErr = err
+		if attempt+1 < CopyRetryAttempts {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+			}
+			delay *= 2
+		}
+	}
+	return lastErr
 }
 
 // uniqueDirectoryUnless is a variant of uniqueDirectory that returns

--- a/internal/service/metadata_writer_test.go
+++ b/internal/service/metadata_writer_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/blackforge/embookshelf/internal/fileproc"
 	"github.com/blackforge/embookshelf/internal/model"
+	"github.com/blackforge/embookshelf/internal/repo"
 	"github.com/blackforge/embookshelf/internal/service"
 	"github.com/blackforge/embookshelf/internal/sidecar"
 	"github.com/blackforge/embookshelf/internal/storage"
@@ -24,6 +25,8 @@ type fakeBookWriter struct {
 	called          []model.Book
 	err             error
 	folderPathCalls []folderPathCall
+	renameTxCalls   []repo.RenameFolderTxArgs
+	renameTxErr     error
 }
 
 type folderPathCall struct {
@@ -40,6 +43,22 @@ func (f *fakeBookWriter) UpdateMetadata(ctx context.Context, b model.Book) error
 func (f *fakeBookWriter) SetFolderPath(ctx context.Context, bookID, folderPath, path string) error {
 	f.folderPathCalls = append(f.folderPathCalls, folderPathCall{BookID: bookID, FolderPath: folderPath, Path: path})
 	return nil
+}
+
+func (f *fakeBookWriter) RenameFolderTx(ctx context.Context, args repo.RenameFolderTxArgs) error {
+	f.renameTxCalls = append(f.renameTxCalls, args)
+	return f.renameTxErr
+}
+
+// fakeOrphans records orphan inserts for the rollback path.
+type fakeOrphans struct {
+	calls [][]repo.PendingOrphanInsert
+	err   error
+}
+
+func (f *fakeOrphans) Insert(ctx context.Context, rows []repo.PendingOrphanInsert) error {
+	f.calls = append(f.calls, rows)
+	return f.err
 }
 
 // fakeLibStore returns a fixed handle for any libraryID.
@@ -649,7 +668,7 @@ func TestMetadataWriter_FolderRename_NoChange(t *testing.T) {
 		t.Fatalf("local.New: %v", err)
 	}
 	folder := "Tolkien/The Hobbit"
-	if err := os.MkdirAll(libRoot + "/" + folder, 0o755); err != nil {
+	if err := os.MkdirAll(libRoot+"/"+folder, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
 
@@ -687,10 +706,182 @@ func TestMetadataWriter_FolderRename_NoChange(t *testing.T) {
 	}
 }
 
-// TestMetadataWriter_FolderRename_S3SkipsRename covers the
-// S3-backend gate: even on author/title change the folder must not
-// be renamed (per ADR-0003 §7).
-func TestMetadataWriter_FolderRename_S3SkipsRename(t *testing.T) {
+// TestMetadataWriter_FolderRename_S3Renames covers ADR-0005: an
+// S3-backed library now performs an edit-time folder rename via
+// list-prefix + server-side copy + sweeper-deferred delete. Uses
+// local.Storage as a stand-in backend (the rename pipeline is
+// agnostic to the concrete Storage impl).
+func TestMetadataWriter_FolderRename_S3Renames(t *testing.T) {
+	libRoot := t.TempDir()
+	fs, err := local.New(libRoot)
+	if err != nil {
+		t.Fatalf("local.New: %v", err)
+	}
+	backendID := "backend-s3"
+	oldFolder := "Tolkien/Hobbit"
+	oldDir := libRoot + "/" + oldFolder
+	if err := os.MkdirAll(oldDir, 0o755); err != nil {
+		t.Fatalf("mkdir old: %v", err)
+	}
+	if err := os.WriteFile(oldDir+"/hobbit.epub", []byte("epub"), 0o644); err != nil {
+		t.Fatalf("write book: %v", err)
+	}
+	if err := os.WriteFile(oldDir+"/metadata.embookshelf.json", []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write sidecar: %v", err)
+	}
+
+	books := &fakeBookWriter{}
+	files := &fakeFileRepo{
+		files: []model.File{
+			{ID: "f1", Location: oldFolder + "/hobbit.epub", Format: "EPUB"},
+		},
+	}
+	orphans := &fakeOrphans{}
+	handle := &service.LibraryHandle{
+		Library: model.Library{ID: "lib1", Path: libRoot, BackendID: &backendID},
+		Storage: fs,
+	}
+	libStore := &fakeLibStore{handle: handle}
+	mw := service.NewMetadataWriter(service.MetadataWriterDeps{
+		Books:       books,
+		LibStore:    libStore,
+		Files:       files,
+		Orphans:     orphans,
+		RenameGrace: time.Hour,
+	})
+
+	folder := oldFolder
+	book := model.Book{
+		ID: "b1", LibraryID: "lib1",
+		Author: "Tolkien", Title: "The Hobbit",
+		Format: "EPUB", Path: oldFolder + "/hobbit.epub",
+		FolderPath: &folder,
+	}
+	out, err := mw.Write(context.Background(), book, service.TriggerManualEdit)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if !out.FolderRenamed {
+		t.Fatalf("FolderRenamed=false; outcome=%+v", out)
+	}
+	wantFolder := "Tolkien/The Hobbit"
+	if out.NewFolderPath != wantFolder {
+		t.Errorf("NewFolderPath=%q want %q", out.NewFolderPath, wantFolder)
+	}
+
+	// New keys exist; old keys still exist (sweeper hasn't run).
+	if _, err := os.Stat(libRoot + "/" + wantFolder + "/hobbit.epub"); err != nil {
+		t.Errorf("new key missing: %v", err)
+	}
+	if _, err := os.Stat(libRoot + "/" + wantFolder + "/metadata.embookshelf.json"); err != nil {
+		t.Errorf("new sidecar missing: %v", err)
+	}
+	if _, err := os.Stat(oldDir + "/hobbit.epub"); err != nil {
+		t.Errorf("old key deleted prematurely; want sweeper-deferred: %v", err)
+	}
+
+	// Single RenameFolderTx call carries the orphan inserts for old keys.
+	if len(books.renameTxCalls) != 1 {
+		t.Fatalf("RenameFolderTx calls=%d want 1", len(books.renameTxCalls))
+	}
+	tx := books.renameTxCalls[0]
+	if tx.NewFolder != wantFolder {
+		t.Errorf("tx.NewFolder=%q want %q", tx.NewFolder, wantFolder)
+	}
+	if len(tx.Files) != 1 || tx.Files[0].Location != wantFolder+"/hobbit.epub" {
+		t.Errorf("tx.Files=%+v", tx.Files)
+	}
+	if len(tx.Orphans) != 2 {
+		t.Errorf("tx.Orphans=%d want 2 (epub + sidecar)", len(tx.Orphans))
+	}
+	for _, o := range tx.Orphans {
+		if !strings.HasPrefix(o.Key, oldFolder+"/") {
+			t.Errorf("orphan key=%q not under old prefix", o.Key)
+		}
+		if o.Reason != repo.ReasonOrphanRename {
+			t.Errorf("orphan reason=%q", o.Reason)
+		}
+	}
+
+	// Rollback path not taken.
+	if len(orphans.calls) != 0 {
+		t.Errorf("rollback orphans called=%d want 0", len(orphans.calls))
+	}
+}
+
+// TestMetadataWriter_FolderRename_BackendTxFailRollback covers the
+// rollback path: phase-1 copy succeeds but the DB tx fails. The
+// half-rename new keys must be enqueued with the short rollback
+// grace via the standalone Orphans queue.
+func TestMetadataWriter_FolderRename_BackendTxFailRollback(t *testing.T) {
+	libRoot := t.TempDir()
+	fs, err := local.New(libRoot)
+	if err != nil {
+		t.Fatalf("local.New: %v", err)
+	}
+	backendID := "backend-s3"
+	oldFolder := "Tolkien/Hobbit"
+	oldDir := libRoot + "/" + oldFolder
+	if err := os.MkdirAll(oldDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(oldDir+"/hobbit.epub", []byte("epub"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	books := &fakeBookWriter{renameTxErr: errors.New("simulated tx failure")}
+	files := &fakeFileRepo{
+		files: []model.File{
+			{ID: "f1", Location: oldFolder + "/hobbit.epub", Format: "EPUB"},
+		},
+	}
+	orphans := &fakeOrphans{}
+	handle := &service.LibraryHandle{
+		Library: model.Library{ID: "lib1", Path: libRoot, BackendID: &backendID},
+		Storage: fs,
+	}
+	mw := service.NewMetadataWriter(service.MetadataWriterDeps{
+		Books:    books,
+		LibStore: &fakeLibStore{handle: handle},
+		Files:    files,
+		Orphans:  orphans,
+	})
+
+	folder := oldFolder
+	book := model.Book{
+		ID: "b1", LibraryID: "lib1",
+		Author: "Tolkien", Title: "The Hobbit",
+		Format: "EPUB", Path: oldFolder + "/hobbit.epub",
+		FolderPath: &folder,
+	}
+	out, err := mw.Write(context.Background(), book, service.TriggerManualEdit)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if out.FolderRenamed {
+		t.Error("FolderRenamed=true; want false on tx failure")
+	}
+
+	// One Orphans.Insert call carrying the new-prefix keys with
+	// short-grace eligibility.
+	if len(orphans.calls) != 1 {
+		t.Fatalf("Orphans.Insert calls=%d want 1", len(orphans.calls))
+	}
+	rows := orphans.calls[0]
+	if len(rows) != 1 {
+		t.Fatalf("rollback rows=%d want 1", len(rows))
+	}
+	wantKey := "Tolkien/The Hobbit/hobbit.epub"
+	if rows[0].Key != wantKey {
+		t.Errorf("rollback key=%q want %q", rows[0].Key, wantKey)
+	}
+}
+
+// TestMetadataWriter_FolderRename_BackendNoOrphansRepo verifies
+// MetadataWriter fails closed when constructed without an Orphans
+// queue: the backend rename arm cannot defer the source delete
+// safely, so it must not attempt the copy + tx at all.
+func TestMetadataWriter_FolderRename_BackendNoOrphansRepo(t *testing.T) {
 	libRoot := t.TempDir()
 	fs, err := local.New(libRoot)
 	if err != nil {
@@ -698,15 +889,18 @@ func TestMetadataWriter_FolderRename_S3SkipsRename(t *testing.T) {
 	}
 	backendID := "backend-s3"
 	folder := "Tolkien/Hobbit"
+	if err := os.MkdirAll(libRoot+"/"+folder, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
 	books := &fakeBookWriter{}
 	handle := &service.LibraryHandle{
 		Library: model.Library{ID: "lib1", Path: libRoot, BackendID: &backendID},
 		Storage: fs,
 	}
-	libStore := &fakeLibStore{handle: handle}
 	mw := service.NewMetadataWriter(service.MetadataWriterDeps{
 		Books:    books,
-		LibStore: libStore,
+		LibStore: &fakeLibStore{handle: handle},
 	})
 
 	book := model.Book{
@@ -720,6 +914,9 @@ func TestMetadataWriter_FolderRename_S3SkipsRename(t *testing.T) {
 		t.Fatalf("Write: %v", err)
 	}
 	if out.FolderRenamed {
-		t.Error("FolderRenamed=true on S3-backed library; want false")
+		t.Error("FolderRenamed=true with nil Orphans; want false")
+	}
+	if len(books.renameTxCalls) != 0 {
+		t.Errorf("RenameFolderTx called %d times; want 0", len(books.renameTxCalls))
 	}
 }

--- a/internal/task/orphaned_keys.go
+++ b/internal/task/orphaned_keys.go
@@ -1,0 +1,106 @@
+package task
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/blackforge/embookshelf/internal/repo"
+	"github.com/blackforge/embookshelf/internal/storage"
+)
+
+// OrphanedKeysBatch caps the number of pending_orphans rows the
+// sweeper drains per pass. Bounded work per tick keeps DB+S3 load
+// predictable and lets transient backend errors retry next tick.
+const OrphanedKeysBatch = 500
+
+// OrphanedKeysDeps is the dependency surface for the sweeper. The
+// Storage backend per library is resolved on each row via Resolver
+// + LibraryRepo so a freshly-added backend is picked up without
+// restarting the loop.
+type OrphanedKeysDeps struct {
+	Orphans  *repo.PendingOrphanRepo
+	Libs     *repo.LibraryRepo
+	Resolver storage.Resolver
+}
+
+// RunOrphanedKeysOnce drains one batch. Used by tests + the looping
+// driver. Returns (deletedCount, error). A backend error on a single
+// row is logged and skipped; the row stays for the next pass.
+func RunOrphanedKeysOnce(ctx context.Context, deps OrphanedKeysDeps, now time.Time) (int, error) {
+	if deps.Orphans == nil || deps.Libs == nil || deps.Resolver == nil {
+		return 0, nil
+	}
+	due, err := deps.Orphans.SelectDue(ctx, now, OrphanedKeysBatch)
+	if err != nil {
+		return 0, err
+	}
+	if len(due) == 0 {
+		return 0, nil
+	}
+	libCache := make(map[string]storage.Storage, 4)
+	deleted := 0
+	for _, po := range due {
+		store, ok := libCache[po.LibraryID]
+		if !ok {
+			lib, lerr := deps.Libs.GetByID(ctx, po.LibraryID)
+			if lerr != nil {
+				slog.Warn("orphan sweeper: lookup library", "library_id", po.LibraryID, "err", lerr)
+				continue
+			}
+			backendID := ""
+			if lib.BackendID != nil {
+				backendID = *lib.BackendID
+			}
+			s, rerr := deps.Resolver.Resolve(backendID)
+			if rerr != nil {
+				slog.Warn("orphan sweeper: resolve backend",
+					"library_id", po.LibraryID, "backend_id", backendID, "err", rerr)
+				continue
+			}
+			store = s
+			libCache[po.LibraryID] = store
+		}
+		if err := store.Delete(ctx, po.Key); err != nil && !errors.Is(err, storage.ErrNotFound) {
+			slog.Warn("orphan sweeper: delete key",
+				"library_id", po.LibraryID, "key", po.Key, "err", err)
+			continue
+		}
+		if err := deps.Orphans.Delete(ctx, po.ID); err != nil {
+			slog.Warn("orphan sweeper: dequeue row",
+				"id", po.ID, "key", po.Key, "err", err)
+			continue
+		}
+		deleted++
+	}
+	return deleted, nil
+}
+
+// LoopOrphanedKeys runs RunOrphanedKeysOnce on a ticker until ctx
+// is cancelled. Errors are logged but do not stop the loop.
+func LoopOrphanedKeys(ctx context.Context, deps OrphanedKeysDeps, every time.Duration) {
+	if every <= 0 {
+		every = time.Hour
+	}
+	if deps.Orphans == nil || deps.Libs == nil || deps.Resolver == nil {
+		return
+	}
+	t := time.NewTicker(every)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			n, err := RunOrphanedKeysOnce(ctx, deps, time.Now())
+			if err != nil {
+				slog.Warn("orphan sweeper", "err", err)
+				continue
+			}
+			if n > 0 {
+				slog.Info("orphan sweeper", "deleted", n)
+			}
+		}
+	}
+}

--- a/internal/task/orphaned_keys_test.go
+++ b/internal/task/orphaned_keys_test.go
@@ -1,0 +1,137 @@
+package task_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/blackforge/embookshelf/internal/repo"
+	"github.com/blackforge/embookshelf/internal/repo/repotest"
+	"github.com/blackforge/embookshelf/internal/storage"
+	"github.com/blackforge/embookshelf/internal/task"
+)
+
+// fakeStore tracks Delete calls and lets tests inject errors per key.
+type fakeStore struct {
+	mu      sync.Mutex
+	deleted []string
+	errOn   map[string]error
+}
+
+func (f *fakeStore) Capabilities() storage.Capability { return 0 }
+func (f *fakeStore) List(context.Context, string) (storage.Iterator, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeStore) Head(context.Context, string) (storage.ObjectInfo, error) {
+	return storage.ObjectInfo{}, errors.New("not implemented")
+}
+func (f *fakeStore) Get(context.Context, string, ...storage.GetOption) (io.ReadCloser, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeStore) Put(context.Context, string, io.Reader, ...storage.PutOption) (storage.PutResult, error) {
+	return storage.PutResult{}, errors.New("not implemented")
+}
+func (f *fakeStore) Delete(_ context.Context, key string, _ ...storage.DeleteOption) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err, ok := f.errOn[key]; ok {
+		return err
+	}
+	f.deleted = append(f.deleted, key)
+	return nil
+}
+func (f *fakeStore) Copy(context.Context, string, string) (storage.CopyResult, error) {
+	return storage.CopyResult{}, errors.New("not implemented")
+}
+func (f *fakeStore) Open(context.Context, string) (storage.Source, error) {
+	return nil, errors.New("not implemented")
+}
+
+// TestRunOrphanedKeysOnce_DrainsDueRows verifies the sweeper only
+// touches rows whose eligible_at has passed and removes them after a
+// successful Delete.
+func TestRunOrphanedKeysOnce_DrainsDueRows(t *testing.T) {
+	d := repotest.NewWithDialect(t, "sqlite")
+	libRepo := repo.NewLibraryRepo(d)
+	orphans := repo.NewPendingOrphanRepo(d)
+	ctx := context.Background()
+
+	lib, err := libRepo.CreateLibrary(ctx, "Sweep", "sweep", "/tmp/sweep", nil)
+	if err != nil {
+		t.Fatalf("CreateLibrary: %v", err)
+	}
+
+	now := time.Now().UTC()
+	bookID := "b1"
+	rows := []repo.PendingOrphanInsert{
+		{LibraryID: lib.ID, Key: "Old/file.epub", EligibleAt: now.Add(-time.Hour), Reason: repo.ReasonOrphanRename, BookID: &bookID},
+		{LibraryID: lib.ID, Key: "Old/cover.jpg", EligibleAt: now.Add(-time.Hour), Reason: repo.ReasonOrphanRename, BookID: &bookID},
+		{LibraryID: lib.ID, Key: "Future/key.epub", EligibleAt: now.Add(time.Hour), Reason: repo.ReasonOrphanRename, BookID: &bookID},
+	}
+	if err := orphans.Insert(ctx, rows); err != nil {
+		t.Fatalf("Insert orphans: %v", err)
+	}
+
+	store := &fakeStore{}
+	deps := task.OrphanedKeysDeps{
+		Orphans:  orphans,
+		Libs:     libRepo,
+		Resolver: storage.ConstantResolver{S: store},
+	}
+
+	n, err := task.RunOrphanedKeysOnce(ctx, deps, now)
+	if err != nil {
+		t.Fatalf("RunOrphanedKeysOnce: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("deleted=%d want 2", n)
+	}
+	if len(store.deleted) != 2 {
+		t.Errorf("Delete calls=%d want 2", len(store.deleted))
+	}
+
+	// Future row still present.
+	remaining, err := orphans.SelectDue(ctx, now.Add(2*time.Hour), 10)
+	if err != nil {
+		t.Fatalf("SelectDue: %v", err)
+	}
+	if len(remaining) != 1 || remaining[0].Key != "Future/key.epub" {
+		t.Errorf("remaining=%+v", remaining)
+	}
+}
+
+// TestRunOrphanedKeysOnce_NotFoundIsSuccess verifies that a missing
+// key is treated as a successful delete (the desired state — gone).
+func TestRunOrphanedKeysOnce_NotFoundIsSuccess(t *testing.T) {
+	d := repotest.NewWithDialect(t, "sqlite")
+	libRepo := repo.NewLibraryRepo(d)
+	orphans := repo.NewPendingOrphanRepo(d)
+	ctx := context.Background()
+	lib, _ := libRepo.CreateLibrary(ctx, "x", "x", "/tmp/x", nil)
+	now := time.Now().UTC()
+	bookID := "b1"
+	if err := orphans.Insert(ctx, []repo.PendingOrphanInsert{
+		{LibraryID: lib.ID, Key: "missing.epub", EligibleAt: now.Add(-time.Minute), Reason: repo.ReasonOrphanRename, BookID: &bookID},
+	}); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	store := &fakeStore{errOn: map[string]error{
+		"missing.epub": errors.Join(storage.ErrNotFound, errors.New("nope")),
+	}}
+	deps := task.OrphanedKeysDeps{
+		Orphans:  orphans,
+		Libs:     libRepo,
+		Resolver: storage.ConstantResolver{S: store},
+	}
+	if _, err := task.RunOrphanedKeysOnce(ctx, deps, now); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	left, _ := orphans.SelectDue(ctx, now.Add(time.Hour), 10)
+	if len(left) != 0 {
+		t.Errorf("not-found should still dequeue; left=%d", len(left))
+	}
+}

--- a/internal/task/scan_import.go
+++ b/internal/task/scan_import.go
@@ -21,10 +21,10 @@ import (
 // emitted them; Mixed propagates Classify's warning flag for admin
 // surfacing later.
 type ScanImportArgs struct {
-	LibraryID string             `json:"library_id"`
-	Folder    string             `json:"folder"`
-	Files     []ScanImportFile   `json:"files"`
-	Mixed     bool               `json:"mixed,omitempty"`
+	LibraryID string           `json:"library_id"`
+	Folder    string           `json:"folder"`
+	Files     []ScanImportFile `json:"files"`
+	Mixed     bool             `json:"mixed,omitempty"`
 }
 
 // ScanImportFile is a JSON-friendly slice of scan.WalkEntry. Carries


### PR DESCRIPTION
This update introduces a new `pending_orphans` table to manage keys left behind after S3 folder renames, as per ADR-0005. The system now queues old keys for deletion after a grace period, ensuring that presigned URLs remain valid during this time. The `MetadataWriter` has been updated to handle the renaming process, including a new transaction method for atomic updates and orphan insertions. Additionally, a background sweeper has been implemented to delete keys past their eligibility date. Tests have been added to verify the functionality of the pending orphan management.