### PR TITLE
feat(pdf-discovery): XMP, hex strings, ISBN, client-rendered cover

### DIFF
--- a/docs/adr/0015-pdf-cover-rendered-client-side.md
+++ b/docs/adr/0015-pdf-cover-rendered-client-side.md
@@ -1,0 +1,33 @@
+# PDF cover rendered in the browser at BookDrop preview
+
+The PDF processor returns no cover bytes — server-side rasterisation needs a PDF rendering library, and every viable Go option violates a load-bearing repo constraint. We push cover rasterisation into the browser instead: when a user opens the BookDrop preview for a PDF, the existing pdfjs-based reader renders page 1, encodes JPEG q85 at 1200 px wide, and `PUT`s the bytes to `/api/v1/bookdrop/:id/cover`. The server treats the upload as the canonical pre-approval cover; approve promotes it through `coverstore` like any other format.
+
+## Status
+
+accepted (2026-05-03)
+
+## Considered options
+
+- **`go-fitz` (CGO MuPDF bindings).** Best fidelity, but introduces CGO. Repo deliberately runs CGO-free (modernc SQLite chosen for that exact reason); enabling CGO breaks `make build` cross-compile and the distroless `nonroot` image.
+- **Exec `mutool draw` / `pdftoppm` from the Go process.** No CGO, but adds a runtime binary dependency. Dents the single-binary distribution and requires a non-distroless image variant.
+- **`unidoc/unipdf` pure-Go.** Rasterisation works, but the licence is AGPL or commercial — incompatible with a self-host project that doesn't want viral copyleft on the server binary.
+- **`pdfcpu` rasterise.** Rasterisation is not a first-class concern; output is fragile on real-world PDFs.
+- **Defer cover entirely.** Status quo. Leaves PDFs without cover bytes for OPDS / Kavita / KOReader / Kobo OPDS clients that don't run pdfjs.
+
+We picked the browser-render path because it preserves the no-CGO, single-binary, licence-clean invariants while still producing a real cover that flows through `coverstore` (SHA-256 dedup) and reaches non-pdfjs OPDS clients on first sync.
+
+## Consequences
+
+- The browser is trusted to produce the cover bytes. The server validates the PNG/JPEG magic and caps the body at 5 MB, but does not verify the bytes truly came from page 1 of the uploaded PDF. Acceptable: the BookDrop reviewer is an authenticated user with admin-or-uploader scope on the item, and the cover is reviewable in the same UI before approve.
+- The endpoint is idempotent-on-absence: first call wins, second call returns 409. A reviewer who wants to replace the auto-rendered cover uses the existing post-approve cover-edit flow, not a re-PUT.
+- PDFs imported before this change land without a cover. A small admin-side backfill ("regenerate covers") is non-blocking future work; it can either reuse the same client-render endpoint against the imported book or, later, ship a server-side rasteriser as an opt-in build tag.
+- The PDF extractor itself remains pure-regex and CGO-free. No PDF library dependency is introduced anywhere in the Go module graph.
+
+## Companion artifacts
+
+- `internal/fileproc/pdf.go` — extractor stays cover-less; `Metadata.HasCover` always false for PDF.
+- `internal/handler/bookdrop.go` — new `BookDropPutCover` handler.
+- `internal/handler/router.go` — `PUT /api/v1/bookdrop/:id/cover`.
+- `internal/service/bookdrop.go` — pre-approval cover write path; reject when item already has a cover or is not in `discovered`/`needs_review`.
+- `ui/src/components/PdfReader.tsx` (or BookDrop preview wrapper) — render page 1, `canvas.toBlob('image/jpeg', 0.85)`, PUT.
+- ADR-0001 — sidecar write-back: cover bytes still flow through `coverstore` on approve, not through sidecar.

--- a/docs/spec/pdf-discovery.spec.md
+++ b/docs/spec/pdf-discovery.spec.md
@@ -1,0 +1,432 @@
+# PDF Discovery, Title & Author Handling — Spec (Go)
+
+## 1. Layout
+
+```
+booklore/
+├── cmd/booklore/main.go
+└── internal/
+    ├── monitoring/        # fs watcher
+    ├── bookdrop/          # alt drop folder
+    ├── ingest/            # event processor + dispatch
+    ├── fileprocessor/     # per-format processors (pdf, epub, ...)
+    ├── metadata/
+    │   └── pdf/           # PDFBox-equivalent extractor
+    ├── store/             # repos + entities (gorm or sqlc)
+    └── config/
+```
+
+Deps:
+- `github.com/fsnotify/fsnotify` — fs events.
+- `github.com/pdfcpu/pdfcpu` or `github.com/ledongthuc/pdf` or `github.com/unidoc/unipdf/v3` — PDF parse + render.
+- `github.com/beevik/etree` — XMP XML.
+- `gorm.io/gorm` or `database/sql` + `sqlc`.
+
+## 2. Discovery
+
+Two entry points feed shared event channel.
+
+### 2.1 Library watcher (primary)
+
+- Pkg: `internal/monitoring`
+- File: `library_watch.go`
+- Wraps `fsnotify.Watcher`. Walks library roots with `filepath.WalkDir`, calls `watcher.Add()` per dir.
+
+```go
+type WatchService struct {
+    w        *fsnotify.Watcher
+    out      chan<- FileEvent
+    roots    []string
+    log      *slog.Logger
+    mu       sync.Mutex
+    watched  map[string]struct{}
+}
+
+func (s *WatchService) Run(ctx context.Context) error {
+    for {
+        select {
+        case <-ctx.Done():
+            return ctx.Err()
+        case ev := <-s.w.Events:
+            if !isSupported(ev.Name) { continue }
+            switch {
+            case ev.Op&fsnotify.Create != 0:
+                if fi, err := os.Stat(ev.Name); err == nil && fi.IsDir() {
+                    s.addRecursive(ev.Name)
+                    continue
+                }
+                s.out <- FileEvent{Op: OpCreate, Path: ev.Name}
+            case ev.Op&fsnotify.Remove != 0:
+                s.out <- FileEvent{Op: OpDelete, Path: ev.Name}
+            }
+        case err := <-s.w.Errors:
+            s.log.Warn("watch error", "err", err)
+        }
+    }
+}
+```
+
+`isSupported` — extension whitelist (`.pdf`, `.epub`, ...).
+
+### 2.2 Bookdrop watcher (alt)
+
+- Pkg: `internal/bookdrop`
+- File: `monitor.go`
+- Watches `cfg.BookdropFolder`.
+- Backfill on startup: `filepath.WalkDir` → emit synthetic create events for existing files.
+- Same `FileEvent` channel.
+
+### 2.3 Event processor
+
+- Pkg: `internal/ingest`
+- File: `processor.go`
+
+Constants:
+
+```go
+const (
+    debounceFile        = 500 * time.Millisecond
+    debounceFolder      = 5 * time.Second
+    stabilityInterval   = 3 * time.Second
+    stabilityMaxWait    = 120 * time.Second
+)
+```
+
+Pipeline:
+
+```go
+type Processor struct {
+    in       <-chan FileEvent
+    handler  TransactionalHandler
+    debounce map[string]*time.Timer
+    mu       sync.Mutex
+}
+
+func (p *Processor) Run(ctx context.Context) {
+    for {
+        select {
+        case <-ctx.Done(): return
+        case ev := <-p.in:
+            p.schedule(ev)
+        }
+    }
+}
+```
+
+Per-path debounce timer resets on every event. After fire:
+1. `fileHasContent(path)` — `os.Stat`, skip if size 0.
+2. `awaitStable(path)` — poll size every `stabilityInterval` until 2 consecutive equal sizes or `stabilityMaxWait` elapsed.
+3. Resolve org mode for library: `BookPerFile` | `BookPerFolder` | `AutoDetect`.
+4. `handler.HandleNewBookFile(ctx, libraryID, path)`.
+
+`AutoDetect`: walk folder, count audio files, treat as folder-book only if ≥ 2.
+
+## 3. PDF dispatch
+
+- Pkg: `internal/fileprocessor`
+- Interface:
+
+```go
+type BookFileProcessor interface {
+    Supports() []BookFileType
+    ProcessNew(ctx context.Context, lf LibraryFile) error
+}
+```
+
+- File: `pdf_processor.go`
+
+```go
+type PdfProcessor struct {
+    creator   *BookCreatorService
+    extractor *pdf.MetadataExtractor
+    cover     *pdf.CoverGenerator
+    log       *slog.Logger
+}
+
+func (p *PdfProcessor) Supports() []BookFileType { return []BookFileType{BookFilePDF} }
+
+func (p *PdfProcessor) ProcessNew(ctx context.Context, lf LibraryFile) error {
+    book, err := p.creator.CreateShell(ctx, lf)
+    if err != nil { return err }
+
+    if err := p.cover.Generate(ctx, lf.Path, book.ID); err != nil {
+        p.log.Warn("cover gen failed, fallback folder image", "err", err)
+        _ = p.cover.FolderFallback(ctx, lf, book.ID)
+    }
+
+    return p.extractAndSet(ctx, lf.Path, book)
+}
+```
+
+Cover render — first page, 150 DPI, RGB. Wrap pdf lib calls in `defer recover()` to catch panics from corrupt PDFs (Go equivalent of `OutOfMemoryError` / `NegativeArraySizeException` handling). On fail: log, return nil error so pipeline proceeds.
+
+## 4. Title resolution
+
+- Pkg: `internal/metadata/pdf`
+- File: `extractor.go`
+
+Fallback chain (first non-blank wins):
+
+1. PDF Document Info dictionary → `Title`.
+2. XMP `dc:title/rdf:Alt/rdf:li`. Overrides DocInfo if present.
+3. Filename basename (`strings.TrimSuffix(filepath.Base(p), filepath.Ext(p))`) — when DocInfo + XMP both blank.
+4. Bookdrop late fallback: `bookdrop.AttachInitial()` sets filename when extractor returned `nil`.
+
+Helper:
+
+```go
+func firstNonBlank(vals ...string) string {
+    for _, v := range vals {
+        if strings.TrimSpace(v) != "" { return v }
+    }
+    return ""
+}
+```
+
+Title-adjacent XMP fields:
+- `booklore:subtitle` (camelCase) + PascalCase legacy `booklore:Subtitle`.
+- `calibre:series`, `calibreSI:series_index`.
+- `booklore:seriesName`, `booklore:seriesNumber`, `booklore:seriesTotal`.
+
+## 5. Author resolution
+
+Chain:
+
+1. PDF Doc Info `Author`. Split on regex `[,&]`:
+
+```go
+var authorSep = regexp.MustCompile(`[,&]`)
+
+func parseAuthors(raw string) []string {
+    out := []string{}
+    for _, s := range authorSep.Split(raw, -1) {
+        s = strings.TrimSpace(s)
+        if s != "" { out = append(out, s) }
+    }
+    return out
+}
+```
+
+2. XMP `dc:creator/rdf:Seq/rdf:li` (preserves order). Overrides DocInfo if non-empty.
+3. **No further fallback.** Empty slice valid. No `"Unknown Author"` sentinel.
+
+Persist:
+
+```go
+func (s *BookCreatorService) AddAuthors(ctx context.Context, bookID int64, names []string) error {
+    for _, n := range names {
+        if len(n) > 255 { n = n[:255] }
+        a, err := s.authors.GetOrCreate(ctx, n)
+        if err != nil { return err }
+        if err := s.authors.Link(ctx, bookID, a.ID); err != nil { return err }
+    }
+    return nil
+}
+```
+
+## 6. XMP namespaces
+
+XML parse: `etree.NewDocument().ReadFromBytes(xmpBytes)`. Namespace-aware paths.
+
+| Namespace | Fields |
+|-----------|--------|
+| `dc:*` (Dublin Core) | title, creator, subject (categories), description, publisher, language |
+| `calibre:*`, `calibreSI:*` | series name, series index |
+| `booklore:*` (camelCase + PascalCase legacy) | subtitle, IDs, ratings, moods, tags |
+| `xmp:Identifier/rdf:Bag/rdf:li` | scheme map: `isbn`, `amazon`, `goodreads`, `google`, `hardcover`, `comicvine`, `ranobedb`, `lubimyczytac` |
+
+IDs read: `isbn13`, `isbn10`, `googleId`, `goodreadsId`, `hardcoverId`, `hardcoverBookId`, `asin`, `comicvineId`, `lubimyczytacId`, `ranobedbId`.
+
+Moods / tags — accept both RDF Bag and legacy `;`-separated string.
+
+ISBN clean:
+
+```go
+var nonIsbn = regexp.MustCompile(`[^0-9Xx]`)
+
+func cleanISBN(s string) string { return nonIsbn.ReplaceAllString(s, "") }
+```
+
+Validate length 10 or 13 post-clean.
+
+Custom DocInfo keys: `Language` → language; `EBX_PUBLISHER` → publisher.
+
+## 7. Filename pattern extractor (Bookdrop only)
+
+- Pkg: `internal/bookdrop`
+- File: `pattern.go`
+- Placeholders: `{Title}`, `{Authors}`, `{SeriesName}`, `{Published:yyyy-MM-dd}`, ...
+- Compile placeholder template → `*regexp.Regexp`.
+- Per-match timeout 5 s — run in goroutine, select on `time.After(5*time.Second)`. Drop match on timeout.
+- Batch 500 files.
+- Merge with PDF-extracted result via `metadata.Merge(base, override)`.
+
+## 8. Truncation
+
+In `PdfProcessor.extractAndSet` before persist:
+
+```go
+func truncate(s string, n int) string {
+    if len(s) > n { return s[:n] }
+    return s
+}
+```
+
+Limits:
+
+| Field | Limit |
+|-------|-------|
+| title | 1000 |
+| subtitle | 1000 |
+| seriesName | 1000 |
+| description | 5000 |
+| author name | 255 |
+| publisher / language | trim only |
+
+Blank guard: only assign when `strings.TrimSpace(v) != ""`. Blank never overwrites existing.
+
+## 9. Persistence
+
+GORM models (or sqlc structs):
+
+```go
+type Book struct {
+    ID            int64     `gorm:"primaryKey"`
+    LibraryID     int64
+    LibraryPathID int64
+    Metadata      BookMetadata `gorm:"foreignKey:BookID;constraint:OnDelete:CASCADE"`
+    Files         []BookFile   `gorm:"foreignKey:BookID;constraint:OnDelete:CASCADE"`
+    AddedOn       time.Time
+    ScannedOn     time.Time
+    DeletedAt     gorm.DeletedAt
+}
+
+type BookMetadata struct {
+    BookID         int64    `gorm:"primaryKey"`
+    Title          string   `gorm:"size:1000;not null"`
+    Subtitle       sql.NullString `gorm:"size:1000"`
+    SeriesName     sql.NullString `gorm:"size:1000"`
+    SeriesNumber   sql.NullFloat64
+    SeriesTotal    sql.NullInt32
+    Publisher      sql.NullString
+    Language       sql.NullString
+    PublishedDate  sql.NullTime
+    Description    sql.NullString `gorm:"type:text"`
+    PageCount      sql.NullInt32
+    ISBN10, ISBN13 sql.NullString
+    ASIN, GoogleID, GoodreadsID, HardcoverID, ComicvineID, RanobedbID, LubimyczytacID sql.NullString
+    AmazonRating, GoodreadsRating, HardcoverRating, LubimyczytacRating, RanobedbRating, Rating sql.NullFloat64
+    Authors    []Author   `gorm:"many2many:book_metadata_author"`
+    Categories []Category `gorm:"many2many:book_metadata_category"`
+    Moods      []Mood     `gorm:"many2many:book_metadata_mood"`
+    Tags       []Tag      `gorm:"many2many:book_metadata_tag"`
+}
+
+type Author struct {
+    ID   int64  `gorm:"primaryKey"`
+    Name string `gorm:"size:255;uniqueIndex"`
+}
+```
+
+Save flow per PDF:
+1. `CreateShell` — single tx insert: `Book` + empty `BookMetadata` + `BookFile`.
+2. Mutate metadata in-memory in `extractAndSet`.
+3. `AddAuthors` — get-or-create per name, link via join.
+4. Final tx: `db.Save(&book)` cascades metadata + saves connections. Optional sidecar metadata file write.
+
+Wrap end-to-end in `db.Transaction(func(tx *gorm.DB) error { ... })`.
+
+## 10. Configuration
+
+Viper or stdlib `flag` + env. `cfg.go`:
+
+```go
+type Config struct {
+    BookdropFolder string `env:"APP_BOOKDROP_FOLDER"`
+    DiskType       string `env:"APP_DISK_TYPE" envDefault:"LOCAL"` // LOCAL|NETWORK
+    PathConfig     string `env:"APP_PATH_CONFIG"`
+    DBDsn          string `env:"DB_DSN"`
+}
+```
+
+`DiskType`:
+- `LOCAL` — `os.Rename` for atomic move.
+- `NETWORK` — copy + fsync + delete (rename across mounts unreliable).
+
+No PDF-specific tunables. Limits hard-coded as `const`.
+
+## 11. Edge cases & errors
+
+| Scenario | Behavior |
+|----------|----------|
+| Panic in PDF lib (corrupt file) | `defer recover()` in cover + extractor; log; return nil err |
+| OOM-equivalent (huge alloc) | bound page render to first page; PDF lib hard limits; runtime.GC() after fail |
+| PDF parse fail | log; metadata stays whatever DocInfo gave |
+| XMP parse fail | log warn; continue with DocInfo only |
+| File not found | return zero `Metadata{}` |
+| Zero-byte file | skipped pre-processing |
+| Partial write | stability poll up to 120 s |
+| Bookdrop dir missing/unwritable | log; disable that watcher; app continues |
+| `ctx` cancel | abort current op, return `ctx.Err()` upstream |
+
+## 12. Concurrency
+
+- One goroutine per watcher (`Run(ctx)`).
+- Single processor goroutine consumes channel; `sync.Map` of debounce timers per path.
+- Worker pool (`errgroup` + `semaphore.Weighted`) for actual file processing — cap at `runtime.NumCPU()` to bound PDF render memory.
+- `BookCreatorService` — stateless, methods take `ctx`.
+- All DB ops scoped to per-task transactions.
+
+## 13. End-to-end flow
+
+```
+filesystem
+   │  fsnotify event
+   ▼
+WatchService / BookdropMonitor
+   │  FileEvent on chan
+   ▼
+ingest.Processor
+   │  debounce 500ms / folder 5s, stability ≤ 120s
+   ▼
+TransactionalHandler.HandleNewBookFile()
+   │
+   ▼
+PdfProcessor.ProcessNew()
+   ├─ BookCreatorService.CreateShell()  → DB shell row
+   ├─ cover.Generate()                  → page 1, 150 DPI
+   └─ extractAndSet()
+        │
+        ▼
+   pdf.MetadataExtractor.Extract()
+   ├─ DocumentInformation   (title, author, subject, keywords, dates, pages)
+   ├─ XMP Dublin Core       (overrides DocInfo)
+   ├─ XMP Calibre           (series)
+   ├─ XMP Booklore custom   (subtitle, IDs, ratings, moods, tags)
+   └─ XMP Identifier map    (scheme IDs)
+        │
+        ▼
+   Title:  XMP dc:title → DocInfo.Title → filename
+   Author: XMP dc:creator → DocInfo.Author (split [,&]) → []
+        │
+        ▼
+   truncate → AddAuthors → tx.Commit
+```
+
+## 14. Testing
+
+- `internal/metadata/pdf/extractor_test.go` — golden-file PDFs in `testdata/`. One per fallback branch (DocInfo only, XMP only, neither, corrupt).
+- `internal/ingest/processor_test.go` — fake `fsnotify` events via channel; assert debounce + stability.
+- `internal/fileprocessor/pdf_processor_test.go` — integration with sqlite in-memory.
+- Race detector: `go test -race ./...`.
+- Fuzz `parseAuthors`, `cleanISBN`.
+
+## 15. Key takeaways
+
+- DocumentInformation = primary; XMP DC overrides; filename = last-resort title only.
+- Author chain stops at XMP. Empty slice valid.
+- XMP backward-compat: legacy PascalCase keys still read.
+- Panics from PDF lib contained via `defer recover()`. Pipeline never crashes.
+- Goroutines + channels replace virtual-thread watcher. fsnotify cheap on large trees.
+- Truncation enforced in processor, not relied on at DB layer.
+- All long-running ops accept `context.Context` for cancellation.

--- a/docs/superpowers/plans/2026-05-03-pdf-discovery-improvements.md
+++ b/docs/superpowers/plans/2026-05-03-pdf-discovery-improvements.md
@@ -1,0 +1,1456 @@
+# PDF Discovery Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden the PDF metadata extractor (XMP, hex/UTF-16BE strings, author Seq, ISBN passthrough) and add a client-rendered cover delivered at BookDrop preview time, so PDFs land with rich metadata, an ISBN where available, and a real cover for OPDS clients.
+
+**Architecture:** PDF processor stays pure-Go, regex-based, CGO-free. XMP packets are located by `<?xpacket begin … end ?>` byte scan over an enlarged read window (head 1 MB + tail 256 KB). Author resolution: XMP `dc:creator/rdf:Seq` overrides DocInfo; both shapes get joined with `, ` into the single `books.author` string. ISBN flows: XMP `xmp:Identifier/rdf:Bag` → `fileproc.Metadata.ISBN` → `extractor.ExtractResult.ISBN` → new `bookdrop_items.isbn` column → `books.isbn` on approve. Covers: extractor stays cover-less for PDFs; the BookDrop preview UI rasters page 1 via pdfjs (already present), encodes JPEG q85 at 1200 px wide, and `PUT`s to a new `/api/v1/bookdrop/:id/cover` endpoint that gates on item state and 409s if a cover is already present. See ADR-0015.
+
+**Tech Stack:** Go 1.25, regex (`regexp`), `encoding/xml` for XMP, modernc SQLite + Postgres dual schema, gin handler, React + pdfjs-dist + TanStack Query for UI.
+
+---
+
+## File Structure
+
+### Backend — modify
+- `internal/fileproc/pdf.go` — extend extractor with hex strings, UTF-16BE, XMP scan, author Seq, ISBN.
+- `internal/fileproc/processor.go` — add `ISBN` field to `Metadata` struct.
+- `internal/extractor/extract.go` — copy `Metadata.ISBN` into `ExtractResult.ISBN`; fix `layerSidecar` to also overlay `s.ISBN`.
+- `internal/repo/bookdrop.go` — extend `SetMetadata` signature to accept ISBN; thread through SELECT cols.
+- `internal/model/bookdrop.go` — add `ISBN` field to `BookDropItem`.
+- `internal/service/bookdrop.go` — `RecordMetadata` accepts ISBN; `Approve` copies item.ISBN → book.ISBN; new `PutPreapprovalCover`; filename fallback on extract path.
+- `internal/task/bookdrop.go` — pass `res.ISBN` to `RecordMetadata`; pass filename hint for fallback.
+- `internal/handler/bookdrop.go` — new `BookDropPutCover` handler.
+- `internal/handler/router.go` — register `PUT /api/v1/bookdrop/:id/cover`.
+
+### Backend — create
+- `internal/migrator/migrations/postgres/000033_bookdrop_isbn.up.sql`
+- `internal/migrator/migrations/postgres/000033_bookdrop_isbn.down.sql`
+- `internal/migrator/migrations/sqlite/000033_bookdrop_isbn.up.sql`
+- `internal/migrator/migrations/sqlite/000033_bookdrop_isbn.down.sql`
+- `internal/fileproc/pdf_xmp.go` — XMP packet scan + parse (separate file to keep `pdf.go` focused).
+- `internal/fileproc/pdf_xmp_test.go`
+- `internal/fileproc/pdf_strings.go` — hex / UTF-16BE decoders shared with DocInfo path.
+- `internal/fileproc/pdf_strings_test.go`
+- `internal/fileproc/testdata/pdf/xmp-dc.pdf` — golden fixture (Calibre-style XMP packet)
+- `internal/fileproc/testdata/pdf/hex-utf16-title.pdf` — DocInfo with `<FEFF…>` Title
+- `internal/fileproc/testdata/pdf/multi-author.pdf` — `Author (Smith, J. & Doe, A.)` literal
+- `internal/fileproc/testdata/pdf/xmp-with-isbn.pdf` — XMP Identifier Bag with ISBN
+
+### Frontend — modify
+- `ui/src/components/PdfReader.tsx` — expose imperative `renderCoverJpeg(): Promise<Blob>` on the handle.
+- `ui/src/api/bookdrop.ts` — `putBookDropCover(id, blob)`.
+- BookDrop preview component (locate during Task 17) — call `renderCoverJpeg()` once on first PDF preview open and `PUT` if item has no cover.
+
+---
+
+## Task 1: Add `ISBN` field to `fileproc.Metadata`
+
+**Files:**
+- Modify: `internal/fileproc/processor.go:17-41`
+
+- [ ] **Step 1: Edit `Metadata` struct, add ISBN below `Language`**
+
+```go
+// ISBN is the canonical identifier extracted from format-embedded
+// metadata (PDF XMP Identifier Bag, EPUB OPF identifier). Empty when
+// the file carries no ISBN. Format-specific extractors clean to digits
+// + 'X', then validate length 10 or 13 before populating; anything
+// else is dropped silently.
+ISBN string
+```
+
+- [ ] **Step 2: Build to verify nothing else needs threading**
+
+Run: `make test`
+Expected: PASS — no consumer reads `Metadata.ISBN` yet.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/fileproc/processor.go
+git commit -m "feat(fileproc): add ISBN field to Metadata"
+```
+
+---
+
+## Task 2: Add `ISBN` to `ExtractResult`, fix `layerSidecar` ISBN bug
+
+**Files:**
+- Modify: `internal/extractor/extract.go:19-32` (struct), `:79-93` (copy), `:130-144` (layerSidecar)
+- Test: `internal/extractor/extract_test.go`
+
+- [ ] **Step 1: Write failing test for sidecar ISBN overlay**
+
+Append to `internal/extractor/extract_test.go`:
+
+```go
+func TestExtract_SidecarISBNOverlaysFormatMeta(t *testing.T) {
+    // Use a tiny PDF source with no ISBN; sidecar provides one.
+    // Existing test setup builds a fake storage with a sidecar JSON;
+    // mirror that pattern, asserting result.ISBN equals sidecar value.
+    //
+    // If the test file already has a fakeStorage helper, reuse it.
+    // Otherwise inline a minimal in-memory storage.Storage.
+    t.Skip("implement after layerSidecar ISBN copy lands")
+}
+```
+
+(If `extract_test.go` already has fixtures, write the real assertion using them — don't `t.Skip`. Re-read the file to find the existing helper before writing.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/extractor/ -run TestExtract_SidecarISBNOverlaysFormatMeta -v`
+Expected: FAIL or SKIP (then unskip and watch FAIL).
+
+- [ ] **Step 3: Add `ISBN` to `ExtractResult`**
+
+Edit `internal/extractor/extract.go` struct:
+
+```go
+type ExtractResult struct {
+    Format      string
+    Title       string
+    Author      string
+    Description string
+    Language    string
+    ISBN        string // 10 or 13 digits (X allowed in ISBN-10 check digit). Empty when not present.
+    HasCover    bool
+    CoverBytes  []byte
+    CoverMime   string
+    DurationSeconds *int
+    Narrator        string
+}
+```
+
+- [ ] **Step 4: Copy ISBN into ExtractResult**
+
+Inside `Extract`, in the `out := ExtractResult{...}` block:
+
+```go
+out := ExtractResult{
+    Format:      format,
+    Title:       meta.Title,
+    Author:      meta.Author,
+    Description: meta.Description,
+    Language:    meta.Language,
+    ISBN:        meta.ISBN,
+    HasCover:    meta.HasCover,
+    CoverBytes:  meta.CoverBytes,
+    CoverMime:   meta.CoverMime,
+}
+```
+
+- [ ] **Step 5: Fix `layerSidecar` — copy `s.ISBN` to `m.ISBN`**
+
+Replace `layerSidecar` body:
+
+```go
+func layerSidecar(m fileproc.Metadata, s sidecar.Sidecar) fileproc.Metadata {
+    if s.Title != "" {
+        m.Title = s.Title
+    }
+    if s.Author != "" {
+        m.Author = s.Author
+    }
+    if s.Description != "" {
+        m.Description = s.Description
+    }
+    if s.Language != "" {
+        m.Language = s.Language
+    }
+    if s.ISBN != "" {
+        m.ISBN = s.ISBN
+    }
+    return m
+}
+```
+
+- [ ] **Step 6: Run test, verify pass**
+
+Run: `go test ./internal/extractor/ -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/extractor/
+git commit -m "feat(extractor): thread ISBN through ExtractResult, fix sidecar overlay bug"
+```
+
+---
+
+## Task 3: Hex / UTF-16BE string decoder
+
+**Files:**
+- Create: `internal/fileproc/pdf_strings.go`
+- Create: `internal/fileproc/pdf_strings_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `internal/fileproc/pdf_strings_test.go`:
+
+```go
+package fileproc
+
+import "testing"
+
+func TestDecodePDFLiteral_PlainASCII(t *testing.T) {
+    got := decodePDFLiteral([]byte("Hello"))
+    if got != "Hello" {
+        t.Fatalf("got %q want %q", got, "Hello")
+    }
+}
+
+func TestDecodePDFLiteral_BOMUTF16BE(t *testing.T) {
+    // \xFE\xFF then UTF-16BE for "Té"
+    raw := []byte{0xFE, 0xFF, 0x00, 'T', 0x00, 0xE9}
+    got := decodePDFLiteral(raw)
+    if got != "Té" {
+        t.Fatalf("got %q want %q", got, "Té")
+    }
+}
+
+func TestDecodePDFHexString_UTF16BE(t *testing.T) {
+    // <FEFF0054006900740065>  → "Title"
+    got := decodePDFHexString("FEFF0054006900740065")
+    if got != "Title" {
+        t.Fatalf("got %q want %q", got, "Title")
+    }
+}
+
+func TestDecodePDFHexString_PlainASCII(t *testing.T) {
+    // <48656C6C6F>  → "Hello"
+    got := decodePDFHexString("48656C6C6F")
+    if got != "Hello" {
+        t.Fatalf("got %q want %q", got, "Hello")
+    }
+}
+
+func TestDecodePDFHexString_OddLengthPadsZero(t *testing.T) {
+    // PDF spec: odd hex digits get a trailing 0 — `<F>` ≡ `<F0>`.
+    got := decodePDFHexString("F")
+    if got != "\xF0" && got != "" {
+        t.Fatalf("unexpected %q", got)
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify FAIL**
+
+Run: `go test ./internal/fileproc/ -run "DecodePDF" -v`
+Expected: FAIL — symbols don't exist.
+
+- [ ] **Step 3: Implement decoders**
+
+Create `internal/fileproc/pdf_strings.go`:
+
+```go
+package fileproc
+
+import (
+    "encoding/hex"
+    "strings"
+    "unicode/utf16"
+)
+
+// decodePDFLiteral handles a PDF string-literal payload that may be a
+// plain ASCII / Latin-1 byte run or a UTF-16BE byte run prefixed with
+// the BOM bytes 0xFE 0xFF. The caller has already stripped the
+// surrounding parens and unescaped \( \) \\ \n \r \t sequences.
+func decodePDFLiteral(b []byte) string {
+    if len(b) >= 2 && b[0] == 0xFE && b[1] == 0xFF {
+        return decodeUTF16BE(b[2:])
+    }
+    return strings.TrimSpace(string(b))
+}
+
+// decodePDFHexString decodes the body of a PDF hex string `<…>` (just
+// the hex digits, parens already stripped). When the bytes start with
+// the UTF-16BE BOM (FEFF), they're decoded as UTF-16BE; otherwise
+// returned as raw bytes interpreted as Latin-1-compatible ASCII.
+//
+// Per PDF spec, an odd number of hex digits is padded with a trailing
+// '0' (so `<F>` ≡ `<F0>`).
+func decodePDFHexString(s string) string {
+    s = strings.Map(func(r rune) rune {
+        switch {
+        case r >= '0' && r <= '9', r >= 'a' && r <= 'f', r >= 'A' && r <= 'F':
+            return r
+        }
+        return -1
+    }, s)
+    if len(s)%2 == 1 {
+        s += "0"
+    }
+    raw, err := hex.DecodeString(s)
+    if err != nil {
+        return ""
+    }
+    if len(raw) >= 2 && raw[0] == 0xFE && raw[1] == 0xFF {
+        return decodeUTF16BE(raw[2:])
+    }
+    return strings.TrimSpace(string(raw))
+}
+
+func decodeUTF16BE(b []byte) string {
+    if len(b) < 2 {
+        return ""
+    }
+    n := len(b) / 2
+    u16 := make([]uint16, n)
+    for i := 0; i < n; i++ {
+        u16[i] = uint16(b[2*i])<<8 | uint16(b[2*i+1])
+    }
+    return strings.TrimSpace(string(utf16.Decode(u16)))
+}
+```
+
+- [ ] **Step 4: Run, verify PASS**
+
+Run: `go test ./internal/fileproc/ -run "DecodePDF" -v`
+Expected: PASS (all four).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/fileproc/pdf_strings.go internal/fileproc/pdf_strings_test.go
+git commit -m "feat(fileproc): add PDF hex / UTF-16BE string decoders"
+```
+
+---
+
+## Task 4: Wire hex strings into DocInfo extraction
+
+**Files:**
+- Modify: `internal/fileproc/pdf.go:28` (regex), `:84-92` (`pdfInfoField`)
+- Test: `internal/fileproc/pdf_embed_test.go` or new `internal/fileproc/pdf_test.go`
+
+- [ ] **Step 1: Add a regex for hex form**
+
+Edit `internal/fileproc/pdf.go`, replace the single regex with two:
+
+```go
+// pdfInfoLiteralRe matches /Name (literal) entries.
+var pdfInfoLiteralRe = regexp.MustCompile(`/([A-Za-z][A-Za-z0-9]*)\s*\(((?:\\.|[^)])*)\)`)
+
+// pdfInfoHexRe matches /Name <hexdigits> entries. Hex strings are how
+// Acrobat / MS Word write non-ASCII titles.
+var pdfInfoHexRe = regexp.MustCompile(`/([A-Za-z][A-Za-z0-9]*)\s*<([0-9A-Fa-f\s]*)>`)
+```
+
+- [ ] **Step 2: Update `pdfInfoField` to consult both forms**
+
+Replace:
+
+```go
+func pdfInfoField(data []byte, key string) string {
+    for _, match := range pdfInfoLiteralRe.FindAllSubmatch(data, -1) {
+        if string(match[1]) != key {
+            continue
+        }
+        body := unescapePDFLiteral(string(match[2]))
+        if v := decodePDFLiteral([]byte(body)); v != "" {
+            return v
+        }
+    }
+    for _, match := range pdfInfoHexRe.FindAllSubmatch(data, -1) {
+        if string(match[1]) != key {
+            continue
+        }
+        if v := decodePDFHexString(string(match[2])); v != "" {
+            return v
+        }
+    }
+    return ""
+}
+```
+
+- [ ] **Step 3: `unescapePDFLiteral` returns string — adjust signature**
+
+`unescapePDFLiteral` currently returns string and trims. Keep that, but the caller now wraps the trimmed result through `decodePDFLiteral` to handle a BOM that survives unescaping. Update to return the unescaped bytes directly:
+
+```go
+func unescapePDFLiteral(s string) string {
+    var b strings.Builder
+    b.Grow(len(s))
+    for i := 0; i < len(s); i++ {
+        c := s[i]
+        if c != '\\' || i+1 >= len(s) {
+            b.WriteByte(c)
+            continue
+        }
+        next := s[i+1]
+        switch next {
+        case '(', ')', '\\':
+            b.WriteByte(next)
+        case 'n':
+            b.WriteByte('\n')
+        case 'r':
+            b.WriteByte('\r')
+        case 't':
+            b.WriteByte('\t')
+        default:
+            b.WriteByte(next)
+        }
+        i++
+    }
+    return b.String() // no TrimSpace — caller will Trim through decodePDFLiteral
+}
+```
+
+- [ ] **Step 4: Bump tail window 8 KB → 256 KB**
+
+In `Extract`, change `const tailSize = 8 << 10` to:
+
+```go
+const tailSize = 256 << 10 // 256 KB — catches Calibre-tail XMP packets
+```
+
+- [ ] **Step 5: Add a test for the hex DocInfo path**
+
+Append to `internal/fileproc/pdf_embed_test.go` (or new file `pdf_test.go`):
+
+```go
+func TestPDFProcessor_HexUTF16BEDocInfoTitle(t *testing.T) {
+    raw := []byte("%PDF-1.4\n%\xE2\xE3\xCF\xD3\n" +
+        "1 0 obj\n<< /Title <FEFF0054006900740065> >>\nendobj\n" +
+        "trailer << /Info 1 0 R >>\n%%EOF\n")
+    src := newMemSource(raw) // existing test helper; mirror what other tests use
+    m, err := (PDFProcessor{}).Extract(context.Background(), src)
+    if err != nil {
+        t.Fatalf("extract: %v", err)
+    }
+    if m.Title != "Title" {
+        t.Fatalf("Title=%q want %q", m.Title, "Title")
+    }
+}
+```
+
+(If `newMemSource` doesn't exist, copy the helper pattern from `pdf_embed_test.go`'s existing test fixtures.)
+
+- [ ] **Step 6: Run tests**
+
+Run: `go test ./internal/fileproc/ -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/fileproc/pdf.go internal/fileproc/pdf_embed_test.go
+git commit -m "feat(fileproc): decode hex/UTF-16BE PDF DocInfo strings, widen tail to 256 KB"
+```
+
+---
+
+## Task 5: XMP packet locate + parse (DC fields)
+
+**Files:**
+- Create: `internal/fileproc/pdf_xmp.go`
+- Create: `internal/fileproc/pdf_xmp_test.go`
+
+- [ ] **Step 1: Write failing tests for XMP scan + parse**
+
+Create `internal/fileproc/pdf_xmp_test.go`:
+
+```go
+package fileproc
+
+import "testing"
+
+const xmpPacket = `<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/">
+ <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about=""
+    xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title><rdf:Alt><rdf:li xml:lang="x-default">XMP Title</rdf:li></rdf:Alt></dc:title>
+    <dc:creator><rdf:Seq><rdf:li>Alice</rdf:li><rdf:li>Bob</rdf:li></rdf:Seq></dc:creator>
+    <dc:description><rdf:Alt><rdf:li xml:lang="x-default">desc here</rdf:li></rdf:Alt></dc:description>
+    <dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language>
+  </rdf:Description>
+ </rdf:RDF>
+</x:xmpmeta>
+<?xpacket end="r"?>`
+
+func TestExtractXMPPacket_FindsBetweenMarkers(t *testing.T) {
+    // Embed the packet inside random PDF-ish padding.
+    blob := []byte("%PDF-1.4\n... noise ...\n" + xmpPacket + "\n... more noise ...\n%%EOF")
+    got, ok := extractXMPPacket(blob)
+    if !ok {
+        t.Fatal("xpacket not found")
+    }
+    if string(got) == "" || !contains(got, []byte("dc:title")) {
+        t.Fatalf("packet payload missing dc:title")
+    }
+}
+
+func TestParseXMP_DublinCore(t *testing.T) {
+    x, err := parseXMP([]byte(xmpPacket))
+    if err != nil {
+        t.Fatalf("parse: %v", err)
+    }
+    if x.Title != "XMP Title" {
+        t.Fatalf("Title=%q", x.Title)
+    }
+    want := []string{"Alice", "Bob"}
+    if len(x.Creators) != 2 || x.Creators[0] != want[0] || x.Creators[1] != want[1] {
+        t.Fatalf("Creators=%v want %v", x.Creators, want)
+    }
+    if x.Description != "desc here" {
+        t.Fatalf("Description=%q", x.Description)
+    }
+    if x.Language != "en" {
+        t.Fatalf("Language=%q", x.Language)
+    }
+}
+
+func contains(haystack, needle []byte) bool {
+    return bytesContains(haystack, needle)
+}
+```
+
+(Add a tiny `bytesContains` shim if you don't want to import `bytes`.)
+
+- [ ] **Step 2: Run, verify FAIL**
+
+Run: `go test ./internal/fileproc/ -run "ExtractXMP|ParseXMP" -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement scan + parse**
+
+Create `internal/fileproc/pdf_xmp.go`:
+
+```go
+package fileproc
+
+import (
+    "bytes"
+    "encoding/xml"
+    "strings"
+)
+
+// XMPMetadata is the subset of XMP fields the PDF processor consumes.
+type XMPMetadata struct {
+    Title       string
+    Creators    []string
+    Description string
+    Language    string
+    ISBN        string // raw value from xmp:Identifier/rdf:Bag where scheme contains "isbn"
+}
+
+// extractXMPPacket finds the first uncompressed XMP packet in raw bytes.
+// XMP packets are wrapped in `<?xpacket begin=… ?>` / `<?xpacket end=…?>`
+// markers — designed for raw scanning. Returns the inner XML payload
+// (between the markers) on success.
+func extractXMPPacket(b []byte) ([]byte, bool) {
+    beginMarker := []byte("<?xpacket begin=")
+    endMarker := []byte("<?xpacket end=")
+    bi := bytes.Index(b, beginMarker)
+    if bi < 0 {
+        return nil, false
+    }
+    // Find the closing `?>` of the begin PI; the XMP starts after it.
+    headEnd := bytes.Index(b[bi:], []byte("?>"))
+    if headEnd < 0 {
+        return nil, false
+    }
+    payloadStart := bi + headEnd + 2
+    ei := bytes.Index(b[payloadStart:], endMarker)
+    if ei < 0 {
+        return nil, false
+    }
+    return b[payloadStart : payloadStart+ei], true
+}
+
+// xmpDoc mirrors the bits of <x:xmpmeta>/<rdf:RDF>/<rdf:Description>
+// the extractor cares about. The `,any` attribute on Description's
+// children plus rdf:* / dc:* tag matches handles namespace-prefixed
+// elements without a full namespace-aware decoder.
+type xmpDoc struct {
+    XMLName     xml.Name           `xml:"xmpmeta"`
+    Description []xmpDescription   `xml:"RDF>Description"`
+}
+
+type xmpDescription struct {
+    Title       xmpAlt    `xml:"title"`
+    Creator     xmpSeq    `xml:"creator"`
+    Description xmpAlt    `xml:"description"`
+    Language    xmpBag    `xml:"language"`
+    Identifier  xmpIdent  `xml:"Identifier"`
+}
+
+type xmpAlt struct {
+    Items []string `xml:"Alt>li"`
+}
+
+type xmpSeq struct {
+    Items []string `xml:"Seq>li"`
+}
+
+type xmpBag struct {
+    Items []string `xml:"Bag>li"`
+}
+
+type xmpIdent struct {
+    Items []xmpIdentItem `xml:"Bag>li"`
+}
+
+type xmpIdentItem struct {
+    Scheme string `xml:"scheme,attr"`
+    Value  string `xml:",chardata"`
+}
+
+// parseXMP unmarshals an XMP packet payload into an XMPMetadata.
+// Tolerant: missing fields are left zero. Unknown elements ignored.
+func parseXMP(payload []byte) (XMPMetadata, error) {
+    var doc xmpDoc
+    if err := xml.Unmarshal(payload, &doc); err != nil {
+        return XMPMetadata{}, err
+    }
+    var out XMPMetadata
+    for _, d := range doc.Description {
+        if out.Title == "" && len(d.Title.Items) > 0 {
+            out.Title = strings.TrimSpace(d.Title.Items[0])
+        }
+        if out.Description == "" && len(d.Description.Items) > 0 {
+            out.Description = strings.TrimSpace(d.Description.Items[0])
+        }
+        if out.Language == "" && len(d.Language.Items) > 0 {
+            out.Language = strings.TrimSpace(d.Language.Items[0])
+        }
+        for _, c := range d.Creator.Items {
+            if v := strings.TrimSpace(c); v != "" {
+                out.Creators = append(out.Creators, v)
+            }
+        }
+        if out.ISBN == "" {
+            for _, ident := range d.Identifier.Items {
+                if strings.Contains(strings.ToLower(ident.Scheme), "isbn") {
+                    out.ISBN = strings.TrimSpace(ident.Value)
+                    break
+                }
+            }
+        }
+    }
+    return out, nil
+}
+```
+
+- [ ] **Step 4: Run, verify PASS**
+
+Run: `go test ./internal/fileproc/ -run "ExtractXMP|ParseXMP" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/fileproc/pdf_xmp.go internal/fileproc/pdf_xmp_test.go
+git commit -m "feat(fileproc): parse PDF XMP packet (DC + Identifier Bag)"
+```
+
+---
+
+## Task 6: ISBN clean + length validation
+
+**Files:**
+- Modify: `internal/fileproc/pdf_xmp.go` — add `cleanAndValidateISBN`
+- Test: `internal/fileproc/pdf_xmp_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `internal/fileproc/pdf_xmp_test.go`:
+
+```go
+func TestCleanAndValidateISBN_13Digit(t *testing.T) {
+    got := cleanAndValidateISBN("978-0-441-17271-9")
+    if got != "9780441172719" {
+        t.Fatalf("got %q want %q", got, "9780441172719")
+    }
+}
+
+func TestCleanAndValidateISBN_10WithX(t *testing.T) {
+    got := cleanAndValidateISBN("0-441-17271-X")
+    if got != "044117271X" {
+        t.Fatalf("got %q", got)
+    }
+}
+
+func TestCleanAndValidateISBN_RejectsShort(t *testing.T) {
+    if got := cleanAndValidateISBN("12345"); got != "" {
+        t.Fatalf("got %q want empty", got)
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify FAIL**
+
+Run: `go test ./internal/fileproc/ -run CleanAndValidateISBN -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Append to `internal/fileproc/pdf_xmp.go`:
+
+```go
+import "regexp"
+
+var nonISBNChar = regexp.MustCompile(`[^0-9Xx]`)
+
+// cleanAndValidateISBN strips separators, uppercases the trailing X,
+// and returns the value only when it is 10 or 13 chars after cleaning.
+// Anything else returns "".
+func cleanAndValidateISBN(s string) string {
+    cleaned := nonISBNChar.ReplaceAllString(s, "")
+    cleaned = strings.ToUpper(cleaned)
+    if len(cleaned) != 10 && len(cleaned) != 13 {
+        return ""
+    }
+    return cleaned
+}
+```
+
+(Move the `regexp` import into the existing import block.)
+
+- [ ] **Step 4: Run, verify PASS**
+
+Run: `go test ./internal/fileproc/ -run CleanAndValidateISBN -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/fileproc/pdf_xmp.go internal/fileproc/pdf_xmp_test.go
+git commit -m "feat(fileproc): clean + validate ISBN extracted from XMP"
+```
+
+---
+
+## Task 7: Wire XMP + author Seq + ISBN into PDFProcessor.Extract
+
+**Files:**
+- Modify: `internal/fileproc/pdf.go:30-80`
+- Test: `internal/fileproc/pdf_xmp_test.go` (add end-to-end Extract test)
+
+- [ ] **Step 1: Write failing test**
+
+Append to `internal/fileproc/pdf_xmp_test.go`:
+
+```go
+func TestPDFProcessor_XMPOverridesDocInfoAndExtractsISBN(t *testing.T) {
+    body := "%PDF-1.4\n%\xE2\xE3\xCF\xD3\n" +
+        "1 0 obj\n<< /Title (DocInfo Title) /Author (DocInfo Author) >>\nendobj\n" +
+        xmpPacket + // DC title overrides; creators Alice + Bob; no ISBN here
+        "trailer << /Info 1 0 R >>\n%%EOF\n"
+    src := newMemSource([]byte(body))
+
+    m, err := (PDFProcessor{}).Extract(context.Background(), src)
+    if err != nil {
+        t.Fatalf("extract: %v", err)
+    }
+    if m.Title != "XMP Title" {
+        t.Fatalf("Title=%q (XMP must override DocInfo)", m.Title)
+    }
+    if m.Author != "Alice, Bob" {
+        t.Fatalf("Author=%q want %q", m.Author, "Alice, Bob")
+    }
+    if m.Description != "desc here" {
+        t.Fatalf("Description=%q", m.Description)
+    }
+    if m.Language != "en" {
+        t.Fatalf("Language=%q", m.Language)
+    }
+}
+
+func TestPDFProcessor_AuthorSplitFromDocInfo(t *testing.T) {
+    body := "%PDF-1.4\n%\xE2\xE3\xCF\xD3\n" +
+        "1 0 obj\n<< /Author (Smith, J. & Doe, A.) >>\nendobj\n" +
+        "trailer << /Info 1 0 R >>\n%%EOF\n"
+    src := newMemSource([]byte(body))
+    m, err := (PDFProcessor{}).Extract(context.Background(), src)
+    if err != nil {
+        t.Fatalf("extract: %v", err)
+    }
+    if m.Author != "Smith, J., Doe, A." {
+        // Split on [,&] yields ["Smith"," J."," Doe"," A."]; trim + rejoin.
+        // We accept this canonical form.
+        t.Fatalf("Author=%q", m.Author)
+    }
+}
+```
+
+- [ ] **Step 2: Implement Extract changes**
+
+Edit `internal/fileproc/pdf.go`. Below the existing struct, add author split helper:
+
+```go
+var pdfAuthorSep = regexp.MustCompile(`[,&]`)
+
+// splitAndJoinAuthors normalises a DocInfo Author string by splitting on
+// `,` or `&`, trimming each chunk, and rejoining with `, `. A single
+// name (no separators) round-trips unchanged. Returns "" for empty input.
+func splitAndJoinAuthors(raw string) string {
+    if strings.TrimSpace(raw) == "" {
+        return ""
+    }
+    parts := pdfAuthorSep.Split(raw, -1)
+    out := parts[:0]
+    for _, p := range parts {
+        if v := strings.TrimSpace(p); v != "" {
+            out = append(out, v)
+        }
+    }
+    return strings.Join(out, ", ")
+}
+```
+
+Replace the block in `Extract` that builds `m`:
+
+```go
+m := Metadata{Format: "PDF"}
+m.Title = pdfInfoField(scan, "Title")
+m.Author = splitAndJoinAuthors(pdfInfoField(scan, "Author"))
+if subject := pdfInfoField(scan, "Subject"); subject != "" {
+    m.Description = subject
+}
+
+// XMP overrides DocInfo when present.
+if packet, ok := extractXMPPacket(scan); ok {
+    if x, err := parseXMP(packet); err == nil {
+        if x.Title != "" {
+            m.Title = x.Title
+        }
+        if len(x.Creators) > 0 {
+            m.Author = strings.Join(x.Creators, ", ")
+        }
+        if x.Description != "" {
+            m.Description = x.Description
+        }
+        if x.Language != "" {
+            m.Language = x.Language
+        }
+        if x.ISBN != "" {
+            if v := cleanAndValidateISBN(x.ISBN); v != "" {
+                m.ISBN = v
+            }
+        }
+    }
+}
+return m, nil
+```
+
+- [ ] **Step 3: Run all fileproc tests**
+
+Run: `go test ./internal/fileproc/ -v`
+Expected: PASS.
+
+- [ ] **Step 4: Run full suite**
+
+Run: `make test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/fileproc/pdf.go internal/fileproc/pdf_xmp_test.go
+git commit -m "feat(fileproc): XMP overrides DocInfo, split DocInfo authors, ISBN from XMP Bag"
+```
+
+---
+
+## Task 8: Migration — `bookdrop_items.isbn`
+
+**Files:**
+- Create: `internal/migrator/migrations/postgres/000033_bookdrop_isbn.up.sql`
+- Create: `internal/migrator/migrations/postgres/000033_bookdrop_isbn.down.sql`
+- Create: `internal/migrator/migrations/sqlite/000033_bookdrop_isbn.up.sql`
+- Create: `internal/migrator/migrations/sqlite/000033_bookdrop_isbn.down.sql`
+
+- [ ] **Step 1: Write Postgres up**
+
+`internal/migrator/migrations/postgres/000033_bookdrop_isbn.up.sql`:
+
+```sql
+ALTER TABLE bookdrop_items
+    ADD COLUMN IF NOT EXISTS isbn TEXT NOT NULL DEFAULT '';
+```
+
+- [ ] **Step 2: Write Postgres down**
+
+`internal/migrator/migrations/postgres/000033_bookdrop_isbn.down.sql`:
+
+```sql
+ALTER TABLE bookdrop_items DROP COLUMN IF EXISTS isbn;
+```
+
+- [ ] **Step 3: Write SQLite up**
+
+`internal/migrator/migrations/sqlite/000033_bookdrop_isbn.up.sql`:
+
+```sql
+ALTER TABLE bookdrop_items ADD COLUMN isbn TEXT NOT NULL DEFAULT '';
+```
+
+- [ ] **Step 4: Write SQLite down**
+
+`internal/migrator/migrations/sqlite/000033_bookdrop_isbn.down.sql`:
+
+```sql
+ALTER TABLE bookdrop_items DROP COLUMN isbn;
+```
+
+- [ ] **Step 5: Apply locally and inspect**
+
+Run: `make migrate && make migrate-version`
+Expected: version reports `33`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/migrator/migrations/
+git commit -m "feat(db): add bookdrop_items.isbn column"
+```
+
+---
+
+## Task 9: Repo + Model — thread ISBN
+
+**Files:**
+- Modify: `internal/model/bookdrop.go:17-30` — add ISBN field
+- Modify: `internal/repo/bookdrop.go:24` (column list), `:106-127` (`SetMetadata`), `:251` (scan)
+
+- [ ] **Step 1: Add `ISBN` to model**
+
+Edit `internal/model/bookdrop.go` `BookDropItem`, after `Description`:
+
+```go
+ISBN string
+```
+
+- [ ] **Step 2: Add to column list**
+
+Edit `internal/repo/bookdrop.go`. Find the `bdCols` constant (search for `title, author, description`). Append `, isbn` to the column list and update the SELECT scan.
+
+- [ ] **Step 3: Update `SetMetadata` signature**
+
+Replace:
+
+```go
+func (r *BookDropRepo) SetMetadata(
+    ctx context.Context,
+    id, title, author, description, language, isbn string,
+    hasCover bool, coverMime string,
+) error {
+    const qPG = `
+        UPDATE bookdrop_items
+           SET title = $2, author = $3, description = $4, language = $5,
+               isbn = $6, has_cover = $7, cover_mime = $8, state = 'ready', progress = 100
+         WHERE id = $1`
+    const qSQLite = `
+        UPDATE bookdrop_items
+           SET title = ?, author = ?, description = ?, language = ?,
+               isbn = ?, has_cover = ?, cover_mime = ?, state = 'ready', progress = 100
+         WHERE id = ?`
+    if r.db.Dialect == db.DialectSQLite {
+        _, err := r.db.SQL.ExecContext(ctx, qSQLite, title, author, description, language, isbn, hasCover, coverMime, id)
+        return err
+    }
+    _, err := r.db.SQL.ExecContext(ctx, qPG, id, title, author, description, language, isbn, hasCover, coverMime)
+    return err
+}
+```
+
+(Match the dialect dispatch already used in this file — copy from existing call sites if the syntax differs.)
+
+- [ ] **Step 4: Update scan in `scanBDRow` (or equivalent)**
+
+In the `Scan` call around `bookdrop.go:251`, add `&item.ISBN` in the same position as the new column in `bdCols`.
+
+- [ ] **Step 5: Build**
+
+Run: `go build ./...`
+Expected: compile errors at `service/bookdrop.go` (`SetMetadata` callers). That's fine — Task 10 fixes them.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/model/bookdrop.go internal/repo/bookdrop.go
+git commit -m "feat(repo): thread ISBN through bookdrop_items"
+```
+
+---
+
+## Task 10: Service — RecordMetadata accepts ISBN; Approve copies to book
+
+**Files:**
+- Modify: `internal/service/bookdrop.go:124-147` (`RecordMetadata`), `:220-229` (`Approve` book construction)
+- Modify: `internal/task/bookdrop.go:119-125`
+
+- [ ] **Step 1: Update RecordMetadata signature**
+
+Edit `internal/service/bookdrop.go`:
+
+```go
+func (s *BookDropService) RecordMetadata(
+    ctx context.Context,
+    id string,
+    title, author, description, language, isbn string,
+    coverBytes []byte,
+    coverMime string,
+) error {
+    hasCover := len(coverBytes) > 0
+    if hasCover && s.covers != nil {
+        if err := s.covers.SaveBookDrop(id, coverBytes); err != nil {
+            slog.Warn("save bookdrop cover", "id", id, "err", err)
+            hasCover = false
+            coverMime = ""
+        }
+    } else if !hasCover {
+        coverMime = ""
+    }
+
+    if err := s.bdrop.SetMetadata(ctx, id, title, author, description, language, isbn, hasCover, coverMime); err != nil {
+        return err
+    }
+    s.broadcast(id)
+    return nil
+}
+```
+
+- [ ] **Step 2: Pass ISBN into book on Approve**
+
+In `Approve`, after `Title`/`Author`/`Format`/`Description` lines:
+
+```go
+book := model.Book{
+    LibraryID:   libraryID,
+    Title:       fallback(item.Title, "Untitled"),
+    Author:      item.Author,
+    Format:      item.Format,
+    Description: item.Description,
+    ISBN:        item.ISBN,
+    Path:        item.Path,
+    HasCover:    item.HasCover,
+    CoverMime:   item.CoverMime,
+}
+```
+
+(Confirm `model.Book` has `ISBN` — `internal/model/book.go:49` shows it does.)
+
+- [ ] **Step 3: Update worker call site**
+
+Edit `internal/task/bookdrop.go:119`:
+
+```go
+if err := deps.Svc.RecordMetadata(
+    ctx, itemID,
+    res.Title, res.Author, res.Description, res.Language, res.ISBN,
+    res.CoverBytes, res.CoverMime,
+); err != nil {
+    return err
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `make test`
+Expected: PASS. If service tests stub `RecordMetadata`, update call signatures there too.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/bookdrop.go internal/task/bookdrop.go
+git commit -m "feat(bookdrop): persist ISBN at extract, copy to book.isbn at approve"
+```
+
+---
+
+## Task 11: Filename fallback for Title
+
+**Files:**
+- Modify: `internal/task/bookdrop.go:112-125`
+
+- [ ] **Step 1: Apply post-extract fallback**
+
+Just after `extractor.Extract(...)` returns, before `RecordMetadata`:
+
+```go
+if strings.TrimSpace(res.Title) == "" {
+    base := filepath.Base(item.Path)
+    res.Title = strings.TrimSuffix(base, filepath.Ext(base))
+}
+```
+
+(Ensure `path/filepath` and `strings` are imported.)
+
+- [ ] **Step 2: Add a test**
+
+Append to `internal/task/bookdrop_test.go` (or create one if absent) — assert that an extractor returning empty Title results in `RecordMetadata` being called with the basename. Use a fake `BookDropService` interface or capture the call via the existing test seam if present.
+
+If no test seam exists, skip the test for this task and rely on integration coverage at `internal/service/bookdrop_test.go` once cover/ISBN flow is exercised end-to-end.
+
+- [ ] **Step 3: Run**
+
+Run: `make test`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/task/bookdrop.go
+git commit -m "feat(bookdrop): fall back to filename when extractor returns empty Title"
+```
+
+---
+
+## Task 12: Handler — `PUT /api/v1/bookdrop/:id/cover`
+
+**Files:**
+- Modify: `internal/handler/bookdrop.go` — add `BookDropPutCover`
+- Modify: `internal/handler/router.go:100` — register route
+
+- [ ] **Step 1: Add handler**
+
+Append to `internal/handler/bookdrop.go`:
+
+```go
+// BookDropPutCover accepts a raw image (PNG or JPEG) for a BookDrop
+// item that doesn't yet have a pre-approval cover. Idempotent on
+// absence: first successful PUT wins; subsequent PUTs return 409.
+//
+// Cap: 5 MB. Magic-sniff: PNG `89 50 4E 47` or JPEG `FF D8 FF`.
+// State gate: item must be in 'discovered' or 'ready' (a.k.a.
+// pre-approval). Refuses 'imported' / 'rejected' / 'processing'.
+func (h *Handler) BookDropPutCover(c *gin.Context) {
+    id := c.Param("id")
+
+    item, err := h.bookDrop.Get(c.Request.Context(), id)
+    if err != nil {
+        writeServerError(c, "bookdrop lookup", err)
+        return
+    }
+    if item.HasCover {
+        c.JSON(http.StatusConflict, gin.H{"error": "cover already present"})
+        return
+    }
+    switch item.State {
+    case model.BookDropDiscovered, model.BookDropReady, model.BookDropProcessing:
+        // fall through — accept upload
+    default:
+        c.JSON(http.StatusConflict, gin.H{"error": "item state does not accept cover upload"})
+        return
+    }
+
+    const maxBytes = 5 << 20
+    c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxBytes)
+    raw, err := io.ReadAll(c.Request.Body)
+    if err != nil {
+        c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "image too large"})
+        return
+    }
+    mime, ok := sniffCoverMime(raw)
+    if !ok {
+        c.JSON(http.StatusUnsupportedMediaType, gin.H{"error": "expected PNG or JPEG"})
+        return
+    }
+
+    if err := h.bookDrop.PutPreapprovalCover(c.Request.Context(), id, raw, mime); err != nil {
+        writeServerError(c, "bookdrop put cover", err)
+        return
+    }
+    c.JSON(http.StatusNoContent, nil)
+}
+
+func sniffCoverMime(b []byte) (string, bool) {
+    switch {
+    case len(b) >= 4 && b[0] == 0x89 && b[1] == 0x50 && b[2] == 0x4E && b[3] == 0x47:
+        return "image/png", true
+    case len(b) >= 3 && b[0] == 0xFF && b[1] == 0xD8 && b[2] == 0xFF:
+        return "image/jpeg", true
+    }
+    return "", false
+}
+```
+
+- [ ] **Step 2: Register route**
+
+Edit `internal/handler/router.go`, in the authed bookdrop block (`:99-103`):
+
+```go
+authed.PUT("/bookdrop/:id/cover", h.BookDropPutCover)
+```
+
+- [ ] **Step 3: Build**
+
+Run: `go build ./...`
+Expected: compile error — `PutPreapprovalCover` not defined yet. Task 13 adds it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/handler/
+git commit -m "feat(handler): add PUT /bookdrop/:id/cover with magic sniff + state gate"
+```
+
+---
+
+## Task 13: Service — `PutPreapprovalCover`
+
+**Files:**
+- Modify: `internal/service/bookdrop.go`
+- Test: `internal/service/bookdrop_test.go`
+
+- [ ] **Step 1: Add method**
+
+Append to `internal/service/bookdrop.go`:
+
+```go
+// PutPreapprovalCover writes raw cover bytes for a BookDrop item that
+// doesn't yet carry a cover. Used by the BookDrop preview UI to push
+// a client-rendered PDF page-1 raster (see ADR-0015). Idempotent on
+// absence — caller must check item.HasCover; this method does not
+// re-read the row.
+func (s *BookDropService) PutPreapprovalCover(ctx context.Context, id string, raw []byte, mime string) error {
+    if s.covers == nil {
+        return errors.New("cover store not configured")
+    }
+    if err := s.covers.SaveBookDrop(id, raw); err != nil {
+        return fmt.Errorf("save cover bytes: %w", err)
+    }
+    if err := s.bdrop.SetCoverPresence(ctx, id, true, mime); err != nil {
+        return fmt.Errorf("mark has_cover: %w", err)
+    }
+    s.broadcast(id)
+    return nil
+}
+```
+
+- [ ] **Step 2: Add `SetCoverPresence` to repo**
+
+If `repo.BookDropRepo` doesn't have a method that flips `has_cover` + `cover_mime` independently of `SetMetadata`, add one — name `SetCoverPresence(ctx, id string, hasCover bool, coverMime string) error`. Mirror the dialect pattern used by `SetMetadata`.
+
+- [ ] **Step 3: Run tests**
+
+Run: `make test`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/service/bookdrop.go internal/repo/bookdrop.go
+git commit -m "feat(bookdrop): PutPreapprovalCover service path for client-rendered PDF covers"
+```
+
+---
+
+## Task 14: API client — `putBookDropCover`
+
+**Files:**
+- Modify: `ui/src/api/bookdrop.ts`
+
+- [ ] **Step 1: Read existing client patterns**
+
+Read `ui/src/api/bookdrop.ts` to see how other mutations are shaped (`approveBookDrop`, `rejectBookDrop`).
+
+- [ ] **Step 2: Add the function**
+
+Append:
+
+```ts
+export async function putBookDropCover(id: string, blob: Blob): Promise<void> {
+  const res = await fetch(`/api/v1/bookdrop/${encodeURIComponent(id)}/cover`, {
+    method: "PUT",
+    body: blob,
+    headers: { "content-type": blob.type || "image/jpeg" },
+    credentials: "include",
+  })
+  if (res.status === 409) {
+    // Already has a cover — fine, no-op for the caller.
+    return
+  }
+  if (!res.ok) {
+    throw new Error(`putBookDropCover ${res.status}`)
+  }
+}
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `make ui-typecheck`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ui/src/api/bookdrop.ts
+git commit -m "feat(ui): add putBookDropCover api client"
+```
+
+---
+
+## Task 15: PdfReader — expose `renderCoverJpeg`
+
+**Files:**
+- Modify: `ui/src/components/PdfReader.tsx`
+
+- [ ] **Step 1: Read current handle shape**
+
+Read `ui/src/components/PdfReader.tsx` to find the `PdfReaderHandle` type and the imperative handle shape.
+
+- [ ] **Step 2: Add the method**
+
+Add to the `PdfReaderHandle` type:
+
+```ts
+export type PdfReaderHandle = {
+  // ...existing fields...
+  renderCoverJpeg: (opts?: { width?: number; quality?: number }) => Promise<Blob | null>
+}
+```
+
+In the component's `useImperativeHandle`, add:
+
+```ts
+async renderCoverJpeg(opts) {
+  const doc = pdfDocRef.current
+  if (!doc) return null
+  const page = await doc.getPage(1)
+  const targetWidth = opts?.width ?? 1200
+  const baseViewport = page.getViewport({ scale: 1 })
+  const scale = targetWidth / baseViewport.width
+  const viewport = page.getViewport({ scale })
+  const canvas = document.createElement("canvas")
+  canvas.width = Math.ceil(viewport.width)
+  canvas.height = Math.ceil(viewport.height)
+  const ctx = canvas.getContext("2d")
+  if (!ctx) return null
+  await page.render({ canvasContext: ctx, viewport }).promise
+  return new Promise<Blob | null>((resolve) =>
+    canvas.toBlob((b) => resolve(b), "image/jpeg", opts?.quality ?? 0.85),
+  )
+},
+```
+
+(`pdfDocRef` is whatever ref already holds the `PDFDocumentProxy` — inspect the existing component to find its actual name.)
+
+- [ ] **Step 3: Type-check**
+
+Run: `make ui-typecheck`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ui/src/components/PdfReader.tsx
+git commit -m "feat(ui): expose renderCoverJpeg on PdfReaderHandle"
+```
+
+---
+
+## Task 16: BookDrop preview — auto-upload cover on first PDF preview
+
+**Files:**
+- Modify: BookDrop preview component (locate by grepping for `BookDropDetail`, `BookDropPreview`, or wherever the BookDrop list opens an item).
+
+- [ ] **Step 1: Locate**
+
+Run: `grep -rn "bookdrop" ui/src/routes ui/src/components | grep -i 'preview\|detail\|drawer'`
+
+- [ ] **Step 2: Wire upload**
+
+In the component that mounts a `PdfReader` for a BookDrop item, add an effect:
+
+```tsx
+const itemHasCoverRef = useRef(item.hasCover)
+useEffect(() => { itemHasCoverRef.current = item.hasCover }, [item.hasCover])
+
+const handlePdfLoaded = useCallback(async () => {
+  if (item.format !== "PDF") return
+  if (itemHasCoverRef.current) return
+  const blob = await pdfRef.current?.renderCoverJpeg()
+  if (!blob) return
+  try {
+    await putBookDropCover(item.id, blob)
+    queryClient.invalidateQueries({ queryKey: ["bookdrop"] })
+  } catch (err) {
+    console.warn("auto cover upload failed", err)
+  }
+}, [item.format, item.id, queryClient])
+```
+
+Pass `handlePdfLoaded` as the `PdfReader`'s `onLoaded` (or equivalent) prop. If no such prop exists, add one in Task 15's edits — call it from inside the existing successful-load branch.
+
+- [ ] **Step 3: Run dev stack and click through**
+
+Run: `make up`
+Open `http://localhost:5173/bookdrop`, drop a PDF without an embedded cover, open its preview. Expect: cover thumbnail appears in the BookDrop list within a second.
+
+- [ ] **Step 4: Approve and verify**
+
+Approve the item. Open the resulting book detail. Cover should be present (promoted from BookDrop into `coverstore`). Verify `/api/v1/books/:id/cover` returns the JPEG.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/
+git commit -m "feat(ui): auto-render PDF page 1 to cover on BookDrop preview"
+```
+
+---
+
+## Task 17: Re-render guard — covers in re-mount / StrictMode
+
+**Files:**
+- Modify: BookDrop preview component (Task 16's file)
+
+- [ ] **Step 1: Add a per-item one-shot ref**
+
+```tsx
+const uploadedRef = useRef<Set<string>>(new Set())
+
+const handlePdfLoaded = useCallback(async () => {
+  if (item.format !== "PDF") return
+  if (item.hasCover) return
+  if (uploadedRef.current.has(item.id)) return
+  uploadedRef.current.add(item.id)
+  // ...rest
+}, [item.format, item.id, item.hasCover])
+```
+
+- [ ] **Step 2: Manually verify by toggling preview twice**
+
+Open + close + reopen the same item. Network tab: only one PUT.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ui/
+git commit -m "fix(ui): guard one-shot cover upload against StrictMode double-render"
+```
+
+---
+
+## Task 18: End-to-end smoke (manual)
+
+- [ ] **Step 1: Drop a Calibre-exported PDF with XMP DC + ISBN**
+
+Drop into `${BOOKDROP_PATH}/`. Wait 5s.
+
+Expected: BookDrop list shows item with title from XMP, author from `dc:creator`, ISBN populated.
+
+- [ ] **Step 2: Drop an Acrobat PDF with hex `<FEFF…>` Title**
+
+Expected: Title shows correctly (non-ASCII rendering).
+
+- [ ] **Step 3: Drop a PDF with neither DocInfo nor XMP**
+
+Expected: Title falls back to filename basename.
+
+- [ ] **Step 4: Approve a PDF, hit OPDS**
+
+Run: `curl -u admin@local:changeme http://localhost:6060/opds/cover/<id>`
+Expected: JPEG bytes (not 404, not empty).
+
+---
+
+## Self-Review Checklist
+
+- [x] Each spec section has a task: XMP (5–7), DocInfo strings (3–4, 7), author Seq + split (5, 7), filename fallback (11), ISBN persist (1–2, 8–10), cover gen (12–17), tests (3–7, 14).
+- [x] No "TBD" / "implement later" placeholders.
+- [x] Type names consistent: `Metadata.ISBN`, `ExtractResult.ISBN`, `BookDropItem.ISBN`, `bookdrop_items.isbn`, `XMPMetadata.ISBN`, `cleanAndValidateISBN`, `splitAndJoinAuthors`, `extractXMPPacket`, `parseXMP`, `decodePDFLiteral`, `decodePDFHexString`, `RecordMetadata(..., isbn, ...)`, `PutPreapprovalCover`, `BookDropPutCover`, `putBookDropCover`, `renderCoverJpeg`.
+- [x] Skipped: server-side rasterizer (ADR-0015), schema-wide author-list refactor, full provider-ID expansion (only ISBN is wired; other XMP IDs deferred).

--- a/internal/extractor/extract.go
+++ b/internal/extractor/extract.go
@@ -22,6 +22,7 @@ type ExtractResult struct {
 	Author      string
 	Description string
 	Language    string
+	ISBN        string
 	HasCover    bool
 	CoverBytes  []byte
 	CoverMime   string
@@ -82,6 +83,7 @@ func Extract(
 		Author:      meta.Author,
 		Description: meta.Description,
 		Language:    meta.Language,
+		ISBN:        meta.ISBN,
 		HasCover:    meta.HasCover,
 		CoverBytes:  meta.CoverBytes,
 		CoverMime:   meta.CoverMime,
@@ -139,6 +141,9 @@ func layerSidecar(m fileproc.Metadata, s sidecar.Sidecar) fileproc.Metadata {
 	}
 	if s.Language != "" {
 		m.Language = s.Language
+	}
+	if s.ISBN != "" {
+		m.ISBN = s.ISBN
 	}
 	return m
 }

--- a/internal/extractor/extract_test.go
+++ b/internal/extractor/extract_test.go
@@ -49,6 +49,26 @@ func TestLayerSidecar_Overlays(t *testing.T) {
 	}
 }
 
+func TestLayerSidecar_ISBNOverlay(t *testing.T) {
+	m := fileproc.Metadata{Title: "Original", ISBN: "0000000000"}
+	s := sidecar.Sidecar{ISBN: "978-0-441-17271-9"}
+	out := layerSidecar(m, s)
+	if out.ISBN != "978-0-441-17271-9" {
+		t.Errorf("ISBN=%q want 978-0-441-17271-9", out.ISBN)
+	}
+	if out.Title != "Original" {
+		t.Errorf("Title=%q want preserved", out.Title)
+	}
+}
+
+func TestLayerSidecar_EmptyISBNDoesNotOverwrite(t *testing.T) {
+	m := fileproc.Metadata{ISBN: "978-0-7432-7356-5"}
+	out := layerSidecar(m, sidecar.Sidecar{})
+	if out.ISBN != "978-0-7432-7356-5" {
+		t.Errorf("ISBN=%q want preserved", out.ISBN)
+	}
+}
+
 func TestLayerSidecar_EmptySidecarLeavesFieldsAlone(t *testing.T) {
 	m := fileproc.Metadata{Title: "Keep", Language: "en"}
 	out := layerSidecar(m, sidecar.Sidecar{})

--- a/internal/fileproc/pdf.go
+++ b/internal/fileproc/pdf.go
@@ -29,6 +29,25 @@ type PDFProcessor struct{}
 var pdfInfoLiteralRe = regexp.MustCompile(`/([A-Za-z][A-Za-z0-9]*)\s*\(((?:\\.|[^)])*)\)`)
 var pdfInfoHexRe = regexp.MustCompile(`/([A-Za-z][A-Za-z0-9]*)\s*<([0-9A-Fa-f\s]*)>`)
 
+var pdfAuthorSep = regexp.MustCompile(`[,&]`)
+
+// splitAndJoinAuthors normalises a DocInfo Author string by splitting on
+// `,` or `&`, trimming each chunk, and rejoining with `, `. A single
+// name (no separators) round-trips unchanged. Empty input returns "".
+func splitAndJoinAuthors(raw string) string {
+	if strings.TrimSpace(raw) == "" {
+		return ""
+	}
+	parts := pdfAuthorSep.Split(raw, -1)
+	out := parts[:0]
+	for _, p := range parts {
+		if v := strings.TrimSpace(p); v != "" {
+			out = append(out, v)
+		}
+	}
+	return strings.Join(out, ", ")
+}
+
 func (PDFProcessor) Extract(ctx context.Context, src storage.Source) (Metadata, error) {
 	_ = ctx
 
@@ -73,9 +92,35 @@ func (PDFProcessor) Extract(ctx context.Context, src storage.Source) (Metadata, 
 
 	m := Metadata{Format: "PDF"}
 	m.Title = pdfInfoField(scan, "Title")
-	m.Author = pdfInfoField(scan, "Author")
+	m.Author = splitAndJoinAuthors(pdfInfoField(scan, "Author"))
 	if subject := pdfInfoField(scan, "Subject"); subject != "" {
 		m.Description = subject
+	}
+
+	// XMP overrides DocInfo when present. Calibre, Acrobat, MS Word, and
+	// other modern writers store rich metadata in an uncompressed XMP
+	// packet wrapped in <?xpacket begin ... ?> markers; that data is more
+	// trustworthy than DocInfo (which often goes stale after edits).
+	if packet, ok := extractXMPPacket(scan); ok {
+		if x, err := parseXMP(packet); err == nil {
+			if x.Title != "" {
+				m.Title = x.Title
+			}
+			if len(x.Creators) > 0 {
+				m.Author = strings.Join(x.Creators, ", ")
+			}
+			if x.Description != "" {
+				m.Description = x.Description
+			}
+			if x.Language != "" {
+				m.Language = x.Language
+			}
+			if x.ISBN != "" {
+				if v := cleanAndValidateISBN(x.ISBN); v != "" {
+					m.ISBN = v
+				}
+			}
+		}
 	}
 	// No filename fallback — callers supply a Source, not a path.
 	return m, nil

--- a/internal/fileproc/pdf.go
+++ b/internal/fileproc/pdf.go
@@ -18,14 +18,16 @@ import (
 // feed BookDrop and the book row; not a full PDF library.
 type PDFProcessor struct{}
 
-// pdfInfoFieldRe matches `/Name (value)` entries in the Info dict. Handles
-// escaped parens inside the string. Misses:
-//   - hex-literal strings (/Title <FEFF...>)
-//   - UTF-16BE BOM-prefixed strings (rare in seed/fixture files)
-//   - PDFs whose Info dict lives past the first ~1 MB or trailer tail
+// pdfInfoLiteralRe matches `/Name (value)` entries in the Info dict.
+// Handles escaped parens inside the string.
 //
-// For those, we fall back to the filename.
-var pdfInfoFieldRe = regexp.MustCompile(`/([A-Za-z][A-Za-z0-9]*)\s*\(((?:\\.|[^)])*)\)`)
+// pdfInfoHexRe matches `/Name <hex>` entries — Acrobat / MS Word write
+// non-ASCII titles as hex-encoded UTF-16BE strings.
+//
+// Together they cover the two PDF string-literal forms; the helpers in
+// pdf_strings.go decode the contents (Latin-1 vs UTF-16BE-BOM).
+var pdfInfoLiteralRe = regexp.MustCompile(`/([A-Za-z][A-Za-z0-9]*)\s*\(((?:\\.|[^)])*)\)`)
+var pdfInfoHexRe = regexp.MustCompile(`/([A-Za-z][A-Za-z0-9]*)\s*<([0-9A-Fa-f\s]*)>`)
 
 func (PDFProcessor) Extract(ctx context.Context, src storage.Source) (Metadata, error) {
 	_ = ctx
@@ -55,7 +57,7 @@ func (PDFProcessor) Extract(ctx context.Context, src storage.Source) (Metadata, 
 
 	var tail []byte
 	if size > int64(hn) {
-		const tailSize = 8 << 10 // 8 KB
+		const tailSize = 256 << 10 // 256 KB — catches Calibre-tail XMP packets
 		pos := size - tailSize
 		if pos < int64(hn) {
 			pos = int64(hn)
@@ -79,14 +81,27 @@ func (PDFProcessor) Extract(ctx context.Context, src storage.Source) (Metadata, 
 	return m, nil
 }
 
-// pdfInfoField pulls a named literal string from the PDF Info dict. Empty
-// when the key isn't present in string form.
+// pdfInfoField pulls a named string from the PDF Info dict. Tries the
+// literal form `(...)` first, then the hex form `<...>`. Returns the
+// first non-empty hit decoded via the helpers in pdf_strings.go (which
+// handle UTF-16BE-BOM payloads). Empty when the key isn't present.
 func pdfInfoField(data []byte, key string) string {
-	for _, match := range pdfInfoFieldRe.FindAllSubmatch(data, -1) {
+	for _, match := range pdfInfoLiteralRe.FindAllSubmatch(data, -1) {
 		if string(match[1]) != key {
 			continue
 		}
-		return unescapePDFLiteral(string(match[2]))
+		body := unescapePDFLiteral(string(match[2]))
+		if v := decodePDFLiteral([]byte(body)); v != "" {
+			return v
+		}
+	}
+	for _, match := range pdfInfoHexRe.FindAllSubmatch(data, -1) {
+		if string(match[1]) != key {
+			continue
+		}
+		if v := decodePDFHexString(string(match[2])); v != "" {
+			return v
+		}
 	}
 	return ""
 }
@@ -94,6 +109,11 @@ func pdfInfoField(data []byte, key string) string {
 // unescapePDFLiteral handles the escapes PDF string literals use. Covers
 // \\ \( \) and newline escapes — the common ones. Other sequences fall
 // through unchanged.
+//
+// Does NOT trim whitespace: the result may begin with a UTF-16BE BOM
+// (0xFE 0xFF) that decodePDFLiteral keys on, and trimming would
+// corrupt those leading bytes. Trim semantics are deferred to
+// decodePDFLiteral once the encoding is known.
 func unescapePDFLiteral(s string) string {
 	var b strings.Builder
 	b.Grow(len(s))
@@ -118,5 +138,5 @@ func unescapePDFLiteral(s string) string {
 		}
 		i++
 	}
-	return strings.TrimSpace(b.String())
+	return b.String()
 }

--- a/internal/fileproc/pdf_embed_test.go
+++ b/internal/fileproc/pdf_embed_test.go
@@ -274,6 +274,24 @@ func TestPDFEmbedder_Embed_PreservesCreationDate(t *testing.T) {
 	}
 }
 
+// TestPDFProcessor_HexUTF16BEDocInfoTitle verifies that a /Title written
+// as a hex-encoded UTF-16BE string (the form Acrobat / MS Word use for
+// non-ASCII titles) round-trips through Extract intact. Embedded
+// whitespace inside <…> must also be tolerated per the PDF spec.
+func TestPDFProcessor_HexUTF16BEDocInfoTitle(t *testing.T) {
+	raw := []byte("%PDF-1.4\n%\xE2\xE3\xCF\xD3\n" +
+		"1 0 obj\n<< /Title <FEFF00540069007400 6C0065> >>\nendobj\n" +
+		"trailer << /Info 1 0 R >>\n%%EOF\n")
+	src := memSourceFromBytes(raw)
+	m, err := (PDFProcessor{}).Extract(context.Background(), src)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if m.Title != "Title" {
+		t.Fatalf("Title=%q want %q", m.Title, "Title")
+	}
+}
+
 func TestDispatchEmbedder_PDF(t *testing.T) {
 	emb, err := DispatchEmbedder("PDF")
 	if err != nil {

--- a/internal/fileproc/pdf_strings.go
+++ b/internal/fileproc/pdf_strings.go
@@ -1,0 +1,60 @@
+package fileproc
+
+import (
+	"encoding/hex"
+	"strings"
+	"unicode/utf16"
+)
+
+// decodePDFLiteral handles a PDF string-literal payload that may be a
+// plain ASCII / Latin-1 byte run or a UTF-16BE byte run prefixed with
+// the BOM bytes 0xFE 0xFF. The caller has already stripped the
+// surrounding parens and unescaped \( \) \\ \n \r \t sequences.
+func decodePDFLiteral(b []byte) string {
+	if len(b) >= 2 && b[0] == 0xFE && b[1] == 0xFF {
+		return decodeUTF16BE(b[2:])
+	}
+	return strings.TrimSpace(string(b))
+}
+
+// decodePDFHexString decodes the body of a PDF hex string `<…>` (just
+// the hex digits, parens already stripped). When the bytes start with
+// the UTF-16BE BOM (FEFF), they're decoded as UTF-16BE; otherwise
+// returned as raw bytes interpreted as Latin-1-compatible ASCII.
+//
+// Per PDF spec, an odd number of hex digits is padded with a trailing
+// '0' (so `<F>` ≡ `<F0>`).
+func decodePDFHexString(s string) string {
+	s = strings.Map(func(r rune) rune {
+		switch {
+		case r >= '0' && r <= '9', r >= 'a' && r <= 'f', r >= 'A' && r <= 'F':
+			return r
+		}
+		return -1
+	}, s)
+	if len(s)%2 == 1 {
+		s += "0"
+	}
+	raw, err := hex.DecodeString(s)
+	if err != nil {
+		return ""
+	}
+	if len(raw) >= 2 && raw[0] == 0xFE && raw[1] == 0xFF {
+		return decodeUTF16BE(raw[2:])
+	}
+	return strings.TrimSpace(string(raw))
+}
+
+// decodeUTF16BE decodes a byte slice as UTF-16 big-endian. Returns the
+// trimmed string. Length < 2 returns "".
+func decodeUTF16BE(b []byte) string {
+	if len(b) < 2 {
+		return ""
+	}
+	n := len(b) / 2
+	u16 := make([]uint16, n)
+	for i := 0; i < n; i++ {
+		u16[i] = uint16(b[2*i])<<8 | uint16(b[2*i+1])
+	}
+	return strings.TrimSpace(string(utf16.Decode(u16)))
+}

--- a/internal/fileproc/pdf_strings_test.go
+++ b/internal/fileproc/pdf_strings_test.go
@@ -1,0 +1,39 @@
+package fileproc
+
+import "testing"
+
+func TestDecodePDFLiteral_PlainASCII(t *testing.T) {
+	got := decodePDFLiteral([]byte("Hello"))
+	if got != "Hello" {
+		t.Fatalf("got %q want %q", got, "Hello")
+	}
+}
+
+func TestDecodePDFLiteral_BOMUTF16BE(t *testing.T) {
+	raw := []byte{0xFE, 0xFF, 0x00, 'T', 0x00, 0xE9}
+	got := decodePDFLiteral(raw)
+	if got != "Té" {
+		t.Fatalf("got %q want %q", got, "Té")
+	}
+}
+
+func TestDecodePDFHexString_UTF16BE(t *testing.T) {
+	got := decodePDFHexString("FEFF00540069007400 6C0065")
+	if got != "Title" {
+		t.Fatalf("got %q want %q", got, "Title")
+	}
+}
+
+func TestDecodePDFHexString_PlainASCII(t *testing.T) {
+	got := decodePDFHexString("48656C6C6F")
+	if got != "Hello" {
+		t.Fatalf("got %q want %q", got, "Hello")
+	}
+}
+
+func TestDecodePDFHexString_OddLengthPadsZero(t *testing.T) {
+	got := decodePDFHexString("F")
+	if got != "\xF0" && got != "" {
+		t.Fatalf("unexpected %q", got)
+	}
+}

--- a/internal/fileproc/pdf_xmp.go
+++ b/internal/fileproc/pdf_xmp.go
@@ -1,0 +1,118 @@
+package fileproc
+
+import (
+	"bytes"
+	"encoding/xml"
+	"strings"
+)
+
+// XMPMetadata is the subset of XMP fields the PDF processor consumes.
+// Title, Creators (in Seq order), Description, Language come from
+// Dublin Core; ISBN comes from xmp:Identifier/rdf:Bag with a
+// "scheme=isbn" attribute (case-insensitive substring match).
+type XMPMetadata struct {
+	Title       string
+	Creators    []string
+	Description string
+	Language    string
+	ISBN        string // raw value before clean+validate
+}
+
+// extractXMPPacket finds the first uncompressed XMP packet in raw bytes.
+// XMP packets are wrapped in `<?xpacket begin=… ?>` / `<?xpacket end=…?>`
+// markers — designed for raw scanning even inside binary containers.
+// Returns the inner XML payload (between the markers) on success.
+func extractXMPPacket(b []byte) ([]byte, bool) {
+	beginMarker := []byte("<?xpacket begin=")
+	endMarker := []byte("<?xpacket end=")
+	bi := bytes.Index(b, beginMarker)
+	if bi < 0 {
+		return nil, false
+	}
+	headEnd := bytes.Index(b[bi:], []byte("?>"))
+	if headEnd < 0 {
+		return nil, false
+	}
+	payloadStart := bi + headEnd + 2
+	if payloadStart >= len(b) {
+		return nil, false
+	}
+	ei := bytes.Index(b[payloadStart:], endMarker)
+	if ei < 0 {
+		return nil, false
+	}
+	return b[payloadStart : payloadStart+ei], true
+}
+
+// xmpDoc mirrors the bits of <x:xmpmeta>/<rdf:RDF>/<rdf:Description>
+// the extractor cares about. xml.Unmarshal matches by local name when
+// no XMLNS is bound for that prefix on the struct tags, so dc:* and
+// rdf:* prefixed elements all match by their local part.
+type xmpDoc struct {
+	XMLName     xml.Name         `xml:"xmpmeta"`
+	Description []xmpDescription `xml:"RDF>Description"`
+}
+
+type xmpDescription struct {
+	Title       xmpAlt   `xml:"title"`
+	Creator     xmpSeq   `xml:"creator"`
+	Description xmpAlt   `xml:"description"`
+	Language    xmpBag   `xml:"language"`
+	Identifier  xmpIdent `xml:"Identifier"`
+}
+
+type xmpAlt struct {
+	Items []string `xml:"Alt>li"`
+}
+
+type xmpSeq struct {
+	Items []string `xml:"Seq>li"`
+}
+
+type xmpBag struct {
+	Items []string `xml:"Bag>li"`
+}
+
+type xmpIdent struct {
+	Items []xmpIdentItem `xml:"Bag>li"`
+}
+
+type xmpIdentItem struct {
+	Scheme string `xml:"scheme,attr"`
+	Value  string `xml:",chardata"`
+}
+
+// parseXMP unmarshals an XMP packet payload into an XMPMetadata.
+// Tolerant: missing fields are left zero. Unknown elements ignored.
+func parseXMP(payload []byte) (XMPMetadata, error) {
+	var doc xmpDoc
+	if err := xml.Unmarshal(payload, &doc); err != nil {
+		return XMPMetadata{}, err
+	}
+	var out XMPMetadata
+	for _, d := range doc.Description {
+		if out.Title == "" && len(d.Title.Items) > 0 {
+			out.Title = strings.TrimSpace(d.Title.Items[0])
+		}
+		if out.Description == "" && len(d.Description.Items) > 0 {
+			out.Description = strings.TrimSpace(d.Description.Items[0])
+		}
+		if out.Language == "" && len(d.Language.Items) > 0 {
+			out.Language = strings.TrimSpace(d.Language.Items[0])
+		}
+		for _, c := range d.Creator.Items {
+			if v := strings.TrimSpace(c); v != "" {
+				out.Creators = append(out.Creators, v)
+			}
+		}
+		if out.ISBN == "" {
+			for _, ident := range d.Identifier.Items {
+				if strings.Contains(strings.ToLower(ident.Scheme), "isbn") {
+					out.ISBN = strings.TrimSpace(ident.Value)
+					break
+				}
+			}
+		}
+	}
+	return out, nil
+}

--- a/internal/fileproc/pdf_xmp.go
+++ b/internal/fileproc/pdf_xmp.go
@@ -3,8 +3,24 @@ package fileproc
 import (
 	"bytes"
 	"encoding/xml"
+	"regexp"
 	"strings"
 )
+
+var nonISBNChar = regexp.MustCompile(`[^0-9Xx]`)
+
+// cleanAndValidateISBN strips separators (including `urn:isbn:` prefixes
+// implicitly — non-`[0-9Xx]` chars), uppercases the trailing X, and
+// returns the value only when it is exactly 10 or 13 chars after
+// cleaning. Anything else returns "".
+func cleanAndValidateISBN(s string) string {
+	cleaned := nonISBNChar.ReplaceAllString(s, "")
+	cleaned = strings.ToUpper(cleaned)
+	if len(cleaned) != 10 && len(cleaned) != 13 {
+		return ""
+	}
+	return cleaned
+}
 
 // XMPMetadata is the subset of XMP fields the PDF processor consumes.
 // Title, Creators (in Seq order), Description, Language come from
@@ -107,7 +123,15 @@ func parseXMP(payload []byte) (XMPMetadata, error) {
 		}
 		if out.ISBN == "" {
 			for _, ident := range d.Identifier.Items {
+				// Explicit scheme match wins regardless of value shape.
 				if strings.Contains(strings.ToLower(ident.Scheme), "isbn") {
+					out.ISBN = strings.TrimSpace(ident.Value)
+					break
+				}
+				// No scheme attribute: Calibre + ADE often emit
+				// `urn:isbn:9780…` with the scheme implied. Accept the
+				// value only when it cleans to a valid 10/13-char ISBN.
+				if ident.Scheme == "" && cleanAndValidateISBN(ident.Value) != "" {
 					out.ISBN = strings.TrimSpace(ident.Value)
 					break
 				}

--- a/internal/fileproc/pdf_xmp_test.go
+++ b/internal/fileproc/pdf_xmp_test.go
@@ -81,3 +81,80 @@ func TestParseXMP_IdentifierBagISBN(t *testing.T) {
 		t.Fatalf("ISBN=%q", x.ISBN)
 	}
 }
+
+func TestCleanAndValidateISBN_13Digit(t *testing.T) {
+	got := cleanAndValidateISBN("978-0-441-17271-9")
+	if got != "9780441172719" {
+		t.Fatalf("got %q want %q", got, "9780441172719")
+	}
+}
+
+func TestCleanAndValidateISBN_10WithX(t *testing.T) {
+	got := cleanAndValidateISBN("0-441-17271-X")
+	if got != "044117271X" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestCleanAndValidateISBN_StripsURNPrefix(t *testing.T) {
+	got := cleanAndValidateISBN("urn:isbn:9780441172719")
+	if got != "9780441172719" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestCleanAndValidateISBN_RejectsShort(t *testing.T) {
+	if got := cleanAndValidateISBN("12345"); got != "" {
+		t.Fatalf("got %q want empty", got)
+	}
+}
+
+func TestCleanAndValidateISBN_RejectsLong(t *testing.T) {
+	if got := cleanAndValidateISBN("12345678901234"); got != "" {
+		t.Fatalf("got %q want empty", got)
+	}
+}
+
+func TestParseXMP_IdentifierBagURNNoSchemeISBN(t *testing.T) {
+	pkt := `<x:xmpmeta xmlns:x="adobe:ns:meta/">
+  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about="" xmlns:xmp="http://ns.adobe.com/xap/1.0/">
+      <xmp:Identifier>
+        <rdf:Bag>
+          <rdf:li>urn:isbn:9780441172719</rdf:li>
+          <rdf:li>not-an-isbn</rdf:li>
+        </rdf:Bag>
+      </xmp:Identifier>
+    </rdf:Description>
+  </rdf:RDF>
+</x:xmpmeta>`
+	x, err := parseXMP([]byte(pkt))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if x.ISBN != "urn:isbn:9780441172719" {
+		t.Fatalf("ISBN=%q", x.ISBN)
+	}
+}
+
+func TestParseXMP_IdentifierBagSkipsNonISBNNoScheme(t *testing.T) {
+	pkt := `<x:xmpmeta xmlns:x="adobe:ns:meta/">
+  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about="" xmlns:xmp="http://ns.adobe.com/xap/1.0/">
+      <xmp:Identifier>
+        <rdf:Bag>
+          <rdf:li>not-an-isbn</rdf:li>
+          <rdf:li>also-not</rdf:li>
+        </rdf:Bag>
+      </xmp:Identifier>
+    </rdf:Description>
+  </rdf:RDF>
+</x:xmpmeta>`
+	x, err := parseXMP([]byte(pkt))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if x.ISBN != "" {
+		t.Fatalf("ISBN=%q want empty", x.ISBN)
+	}
+}

--- a/internal/fileproc/pdf_xmp_test.go
+++ b/internal/fileproc/pdf_xmp_test.go
@@ -2,6 +2,7 @@ package fileproc
 
 import (
 	"bytes"
+	"context"
 	"testing"
 )
 
@@ -156,5 +157,70 @@ func TestParseXMP_IdentifierBagSkipsNonISBNNoScheme(t *testing.T) {
 	}
 	if x.ISBN != "" {
 		t.Fatalf("ISBN=%q want empty", x.ISBN)
+	}
+}
+
+func TestPDFProcessor_XMPOverridesDocInfoAndExtractsISBN(t *testing.T) {
+	body := []byte("%PDF-1.4\n%\xE2\xE3\xCF\xD3\n" +
+		"1 0 obj\n<< /Title (DocInfo Title) /Author (DocInfo Author) >>\nendobj\n")
+	body = append(body, []byte(xmpPacket)...)
+	body = append(body, []byte("\ntrailer << /Info 1 0 R >>\n%%EOF\n")...)
+	src := memSourceFromBytes(body)
+
+	m, err := (PDFProcessor{}).Extract(context.Background(), src)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if m.Title != "XMP Title" {
+		t.Fatalf("Title=%q (XMP must override DocInfo)", m.Title)
+	}
+	if m.Author != "Alice, Bob" {
+		t.Fatalf("Author=%q want %q", m.Author, "Alice, Bob")
+	}
+	if m.Description != "desc here" {
+		t.Fatalf("Description=%q", m.Description)
+	}
+	if m.Language != "en" {
+		t.Fatalf("Language=%q", m.Language)
+	}
+}
+
+func TestPDFProcessor_AuthorSplitFromDocInfo(t *testing.T) {
+	raw := []byte("%PDF-1.4\n%\xE2\xE3\xCF\xD3\n" +
+		"1 0 obj\n<< /Author (Smith, J. & Doe, A.) >>\nendobj\n" +
+		"trailer << /Info 1 0 R >>\n%%EOF\n")
+	src := memSourceFromBytes(raw)
+	m, err := (PDFProcessor{}).Extract(context.Background(), src)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if m.Author != "Smith, J., Doe, A." {
+		t.Fatalf("Author=%q (split [,&], trim, rejoin with ', ')", m.Author)
+	}
+}
+
+func TestPDFProcessor_XMPISBNFromIdentifierBag(t *testing.T) {
+	wrappedBody := []byte("%PDF-1.4\n%\xE2\xE3\xCF\xD3\n1 0 obj\n<< >>\nendobj\n")
+	wrappedBody = append(wrappedBody, []byte(`<?xpacket begin="" id="W5M0MpCehiHzreSzNTczkc9d"?>`+"\n")...)
+	wrappedBody = append(wrappedBody, []byte(`<x:xmpmeta xmlns:x="adobe:ns:meta/">
+  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about="" xmlns:xmp="http://ns.adobe.com/xap/1.0/">
+      <xmp:Identifier>
+        <rdf:Bag>
+          <rdf:li scheme="isbn">978-0-441-17271-9</rdf:li>
+        </rdf:Bag>
+      </xmp:Identifier>
+    </rdf:Description>
+  </rdf:RDF>
+</x:xmpmeta>`)...)
+	wrappedBody = append(wrappedBody, []byte("\n<?xpacket end=\"r\"?>\ntrailer << /Info 1 0 R >>\n%%EOF\n")...)
+
+	src := memSourceFromBytes(wrappedBody)
+	m, err := (PDFProcessor{}).Extract(context.Background(), src)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if m.ISBN != "9780441172719" {
+		t.Fatalf("ISBN=%q want %q (must be cleanAndValidate'd)", m.ISBN, "9780441172719")
 	}
 }

--- a/internal/fileproc/pdf_xmp_test.go
+++ b/internal/fileproc/pdf_xmp_test.go
@@ -1,0 +1,83 @@
+package fileproc
+
+import (
+	"bytes"
+	"testing"
+)
+
+// xmpPacket is built so the UTF-8 BOM (\xef\xbb\xbf) sits between the begin
+// quotes — exactly how Adobe-style XMP packets are wrapped in real PDFs.
+// We construct it via concatenation because Go source files can't contain a
+// raw BOM mid-file.
+var xmpPacket = "<?xpacket begin=\"\xef\xbb\xbf\" id=\"W5M0MpCehiHzreSzNTczkc9d\"?>\n" +
+	`<x:xmpmeta xmlns:x="adobe:ns:meta/">
+ <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about=""
+    xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title><rdf:Alt><rdf:li xml:lang="x-default">XMP Title</rdf:li></rdf:Alt></dc:title>
+    <dc:creator><rdf:Seq><rdf:li>Alice</rdf:li><rdf:li>Bob</rdf:li></rdf:Seq></dc:creator>
+    <dc:description><rdf:Alt><rdf:li xml:lang="x-default">desc here</rdf:li></rdf:Alt></dc:description>
+    <dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language>
+  </rdf:Description>
+ </rdf:RDF>
+</x:xmpmeta>
+<?xpacket end="r"?>`
+
+func TestExtractXMPPacket_FindsBetweenMarkers(t *testing.T) {
+	blob := []byte("%PDF-1.4\n... noise ...\n" + xmpPacket + "\n... more noise ...\n%%EOF")
+	got, ok := extractXMPPacket(blob)
+	if !ok {
+		t.Fatal("xpacket not found")
+	}
+	if !bytes.Contains(got, []byte("dc:title")) {
+		t.Fatalf("packet payload missing dc:title")
+	}
+}
+
+func TestExtractXMPPacket_NoneFound(t *testing.T) {
+	if _, ok := extractXMPPacket([]byte("plain bytes")); ok {
+		t.Fatal("expected miss")
+	}
+}
+
+func TestParseXMP_DublinCore(t *testing.T) {
+	x, err := parseXMP([]byte(xmpPacket))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if x.Title != "XMP Title" {
+		t.Fatalf("Title=%q", x.Title)
+	}
+	want := []string{"Alice", "Bob"}
+	if len(x.Creators) != 2 || x.Creators[0] != want[0] || x.Creators[1] != want[1] {
+		t.Fatalf("Creators=%v want %v", x.Creators, want)
+	}
+	if x.Description != "desc here" {
+		t.Fatalf("Description=%q", x.Description)
+	}
+	if x.Language != "en" {
+		t.Fatalf("Language=%q", x.Language)
+	}
+}
+
+func TestParseXMP_IdentifierBagISBN(t *testing.T) {
+	pkt := `<x:xmpmeta xmlns:x="adobe:ns:meta/">
+  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about="" xmlns:xmp="http://ns.adobe.com/xap/1.0/">
+      <xmp:Identifier>
+        <rdf:Bag>
+          <rdf:li scheme="isbn">978-0-441-17271-9</rdf:li>
+          <rdf:li scheme="amazon">B00001</rdf:li>
+        </rdf:Bag>
+      </xmp:Identifier>
+    </rdf:Description>
+  </rdf:RDF>
+</x:xmpmeta>`
+	x, err := parseXMP([]byte(pkt))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if x.ISBN != "978-0-441-17271-9" {
+		t.Fatalf("ISBN=%q", x.ISBN)
+	}
+}

--- a/internal/fileproc/processor.go
+++ b/internal/fileproc/processor.go
@@ -19,6 +19,12 @@ type Metadata struct {
 	Author      string
 	Description string
 	Language    string
+	// ISBN is the canonical identifier extracted from format-embedded
+	// metadata (PDF XMP Identifier Bag, EPUB OPF identifier). Empty when
+	// the file carries no ISBN. Format-specific extractors clean to digits
+	// + 'X', then validate length 10 or 13 before populating; anything
+	// else is dropped silently.
+	ISBN string
 	// HasCover reports whether the processor saw a cover image.
 	HasCover bool
 	// CoverBytes are the raw image bytes extracted from the file. nil when

--- a/internal/handler/bookdrop.go
+++ b/internal/handler/bookdrop.go
@@ -131,6 +131,46 @@ func (h *Handler) BookDropCover(c *gin.Context) {
 	}
 }
 
+// BookDropFile streams the staged BookDrop file bytes for client-side
+// rendering of a pre-approval cover (e.g. PDF page-1 rasterization in
+// the BookDrop preview). Mirrors BookDropCover's auth shape but reads
+// the original file from the staging directory.
+func (h *Handler) BookDropFile(c *gin.Context) {
+	userID := requireUserID(c)
+	if userID == "" {
+		return
+	}
+	id := c.Param("id")
+	item, err := h.bookdrop.Get(c.Request.Context(), id)
+	if err != nil {
+		if errors.Is(err, repo.ErrNotFound) {
+			c.Status(http.StatusNotFound)
+			return
+		}
+		writeServerError(c, "bookdrop file lookup", err)
+		return
+	}
+	f, err := os.Open(item.Path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			c.Status(http.StatusNotFound)
+			return
+		}
+		writeServerError(c, "bookdrop file open", err)
+		return
+	}
+	defer func() { _ = f.Close() }()
+	mime := mimeForFormat(item.Format)
+	if mime == "" {
+		mime = "application/octet-stream"
+	}
+	c.Header("Content-Type", mime)
+	c.Header("Cache-Control", "private, max-age=3600")
+	if _, err := io.Copy(c.Writer, f); err != nil {
+		writeServerError(c, "bookdrop file stream", err)
+	}
+}
+
 // BookDropPutCover accepts a raw image (PNG or JPEG) for a BookDrop
 // item that doesn't yet have a pre-approval cover. Idempotent on
 // absence: first successful PUT wins; subsequent PUTs return 409.

--- a/internal/handler/bookdrop.go
+++ b/internal/handler/bookdrop.go
@@ -170,7 +170,12 @@ func (h *Handler) BookDropPutCover(c *gin.Context) {
 	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxBytes)
 	raw, err := io.ReadAll(c.Request.Body)
 	if err != nil {
-		c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "image too large"})
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "image too large"})
+			return
+		}
+		writeServerError(c, "bookdrop read cover body", err)
 		return
 	}
 	mime, ok := sniffCoverMime(raw)

--- a/internal/handler/bookdrop.go
+++ b/internal/handler/bookdrop.go
@@ -131,6 +131,74 @@ func (h *Handler) BookDropCover(c *gin.Context) {
 	}
 }
 
+// BookDropPutCover accepts a raw image (PNG or JPEG) for a BookDrop
+// item that doesn't yet have a pre-approval cover. Idempotent on
+// absence: first successful PUT wins; subsequent PUTs return 409.
+//
+// Cap: 5 MB. Magic-sniff: PNG `89 50 4E 47` or JPEG `FF D8 FF`.
+// State gate: item must be in 'discovered', 'processing', or 'ready'.
+// Refuses 'imported' / 'rejected' / 'failed'.
+func (h *Handler) BookDropPutCover(c *gin.Context) {
+	userID := requireUserID(c)
+	if userID == "" {
+		return
+	}
+	id := c.Param("id")
+
+	item, err := h.bookdrop.Get(c.Request.Context(), id)
+	if err != nil {
+		if errors.Is(err, repo.ErrNotFound) {
+			c.Status(http.StatusNotFound)
+			return
+		}
+		writeServerError(c, "bookdrop lookup", err)
+		return
+	}
+	if item.HasCover {
+		c.JSON(http.StatusConflict, gin.H{"error": "cover already present"})
+		return
+	}
+	switch item.State {
+	case model.BookDropDiscovered, model.BookDropProcessing, model.BookDropReady:
+		// accept
+	default:
+		c.JSON(http.StatusConflict, gin.H{"error": "item state does not accept cover upload"})
+		return
+	}
+
+	const maxBytes = 5 << 20
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxBytes)
+	raw, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "image too large"})
+		return
+	}
+	mime, ok := sniffCoverMime(raw)
+	if !ok {
+		c.JSON(http.StatusUnsupportedMediaType, gin.H{"error": "expected PNG or JPEG"})
+		return
+	}
+
+	if err := h.bookdrop.PutPreapprovalCover(c.Request.Context(), id, raw, mime); err != nil {
+		writeServerError(c, "bookdrop put cover", err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// sniffCoverMime returns ("image/png", true) for a PNG magic header,
+// ("image/jpeg", true) for a JPEG SOI, and ("", false) for anything else.
+// Used by BookDropPutCover to gate user-supplied bytes.
+func sniffCoverMime(b []byte) (string, bool) {
+	switch {
+	case len(b) >= 4 && b[0] == 0x89 && b[1] == 0x50 && b[2] == 0x4E && b[3] == 0x47:
+		return "image/png", true
+	case len(b) >= 3 && b[0] == 0xFF && b[1] == 0xD8 && b[2] == 0xFF:
+		return "image/jpeg", true
+	}
+	return "", false
+}
+
 type approveBookDropReq struct {
 	LibraryID string `json:"libraryId,omitempty"`
 }

--- a/internal/handler/bookdrop_test.go
+++ b/internal/handler/bookdrop_test.go
@@ -1,0 +1,28 @@
+package handler
+
+import "testing"
+
+// TestSniffCoverMime exercises the magic-byte sniff used by BookDropPutCover
+// to gate user-supplied cover bytes.
+func TestSniffCoverMime(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   []byte
+		want    string
+		wantOK  bool
+	}{
+		{"png", []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}, "image/png", true},
+		{"jpeg", []byte{0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 'J', 'F', 'I', 'F'}, "image/jpeg", true},
+		{"garbage", []byte{0x00, 0x01, 0x02, 0x03}, "", false},
+		{"empty", []byte{}, "", false},
+		{"too-short-png", []byte{0x89, 0x50, 0x4E}, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := sniffCoverMime(tc.input)
+			if got != tc.want || ok != tc.wantOK {
+				t.Fatalf("sniffCoverMime(%v) = (%q, %v), want (%q, %v)", tc.input, got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}

--- a/internal/handler/bookdrop_test.go
+++ b/internal/handler/bookdrop_test.go
@@ -6,10 +6,10 @@ import "testing"
 // to gate user-supplied cover bytes.
 func TestSniffCoverMime(t *testing.T) {
 	cases := []struct {
-		name    string
-		input   []byte
-		want    string
-		wantOK  bool
+		name   string
+		input  []byte
+		want   string
+		wantOK bool
 	}{
 		{"png", []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}, "image/png", true},
 		{"jpeg", []byte{0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 'J', 'F', 'I', 'F'}, "image/jpeg", true},

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -99,6 +99,7 @@ func (h *Handler) Engine() *gin.Engine {
 			authed.GET("/bookdrop", h.BookDropList)
 			authed.GET("/bookdrop/:id/cover", h.BookDropCover)
 			authed.PUT("/bookdrop/:id/cover", h.BookDropPutCover)
+			authed.GET("/bookdrop/:id/file", h.BookDropFile)
 			authed.POST("/bookdrop/upload", h.BookDropUpload)
 			authed.POST("/bookdrop/:id/approve", h.BookDropApprove)
 			authed.POST("/bookdrop/:id/reject", h.BookDropReject)

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -98,6 +98,7 @@ func (h *Handler) Engine() *gin.Engine {
 			// BookDrop ingest queue
 			authed.GET("/bookdrop", h.BookDropList)
 			authed.GET("/bookdrop/:id/cover", h.BookDropCover)
+			authed.PUT("/bookdrop/:id/cover", h.BookDropPutCover)
 			authed.POST("/bookdrop/upload", h.BookDropUpload)
 			authed.POST("/bookdrop/:id/approve", h.BookDropApprove)
 			authed.POST("/bookdrop/:id/reject", h.BookDropReject)

--- a/internal/migrator/migrations/postgres/000033_bookdrop_isbn.down.sql
+++ b/internal/migrator/migrations/postgres/000033_bookdrop_isbn.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE bookdrop_items DROP COLUMN IF EXISTS isbn;

--- a/internal/migrator/migrations/postgres/000033_bookdrop_isbn.up.sql
+++ b/internal/migrator/migrations/postgres/000033_bookdrop_isbn.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE bookdrop_items
+    ADD COLUMN IF NOT EXISTS isbn TEXT NOT NULL DEFAULT '';

--- a/internal/migrator/migrations/sqlite/000033_bookdrop_isbn.down.sql
+++ b/internal/migrator/migrations/sqlite/000033_bookdrop_isbn.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE bookdrop_items DROP COLUMN isbn;

--- a/internal/migrator/migrations/sqlite/000033_bookdrop_isbn.up.sql
+++ b/internal/migrator/migrations/sqlite/000033_bookdrop_isbn.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE bookdrop_items ADD COLUMN isbn TEXT NOT NULL DEFAULT '';

--- a/internal/model/bookdrop.go
+++ b/internal/model/bookdrop.go
@@ -27,6 +27,7 @@ type BookDropItem struct {
 	Author       string
 	Description  string
 	Language     string
+	ISBN         string
 	HasCover     bool
 	CoverMime    string
 	BookID       *string

--- a/internal/repo/bookdrop.go
+++ b/internal/repo/bookdrop.go
@@ -128,6 +128,29 @@ func (r *BookDropRepo) SetMetadata(ctx context.Context, id, title, author, descr
 	return err
 }
 
+// SetCoverPresence flips has_cover + cover_mime for a row without
+// otherwise touching state/progress. Used by the user-driven cover
+// upload path (BookDropPutCover); ingest's SetMetadata already covers
+// the worker-side path.
+func (r *BookDropRepo) SetCoverPresence(ctx context.Context, id string, hasCover bool, coverMime string) error {
+	const qPG = `
+		UPDATE bookdrop_items
+		SET has_cover = $2, cover_mime = $3, updated_at = now()
+		WHERE id = $1
+	`
+	const qSQLite = `
+		UPDATE bookdrop_items
+		SET has_cover = ?, cover_mime = ?, updated_at = (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+		WHERE id = ?
+	`
+	if r.db.Dialect == db.DialectSQLite {
+		_, err := r.db.SQL.ExecContext(ctx, qSQLite, hasCover, coverMime, id)
+		return err
+	}
+	_, err := r.db.SQL.ExecContext(ctx, qPG, id, hasCover, coverMime)
+	return err
+}
+
 // DeleteProcessed removes every bookdrop row in a terminal state
 // ('imported' or 'rejected'). Returns the ids of the deleted rows so the
 // caller can clean up any lingering cover files off-DB. Active-state rows

--- a/internal/repo/bookdrop.go
+++ b/internal/repo/bookdrop.go
@@ -21,7 +21,7 @@ func NewBookDropRepo(d *db.DB) *BookDropRepo {
 }
 
 const bdCols = `id, path, file_size, format, state, progress, error_msg,
-                title, author, description, language, has_cover, cover_mime, book_id,
+                title, author, description, language, isbn, has_cover, cover_mime, book_id,
                 discovered_at, updated_at, content_hash,
                 duration_seconds, narrator, chapters`
 
@@ -103,11 +103,11 @@ func (r *BookDropRepo) SetState(ctx context.Context, id string, state model.Book
 
 // SetMetadata records metadata extracted by the fileproc worker and flips the
 // item into 'ready' state. cover_mime is empty when no cover was extracted.
-func (r *BookDropRepo) SetMetadata(ctx context.Context, id, title, author, description, language string, hasCover bool, coverMime string) error {
+func (r *BookDropRepo) SetMetadata(ctx context.Context, id, title, author, description, language, isbn string, hasCover bool, coverMime string) error {
 	const qPG = `
 		UPDATE bookdrop_items
 		SET title = $2, author = $3, description = $4, language = $5,
-		    has_cover = $6, cover_mime = $7,
+		    isbn = $6, has_cover = $7, cover_mime = $8,
 		    state = 'ready', progress = 100, error_msg = '',
 		    updated_at = now()
 		WHERE id = $1
@@ -115,16 +115,16 @@ func (r *BookDropRepo) SetMetadata(ctx context.Context, id, title, author, descr
 	const qSQLite = `
 		UPDATE bookdrop_items
 		SET title = ?, author = ?, description = ?, language = ?,
-		    has_cover = ?, cover_mime = ?,
+		    isbn = ?, has_cover = ?, cover_mime = ?,
 		    state = 'ready', progress = 100, error_msg = '',
 		    updated_at = (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 		WHERE id = ?
 	`
 	if r.db.Dialect == db.DialectSQLite {
-		_, err := r.db.SQL.ExecContext(ctx, qSQLite, title, author, description, language, hasCover, coverMime, id)
+		_, err := r.db.SQL.ExecContext(ctx, qSQLite, title, author, description, language, isbn, hasCover, coverMime, id)
 		return err
 	}
-	_, err := r.db.SQL.ExecContext(ctx, qPG, id, title, author, description, language, hasCover, coverMime)
+	_, err := r.db.SQL.ExecContext(ctx, qPG, id, title, author, description, language, isbn, hasCover, coverMime)
 	return err
 }
 
@@ -248,7 +248,7 @@ func (r *BookDropRepo) scanBookDrop(s scanner) (model.BookDropItem, error) {
 	)
 	err := s.Scan(
 		&item.ID, &item.Path, &item.FileSize, &item.Format, &state, &item.Progress, &item.ErrorMsg,
-		&item.Title, &item.Author, &item.Description, &item.Language, &item.HasCover, &item.CoverMime, &item.BookID,
+		&item.Title, &item.Author, &item.Description, &item.Language, &item.ISBN, &item.HasCover, &item.CoverMime, &item.BookID,
 		&discoveredAny, &updatedAny, &item.ContentHash,
 		&durationAny, &item.Narrator, &chaptersAny,
 	)

--- a/internal/service/bookdrop.go
+++ b/internal/service/bookdrop.go
@@ -124,7 +124,7 @@ func (s *BookDropService) BeginProcessing(ctx context.Context, id string) error 
 func (s *BookDropService) RecordMetadata(
 	ctx context.Context,
 	id string,
-	title, author, description, language string,
+	title, author, description, language, isbn string,
 	coverBytes []byte,
 	coverMime string,
 ) error {
@@ -139,7 +139,7 @@ func (s *BookDropService) RecordMetadata(
 		coverMime = ""
 	}
 
-	if err := s.bdrop.SetMetadata(ctx, id, title, author, description, language, hasCover, coverMime); err != nil {
+	if err := s.bdrop.SetMetadata(ctx, id, title, author, description, language, isbn, hasCover, coverMime); err != nil {
 		return err
 	}
 	s.broadcast(id)
@@ -223,6 +223,7 @@ func (s *BookDropService) Approve(ctx context.Context, id, libraryID string) (mo
 		Author:      item.Author,
 		Format:      item.Format,
 		Description: item.Description,
+		ISBN:        item.ISBN,
 		Path:        item.Path,
 		HasCover:    item.HasCover,
 		CoverMime:   item.CoverMime,

--- a/internal/service/bookdrop.go
+++ b/internal/service/bookdrop.go
@@ -146,6 +146,24 @@ func (s *BookDropService) RecordMetadata(
 	return nil
 }
 
+// PutPreapprovalCover writes raw cover bytes for a BookDrop item that
+// doesn't yet carry a cover. Used by the BookDrop preview UI to push
+// a client-rendered PDF page-1 raster (see ADR-0015). Caller must
+// ensure item.HasCover is false; this method does not re-check.
+func (s *BookDropService) PutPreapprovalCover(ctx context.Context, id string, raw []byte, mime string) error {
+	if s.covers == nil {
+		return errors.New("cover store not configured")
+	}
+	if err := s.covers.SaveBookDrop(id, raw); err != nil {
+		return fmt.Errorf("save cover bytes: %w", err)
+	}
+	if err := s.bdrop.SetCoverPresence(ctx, id, true, mime); err != nil {
+		return fmt.Errorf("mark has_cover: %w", err)
+	}
+	s.broadcast(id)
+	return nil
+}
+
 // SetAudio persists the audiobook fields extracted by the ingest worker.
 // Used after RecordMetadata for MP3/M4B; non-audio formats skip this call.
 // Failures bubble up to the worker which retries the whole job.

--- a/internal/service/bookdrop.go
+++ b/internal/service/bookdrop.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -241,10 +242,19 @@ func (s *BookDropService) Approve(ctx context.Context, id, libraryID string) (mo
 		Author:      item.Author,
 		Format:      item.Format,
 		Description: item.Description,
-		ISBN:        item.ISBN,
 		Path:        item.Path,
 		HasCover:    item.HasCover,
 		CoverMime:   item.CoverMime,
+	}
+	// Route the extractor-supplied ISBN by length: book.ISBN is the
+	// ISBN-13 slot, book.ISBN10 is the 10-digit slot. Mirrors the
+	// length-based routing in enrichment.go so a Calibre PDF whose XMP
+	// only carries an ISBN-10 doesn't pollute the ISBN-13 column.
+	switch len(strings.TrimSpace(item.ISBN)) {
+	case 13:
+		book.ISBN = strings.TrimSpace(item.ISBN)
+	case 10:
+		book.ISBN10 = strings.TrimSpace(item.ISBN)
 	}
 
 	res, perr := handle.Placer.Place(ctx, PlaceSource{

--- a/internal/task/bookdrop.go
+++ b/internal/task/bookdrop.go
@@ -118,7 +118,7 @@ func BookDropIngest(ctx context.Context, args BookDropIngestArgs, deps BookDropD
 
 	if err := deps.Svc.RecordMetadata(
 		ctx, itemID,
-		res.Title, res.Author, res.Description, res.Language,
+		res.Title, res.Author, res.Description, res.Language, res.ISBN,
 		res.CoverBytes, res.CoverMime,
 	); err != nil {
 		return err

--- a/internal/task/bookdrop.go
+++ b/internal/task/bookdrop.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/riverqueue/river"
@@ -114,6 +115,15 @@ func BookDropIngest(ctx context.Context, args BookDropIngestArgs, deps BookDropD
 		slog.Warn("bookdrop extract failed", "item_id", itemID, "path", item.Path, "err", extractErr)
 		_ = deps.Svc.Fail(ctx, itemID, extractErr)
 		return nil
+	}
+
+	// Filename fallback: extractors that can't surface a Title (e.g. PDFs
+	// without /Info Title, or sparse OPF metadata) would otherwise leave
+	// the BookDrop list with a blank row. Use the basename without the
+	// extension so the user has something selectable to triage.
+	if strings.TrimSpace(res.Title) == "" {
+		base := filepath.Base(item.Path)
+		res.Title = strings.TrimSuffix(base, filepath.Ext(base))
 	}
 
 	if err := deps.Svc.RecordMetadata(

--- a/ui/src/api/bookdrop.ts
+++ b/ui/src/api/bookdrop.ts
@@ -157,3 +157,29 @@ export function uploadBookDrop(
 export const bookdropQueryKey = ["bookdrop"] as const
 
 export const bookdropCoverUrl = (id: string) => `/api/v1/bookdrop/${id}/cover`
+
+// bookdropFileUrl returns the URL serving the staged file bytes for a
+// BookDrop item before approval. Used by the preview pane to render a
+// client-side cover (e.g. PDF page-1) when the extractor didn't find one.
+export const bookdropFileUrl = (id: string) =>
+  `/api/v1/bookdrop/${encodeURIComponent(id)}/file`
+
+// putBookDropCover uploads a client-rendered cover image (PNG/JPEG raw
+// bytes, <= 5 MB) for a BookDrop item that doesn't yet have a cover.
+// 409 (already-present) is treated as success — caller doesn't need to
+// distinguish "we wrote it" from "someone else already did".
+export async function putBookDropCover(
+  id: string,
+  blob: Blob
+): Promise<void> {
+  const res = await fetch(`/api/v1/bookdrop/${encodeURIComponent(id)}/cover`, {
+    method: "PUT",
+    body: blob,
+    headers: { "content-type": blob.type || "image/jpeg" },
+    credentials: "include",
+  })
+  if (res.status === 409) return
+  if (!res.ok) {
+    throw new Error(`putBookDropCover ${res.status}`)
+  }
+}

--- a/ui/src/lib/pdfCover.ts
+++ b/ui/src/lib/pdfCover.ts
@@ -19,16 +19,25 @@ export type RenderCoverOpts = {
 // JPEG blob. Returns null when the document is unreadable or the
 // canvas can't allocate. The caller is expected to upload the blob via
 // putBookDropCover and discard it afterwards.
+//
+// When `signal` aborts, the in-flight pdfjs `loadingTask` is destroyed,
+// which cancels both the network fetch and the worker-side parsing.
 export async function renderPdfPageOneJpeg(
   url: string,
-  opts?: RenderCoverOpts
+  opts?: RenderCoverOpts & { signal?: AbortSignal }
 ): Promise<Blob | null> {
   const targetWidth = opts?.width ?? 1200
   const quality = opts?.quality ?? 0.85
   const loadingTask = pdfjsLib.getDocument({ url, withCredentials: true })
+  const signal = opts?.signal
+  const onAbort = () => {
+    void loadingTask.destroy()
+  }
+  signal?.addEventListener("abort", onAbort, { once: true })
   let doc: PDFDocumentProxy | null = null
   try {
     doc = await loadingTask.promise
+    if (signal?.aborted) return null
     const page = await doc.getPage(1)
     const baseViewport = page.getViewport({ scale: 1 })
     const scale = targetWidth / baseViewport.width
@@ -39,12 +48,14 @@ export async function renderPdfPageOneJpeg(
     const ctx = canvas.getContext("2d")
     if (!ctx) return null
     await page.render({ canvasContext: ctx, viewport, canvas }).promise
+    if (signal?.aborted) return null
     return await new Promise<Blob | null>((resolve) =>
       canvas.toBlob((b) => resolve(b), "image/jpeg", quality)
     )
   } catch {
     return null
   } finally {
+    signal?.removeEventListener("abort", onAbort)
     if (doc) {
       try {
         await doc.destroy()

--- a/ui/src/lib/pdfCover.ts
+++ b/ui/src/lib/pdfCover.ts
@@ -1,0 +1,56 @@
+import * as pdfjsLib from "pdfjs-dist"
+import type { PDFDocumentProxy } from "pdfjs-dist"
+
+// Worker URL is computed once at module load — same shape as PdfReader.
+// Vite resolves the URL at build time and emits the worker as a hashed
+// asset, so this is safe to set even when the helper is imported by
+// non-reader pages (e.g. BookDrop preview).
+pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
+  "pdfjs-dist/build/pdf.worker.min.mjs",
+  import.meta.url
+).toString()
+
+export type RenderCoverOpts = {
+  width?: number
+  quality?: number
+}
+
+// renderPdfPageOneJpeg fetches a PDF and rasters its first page to a
+// JPEG blob. Returns null when the document is unreadable or the
+// canvas can't allocate. The caller is expected to upload the blob via
+// putBookDropCover and discard it afterwards.
+export async function renderPdfPageOneJpeg(
+  url: string,
+  opts?: RenderCoverOpts
+): Promise<Blob | null> {
+  const targetWidth = opts?.width ?? 1200
+  const quality = opts?.quality ?? 0.85
+  const loadingTask = pdfjsLib.getDocument({ url, withCredentials: true })
+  let doc: PDFDocumentProxy | null = null
+  try {
+    doc = await loadingTask.promise
+    const page = await doc.getPage(1)
+    const baseViewport = page.getViewport({ scale: 1 })
+    const scale = targetWidth / baseViewport.width
+    const viewport = page.getViewport({ scale })
+    const canvas = document.createElement("canvas")
+    canvas.width = Math.ceil(viewport.width)
+    canvas.height = Math.ceil(viewport.height)
+    const ctx = canvas.getContext("2d")
+    if (!ctx) return null
+    await page.render({ canvasContext: ctx, viewport, canvas }).promise
+    return await new Promise<Blob | null>((resolve) =>
+      canvas.toBlob((b) => resolve(b), "image/jpeg", quality)
+    )
+  } catch {
+    return null
+  } finally {
+    if (doc) {
+      try {
+        await doc.destroy()
+      } catch {
+        // best-effort
+      }
+    }
+  }
+}

--- a/ui/src/routes/_app.bookdrop.tsx
+++ b/ui/src/routes/_app.bookdrop.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
 import type { ReactNode } from "react"
@@ -13,11 +13,14 @@ import type { Library } from "@/api/books"
 import {
   approveBookDrop,
   bookdropCoverUrl,
+  bookdropFileUrl,
   bookdropQueryKey,
   fetchBookDrop,
+  putBookDropCover,
   rejectBookDrop,
   uploadBookDrop,
 } from "@/api/bookdrop"
+import { renderPdfPageOneJpeg } from "@/lib/pdfCover"
 import { booksQueryKey, fetchLibraries, librariesQueryKey } from "@/api/books"
 import { Icon } from "@/components/Icon"
 import { TopBar } from "@/components/TopBar"
@@ -570,6 +573,40 @@ function EmptyDetail() {
 }
 
 function CoverPanel({ item }: { item: BookDropItem }) {
+  const queryClient = useQueryClient()
+  // Set guards against duplicate uploads on re-render / StrictMode
+  // double-effect. Survives across renders for the lifetime of the
+  // component instance.
+  const uploadedRef = useRef<Set<string>>(new Set())
+  const isPreapprovalState =
+    item.state === "discovered" ||
+    item.state === "processing" ||
+    item.state === "ready"
+
+  useEffect(() => {
+    if (item.format !== "PDF") return
+    if (item.hasCover) return
+    if (!isPreapprovalState) return
+    if (uploadedRef.current.has(item.id)) return
+    uploadedRef.current.add(item.id)
+    // Explicit `: boolean` widens the type so the lint rule doesn't
+    // narrow to literal-false — the cleanup closure mutates it.
+    let cancelled = false as boolean
+    void (async () => {
+      const blob = await renderPdfPageOneJpeg(bookdropFileUrl(item.id))
+      if (cancelled || !blob) return
+      try {
+        await putBookDropCover(item.id, blob)
+        queryClient.invalidateQueries({ queryKey: bookdropQueryKey })
+      } catch (err) {
+        console.warn("auto cover upload failed", err)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [item.id, item.format, item.hasCover, isPreapprovalState, queryClient])
+
   return (
     <div className="bdrop-cover-frame">
       {item.hasCover ? (
@@ -581,7 +618,11 @@ function CoverPanel({ item }: { item: BookDropItem }) {
             size={28}
             className="mb-2 text-(--color-ink-3)"
           />
-          <span className="bdrop-cover-blank-label">no cover detected</span>
+          <span className="bdrop-cover-blank-label">
+            {item.format === "PDF" && isPreapprovalState
+              ? "rendering cover…"
+              : "no cover detected"}
+          </span>
         </div>
       )}
     </div>

--- a/ui/src/routes/_app.bookdrop.tsx
+++ b/ui/src/routes/_app.bookdrop.tsx
@@ -576,7 +576,8 @@ function CoverPanel({ item }: { item: BookDropItem }) {
   const queryClient = useQueryClient()
   // Set guards against duplicate uploads on re-render / StrictMode
   // double-effect. Survives across renders for the lifetime of the
-  // component instance.
+  // component instance. Relies on backend 409 idempotency for
+  // cross-mount duplicate suppression.
   const uploadedRef = useRef<Set<string>>(new Set())
   const isPreapprovalState =
     item.state === "discovered" ||
@@ -589,12 +590,11 @@ function CoverPanel({ item }: { item: BookDropItem }) {
     if (!isPreapprovalState) return
     if (uploadedRef.current.has(item.id)) return
     uploadedRef.current.add(item.id)
-    // Explicit `: boolean` widens the type so the lint rule doesn't
-    // narrow to literal-false — the cleanup closure mutates it.
-    let cancelled = false as boolean
+    const ctrl = new AbortController()
     void (async () => {
-      const blob = await renderPdfPageOneJpeg(bookdropFileUrl(item.id))
-      if (cancelled || !blob) return
+      const url = bookdropFileUrl(item.id)
+      const blob = await renderPdfPageOneJpeg(url, { signal: ctrl.signal })
+      if (ctrl.signal.aborted || !blob) return
       try {
         await putBookDropCover(item.id, blob)
         queryClient.invalidateQueries({ queryKey: bookdropQueryKey })
@@ -603,7 +603,7 @@ function CoverPanel({ item }: { item: BookDropItem }) {
       }
     })()
     return () => {
-      cancelled = true
+      ctrl.abort()
     }
   }, [item.id, item.format, item.hasCover, isPreapprovalState, queryClient])
 


### PR DESCRIPTION
## Summary

Hardens PDF metadata discovery and adds a client-rendered cover at BookDrop preview, all without a Go-side PDF rasterizer (per ADR-0015).

**Backend (extractor)**
- DocInfo: decode hex `<FEFF…>` and UTF-16BE BOM literals (Acrobat/MS Word non-ASCII titles), trailer-tail window 8 KB → 256 KB.
- XMP: pure-byte `<?xpacket begin … end ?>` scan, `dc:title/creator(Seq)/description/language` plus `xmp:Identifier/rdf:Bag` ISBN (scheme=isbn or no-scheme `urn:isbn:` Calibre/ADE form).
- Author: DocInfo split on `[,&]`, XMP `dc:creator` Seq overrides, joined `, `.
- ISBN: clean+validate (10 or 13 digits), routed by length to `book.ISBN` (13) vs `book.ISBN10` (10) on approve.
- Filename fallback for empty Title.
- Bug fix: `extractor.layerSidecar` now overlays `s.ISBN` (was silently dropped — affects EPUB OPF too).

**Backend (handlers)**
- `PUT /api/v1/bookdrop/:id/cover` — 5 MB cap, magic-sniff PNG/JPEG, state-gated (`discovered`/`processing`/`ready`), 409 if already present, 204 on success. `MaxBytesError` differentiated from transport errors.
- `GET /api/v1/bookdrop/:id/file` — streams staged BookDrop bytes for client raster.
- New `BookDropService.PutPreapprovalCover` + `BookDropRepo.SetCoverPresence`.

**Frontend**
- `ui/src/lib/pdfCover.ts` — `renderPdfPageOneJpeg(url, {signal})` rasters page 1 at 1200 px JPEG q85; `AbortSignal` cancels stale `loadingTask` on unmount.
- `CoverPanel` in `_app.bookdrop.tsx` auto-fires for PDFs without a cover, guarded by per-mount `Set<string>` against StrictMode double-effect.
- `putBookDropCover(id, blob)` API client treats 409 as success.

**Schema**
- Migration `000033_bookdrop_isbn` (Postgres + SQLite).

**Docs**
- ADR-0015 (PDF cover rendered in browser at BookDrop preview).
- `docs/superpowers/plans/2026-05-03-pdf-discovery-improvements.md`.
- `docs/spec/pdf-discovery.spec.md` (input spec).

## Test plan

- [ ] Drop a Calibre-exported PDF with XMP DC + ISBN — preview shows correct title/author/ISBN; cover thumbnail appears within ~1 s; approve persists ISBN.
- [ ] Drop an Acrobat-saved PDF with hex `<FEFF…>` `/Title` — non-ASCII title renders correctly.
- [ ] Drop a PDF with neither DocInfo nor XMP — title falls back to filename basename without extension.
- [ ] Drop a PDF whose XMP carries an ISBN-10 (e.g., `urn:isbn:0-441-17271-X`) — value lands in `book.isbn10`, NOT in `book.isbn`.
- [ ] Approve a PDF, hit `/opds/cover/<id>` — JPEG bytes returned.
- [ ] Open + close + reopen the same BookDrop item — only one PUT to `/cover` (StrictMode + remount guard).
- [ ] Try a >5 MB JPEG via `PUT /bookdrop/:id/cover` — 413 with `image too large`.
- [ ] Try a PDF/text body via `PUT /bookdrop/:id/cover` — 415 with `expected PNG or JPEG`.
- [ ] PUT a second cover after one already present — 409 with `cover already present`.

## Known follow-ups (track separately)

- `BookDropFile` could use `http.ServeContent` for Range support (lets pdfjs partial-fetch large PDFs).
- `pdfjsLib.GlobalWorkerOptions.workerSrc` is set in two modules (`PdfReader.tsx`, `pdfCover.ts`); dedupe to one shared module.
- Consider sharing `cleanAndValidateISBN` between `internal/fileproc` and `internal/service/enrichment`.
- ISBN-10 checksum validation is not enforced (length-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)