### PR TITLE
refactor(oidc): one provider adapter absorbs the five per-slug switches

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -40,6 +40,12 @@ Guarded by a parity test that parses the package's own sources (package-level va
 
 `METADATA_AUTO_ENRICH` is deliberately outside it: a bare `GetBool`/`SetBool` flag with no `Setting[T]`, unseeded, reading false when absent.
 
+### Settings surface
+
+`handler.settingsDomain[Cfg, DTO]`; the handler-tier declaration of one admin settings panel's get/put pair, the third layer over [[Setting]] and the [[Settings registry]]. The HTTP pipeline — nil-store 503, bind, load-current, merge, secret resolution, save, error split, reload, side effect, respond — is written once in `settingsGet`/`settingsPut`; a domain declares only its wire shape, its tri-state secret slots, which save refusal is the admin's 400, and its post-save side effect (SMTP hot-reload, forward-auth runtime publish). `resolveSecret` runs in exactly one place, the adapter's loop over declared slots, so a new panel cannot restate the keep-versus-clear rule — only declare where it applies.
+
+Exists because five surfaces restated that pipeline and had already diverged three ways (#249). Six declarations today: EMAIL, READING_GUIDE, AUDIOBOOK, FORWARD_AUTH, CONVERTER, and OIDC — whose config aggregates five rows and whose save is the transactional `OIDCSettingsService.Apply`, not a store write. `METADATA_AUTO_ENRICH` stays outside for the same reason it skips the registry: no typed row, no pipeline. Probe/test endpoints (SMTP test-send, TTS probe, OIDC connection test) are not part of the shape — they stay hand-written.
+
 ---
 
 ## Users & identity

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -44,7 +44,7 @@ Guarded by a parity test that parses the package's own sources (package-level va
 
 `handler.settingsDomain[Cfg, DTO]`; the handler-tier declaration of one admin settings panel's get/put pair, the third layer over [[Setting]] and the [[Settings registry]]. The HTTP pipeline — nil-store 503, bind, load-current, merge, secret resolution, save, error split, reload, side effect, respond — is written once in `settingsGet`/`settingsPut`; a domain declares only its wire shape, its tri-state secret slots, which save refusal is the admin's 400, and its post-save side effect (SMTP hot-reload, forward-auth runtime publish). `resolveSecret` runs in exactly one place, the adapter's loop over declared slots, so a new panel cannot restate the keep-versus-clear rule — only declare where it applies.
 
-Exists because five surfaces restated that pipeline and had already diverged three ways (#249). Six declarations today: EMAIL, READING_GUIDE, AUDIOBOOK, FORWARD_AUTH, CONVERTER, and OIDC — whose config aggregates five rows and whose save is the transactional `OIDCSettingsService.Apply`, not a store write. `METADATA_AUTO_ENRICH` stays outside for the same reason it skips the registry: no typed row, no pipeline. Probe/test endpoints (SMTP test-send, TTS probe, OIDC connection test) are not part of the shape — they stay hand-written.
+Exists because five surfaces restated that pipeline and had already diverged three ways (#249). Six declarations today: EMAIL, READING_GUIDE, AUDIOBOOK, FORWARD_AUTH, CONVERTER, and OIDC — whose config aggregates five rows and whose save is the transactional `OIDCSettingsService.Apply`, not a store write. `METADATA_AUTO_ENRICH` stays outside for the same reason it skips the registry: no typed row, no pipeline. Probe/test endpoints (SMTP test-send, TTS probe, OIDC connection test) are not part of the shape; since #258 the OIDC one dispatches through the [[OIDC provider registry]] rather than a hand-written slug switch, but it still lives outside the settings pipeline.
 
 ---
 
@@ -97,9 +97,9 @@ The policy has a single implementation: `service.Provisioner` (identity match �
 
 ### OIDC provider registry
 
-`OIDCService.providers`; the slug → operations map built once at construction. Each entry pairs a provider's authorize-URL builder with its callback exchange, because both dispatch on the same slug and previously did so in separate `switch` statements that had to stay in step by hand. Adding a provider is one entry in `newProviderRegistry`; nothing else in the file switches on a slug.
+`OIDCService.providers`; the ordered slice of slug → adapter entries built once at construction (`oidc_providers.go`). Each adapter satisfies the `oidcProvider` interface — usable gate + public listing (one `public()` call, merged because "usable" exists so the login page never offers a button that 500s), auth URL, callback, and connection test — because all five previously dispatched on the same slug across four service sites plus a hand-written switch in the handler (#258). Adding a provider is one entry in `newProviderRegistry`; nothing else switches on a slug, pinned by a test that enumerates the registry. A slice rather than a map so the login page lists providers in a stable order.
 
-Shaped as a struct of funcs rather than an interface, matching the [[Job registry]]: the per-provider work already exists as methods, so a registration is a pair of method values and no bodies move. GitHub is the odd one — not an OIDC provider at all, so it has no discovery document and its issuer is the `githubIssuer` constant rather than something the exchange reports.
+Reshaped from a struct of funcs to an interface at #258, when the surface grew from two operations to five: the adapters own their provider-shaped differences (fixed issuers vs generic, GitHub's no-discovery `githubIssuer` constant, each connection test's override wire shape), while the shared machinery — discovery cache, state minting, the OAuth exchanges — stays on `OIDCService`. The connection test's blank-submission fallback ("a blank submission tests the stored row instead") is stated once, in `testWithStoredFallback`.
 
 ### OIDC state
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -346,7 +346,11 @@ Handler → Service → Repository → PostgreSQL
   `bookdropDTO`, `enrichMatchDTO`, `deviceDTO`, `annotationDTO`,
   `identityDTO`, `oidcConfigDTO` + pointer-field PATCH types).
   camelCase on the wire; matching TS types under
-  [ui/src/api/](../ui/src/api/).
+  [ui/src/api/](../ui/src/api/). One deliberate exception (#258): the
+  OIDC connection-test override shapes live with their provider
+  adapters in `internal/service/oidc_providers.go`, because each
+  provider owns its test submission and the handler forwards the raw
+  body without interpreting it.
 
 ### 4.2 Concurrency Model
 

--- a/internal/handler/audiobook_settings.go
+++ b/internal/handler/audiobook_settings.go
@@ -3,6 +3,7 @@
 package handler
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -11,17 +12,21 @@ import (
 	"github.com/blackforge/embookshelf/internal/tts"
 )
 
-// audiobookEngineDTO is one engine's row in the settings panel.
+// audiobookEngineDTO is one engine's row in the settings panel, and the
+// same shape a PUT submits back.
 //
 // KeySet rather than the key itself: a GET must never hand back a
-// credential it was given. It comes back on PUT too, so an empty
-// submitted key can mean either "keep the stored one" or "clear it" —
-// the same write-only shape the reading-guide panel uses.
+// credential it was given. APIKey is write-only — never populated on
+// the way out — and rides with KeySet so an empty submitted key can
+// mean either "keep the stored one" or "clear it", the same tri-state
+// the reading-guide panel uses. Label and the Needs*/MaxRequestChars
+// fields are read-only catalog facts a submission cannot change.
 type audiobookEngineDTO struct {
 	ID                   string  `json:"id"`
 	Label                string  `json:"label"`
 	Enabled              bool    `json:"enabled"`
 	BaseURL              string  `json:"baseUrl"`
+	APIKey               string  `json:"apiKey,omitempty"`
 	KeySet               bool    `json:"keySet"`
 	Model                string  `json:"model"`
 	DefaultVoice         string  `json:"defaultVoice"`
@@ -41,85 +46,61 @@ type audiobookSettingsDTO struct {
 	Engines []audiobookEngineDTO `json:"engines"`
 }
 
-// audiobookSettingsRequest mirrors the DTO minus the read-only catalog
-// facts, plus the write-only key.
-type audiobookEngineRequest struct {
-	ID                   string  `json:"id"`
-	Enabled              bool    `json:"enabled"`
-	BaseURL              string  `json:"baseUrl"`
-	APIKey               string  `json:"apiKey"`
-	KeySet               bool    `json:"keySet"`
-	Model                string  `json:"model"`
-	DefaultVoice         string  `json:"defaultVoice"`
-	PricePerMillionChars float64 `json:"pricePerMillionChars"`
-}
-
-type audiobookSettingsRequest struct {
-	Enabled bool                     `json:"enabled"`
-	Engine  string                   `json:"engine"`
-	Engines []audiobookEngineRequest `json:"engines"`
-}
-
-func (h *Handler) SettingsAudiobookGet(c *gin.Context) {
-	if h.appSettings == nil {
-		writeError(c, http.StatusServiceUnavailable, "settings are unavailable")
-		return
-	}
-	cfg, err := h.appSettings.GetAudiobook(c.Request.Context())
-	if err != nil {
-		writeServerError(c, "audiobook settings get", err)
-		return
-	}
-	c.JSON(http.StatusOK, audiobookSettingsToDTO(cfg))
-}
-
-func (h *Handler) SettingsAudiobookUpdate(c *gin.Context) {
-	if h.appSettings == nil {
-		writeError(c, http.StatusServiceUnavailable, "settings are unavailable")
-		return
-	}
-	var req audiobookSettingsRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		writeError(c, http.StatusBadRequest, "invalid request body")
-		return
-	}
-
-	// Load first so a key the admin did not retype can be kept. Submitting
-	// the form without retyping every credential has to be safe, or admins
-	// learn to paste keys into a field they can no longer read back.
-	cfg, err := h.appSettings.GetAudiobook(c.Request.Context())
-	if err != nil {
-		writeServerError(c, "audiobook settings load", err)
-		return
-	}
-	cfg.Enabled = req.Enabled
-	cfg.Engine = req.Engine
-	for _, in := range req.Engines {
-		slot := cfg.EngineSlot(tts.EngineID(in.ID))
-		if slot == nil {
-			continue
+// audiobookSettings declares the AUDIOBOOK surface. The engine list is
+// the one dynamic secret set among the settings domains: each submitted
+// engine that matches a config slot carries its own tri-state API key.
+// Every save refusal maps to a 400 — same reasoning as the reading
+// guide surface.
+var audiobookSettings = settingsDomain[repo.AudiobookConfig, audiobookSettingsDTO]{
+	name: "audiobook settings",
+	get: func(ctx context.Context, h *Handler) (repo.AudiobookConfig, error) {
+		return h.appSettings.GetAudiobook(ctx)
+	},
+	save: func(ctx context.Context, h *Handler, cfg repo.AudiobookConfig) error {
+		return h.appSettings.SetAudiobook(ctx, cfg)
+	},
+	toDTO: func(_ *Handler, _ *gin.Context, cfg repo.AudiobookConfig) audiobookSettingsDTO {
+		return audiobookSettingsToDTO(cfg)
+	},
+	merge: func(req audiobookSettingsDTO, current repo.AudiobookConfig) repo.AudiobookConfig {
+		next := current
+		next.Enabled = req.Enabled
+		next.Engine = req.Engine
+		for _, in := range req.Engines {
+			slot := next.EngineSlot(tts.EngineID(in.ID))
+			if slot == nil {
+				continue
+			}
+			slot.Enabled = in.Enabled
+			slot.BaseURL = in.BaseURL
+			slot.Model = in.Model
+			slot.DefaultVoice = in.DefaultVoice
+			slot.PricePerMillionChars = in.PricePerMillionChars
 		}
-		slot.Enabled = in.Enabled
-		slot.BaseURL = in.BaseURL
-		slot.Model = in.Model
-		slot.DefaultVoice = in.DefaultVoice
-		slot.PricePerMillionChars = in.PricePerMillionChars
-		slot.APIKey = resolveSecret(in.APIKey, in.KeySet, slot.APIKey)
-	}
-
-	if err := h.appSettings.SetAudiobook(c.Request.Context(), cfg); err != nil {
-		// Validation failures are the admin's to fix and carry their own
-		// message; anything else is ours.
-		writeError(c, http.StatusBadRequest, err.Error())
-		return
-	}
-	saved, err := h.appSettings.GetAudiobook(c.Request.Context())
-	if err != nil {
-		writeServerError(c, "audiobook settings reload", err)
-		return
-	}
-	c.JSON(http.StatusOK, audiobookSettingsToDTO(saved))
+		return next
+	},
+	secrets: func(req *audiobookSettingsDTO, next, current *repo.AudiobookConfig) []settingsSecret {
+		out := make([]settingsSecret, 0, len(req.Engines))
+		for _, in := range req.Engines {
+			slot := next.EngineSlot(tts.EngineID(in.ID))
+			if slot == nil {
+				continue
+			}
+			out = append(out, settingsSecret{
+				incoming: in.APIKey,
+				set:      in.KeySet,
+				stored:   slot.APIKey,
+				slot:     &slot.APIKey,
+			})
+		}
+		return out
+	},
+	badRequest: anySaveRefusalIsA400,
 }
+
+func (h *Handler) SettingsAudiobookGet(c *gin.Context) { settingsGet(c, h, audiobookSettings) }
+
+func (h *Handler) SettingsAudiobookUpdate(c *gin.Context) { settingsPut(c, h, audiobookSettings) }
 
 // SettingsAudiobookVoices proxies the selected engine's voice list, which
 // is what populates the generate dialog's picker.
@@ -170,7 +151,7 @@ func (h *Handler) SettingsAudiobookTest(c *gin.Context) {
 func (h *Handler) probeEngine(c *gin.Context) (repo.ConfiguredEngine, bool) {
 	var zero repo.ConfiguredEngine
 	if h.appSettings == nil {
-		writeError(c, http.StatusServiceUnavailable, "settings are unavailable")
+		writeError(c, http.StatusServiceUnavailable, "settings repo unavailable")
 		return zero, false
 	}
 	cfg, err := h.appSettings.GetAudiobook(c.Request.Context())

--- a/internal/handler/audiobook_settings_test.go
+++ b/internal/handler/audiobook_settings_test.go
@@ -85,9 +85,9 @@ func TestSettingsAudiobookUpdateKeepsAKeyNotRetyped(t *testing.T) {
 			store := &fakeAppSettings{audiobook: storedAudiobook()}
 			h := &Handler{appSettings: store}
 
-			req := audiobookSettingsRequest{
+			req := audiobookSettingsDTO{
 				Enabled: true, Engine: string(tts.EngineOpenAI),
-				Engines: []audiobookEngineRequest{{
+				Engines: []audiobookEngineDTO{{
 					ID: string(tts.EngineOpenAI), Enabled: true,
 					DefaultVoice: "nova",
 					APIKey:       tc.apiKey, KeySet: tc.keySet,

--- a/internal/handler/audiobook_test.go
+++ b/internal/handler/audiobook_test.go
@@ -92,9 +92,9 @@ func assertSingleResponse(t *testing.T, body string) {
 func TestSettingsAudiobookUpdateResolvesTheKey(t *testing.T) {
 	ctx := context.Background()
 	body := func(apiKey string, keySet bool) string {
-		b, err := json.Marshal(audiobookSettingsRequest{
+		b, err := json.Marshal(audiobookSettingsDTO{
 			Engine: string(tts.EngineElevenLabs),
-			Engines: []audiobookEngineRequest{{
+			Engines: []audiobookEngineDTO{{
 				ID: string(tts.EngineElevenLabs), APIKey: apiKey, KeySet: keySet,
 			}},
 		})

--- a/internal/handler/converter_settings.go
+++ b/internal/handler/converter_settings.go
@@ -43,29 +43,30 @@ type converterSettingsDTO struct {
 	BaseURL string `json:"baseUrl"`
 }
 
-func (h *Handler) SettingsConverterGet(c *gin.Context) {
-	cfg, err := h.appSettings.GetConverter(c.Request.Context())
-	if err != nil {
-		writeServerError(c, "read converter settings", err)
-		return
-	}
-	c.JSON(http.StatusOK, converterSettingsDTO{Enabled: cfg.Enabled, BaseURL: cfg.BaseURL})
+// converterSettings declares the CONVERTER surface. No secrets, no
+// side effects; every save refusal maps to a 400 — validation refuses
+// enabling without a URL, and that is the admin's mistake to see, not
+// a 500.
+var converterSettings = settingsDomain[repo.ConverterConfig, converterSettingsDTO]{
+	name: "converter settings",
+	get: func(ctx context.Context, h *Handler) (repo.ConverterConfig, error) {
+		return h.appSettings.GetConverter(ctx)
+	},
+	save: func(ctx context.Context, h *Handler, cfg repo.ConverterConfig) error {
+		return h.appSettings.SetConverter(ctx, cfg)
+	},
+	toDTO: func(_ *Handler, _ *gin.Context, cfg repo.ConverterConfig) converterSettingsDTO {
+		return converterSettingsDTO{Enabled: cfg.Enabled, BaseURL: cfg.BaseURL}
+	},
+	merge: func(dto converterSettingsDTO, _ repo.ConverterConfig) repo.ConverterConfig {
+		return repo.ConverterConfig{Enabled: dto.Enabled, BaseURL: dto.BaseURL}
+	},
+	badRequest: anySaveRefusalIsA400,
 }
 
-func (h *Handler) SettingsConverterUpdate(c *gin.Context) {
-	var body converterSettingsDTO
-	if !bindJSON(c, &body) {
-		return
-	}
-	next := repo.ConverterConfig{Enabled: body.Enabled, BaseURL: body.BaseURL}
-	if err := h.appSettings.SetConverter(c.Request.Context(), next); err != nil {
-		// Validation refuses enabling without a URL; that is the admin's
-		// mistake to see, not a 500.
-		writeError(c, http.StatusBadRequest, err.Error())
-		return
-	}
-	h.SettingsConverterGet(c)
-}
+func (h *Handler) SettingsConverterGet(c *gin.Context) { settingsGet(c, h, converterSettings) }
+
+func (h *Handler) SettingsConverterUpdate(c *gin.Context) { settingsPut(c, h, converterSettings) }
 
 // converterCoverageDTO is the bulk-conversion card's numbers: the
 // pre-flight ("candidates would convert") and the progress poll are the

--- a/internal/handler/reading_guide.go
+++ b/internal/handler/reading_guide.go
@@ -3,6 +3,7 @@
 package handler
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -180,49 +181,53 @@ type readingGuideSettingsDTO struct {
 	RequestJSONMode bool   `json:"requestJsonMode"`
 }
 
+// readingGuideSettings declares the READING_GUIDE surface. Every save
+// refusal maps to a 400: the row's failures are validation, and the
+// cipher/database cases were already reported this way before the
+// adapter — kept verbatim rather than silently reclassified.
+var readingGuideSettings = settingsDomain[repo.ReadingGuideConfig, readingGuideSettingsDTO]{
+	name: "read guide settings",
+	get: func(ctx context.Context, h *Handler) (repo.ReadingGuideConfig, error) {
+		return h.appSettings.GetReadingGuide(ctx)
+	},
+	save: func(ctx context.Context, h *Handler, cfg repo.ReadingGuideConfig) error {
+		return h.appSettings.SetReadingGuide(ctx, cfg)
+	},
+	toDTO: func(_ *Handler, _ *gin.Context, cfg repo.ReadingGuideConfig) readingGuideSettingsDTO {
+		return readingGuideSettingsDTO{
+			Enabled: cfg.Enabled, BaseURL: cfg.BaseURL, Model: cfg.Model,
+			KeySet: cfg.APIKey != "", AuthStyle: cfg.AuthStyle, Language: cfg.Language,
+			TextCap: cfg.TextCap, RequestJSONMode: cfg.RequestJSONMode,
+		}
+	},
+	merge: func(dto readingGuideSettingsDTO, _ repo.ReadingGuideConfig) repo.ReadingGuideConfig {
+		return repo.ReadingGuideConfig{
+			Enabled:         dto.Enabled,
+			BaseURL:         dto.BaseURL,
+			Model:           dto.Model,
+			AuthStyle:       dto.AuthStyle,
+			Language:        dto.Language,
+			TextCap:         dto.TextCap,
+			RequestJSONMode: dto.RequestJSONMode,
+		}
+	},
+	secrets: func(dto *readingGuideSettingsDTO, next, current *repo.ReadingGuideConfig) []settingsSecret {
+		return []settingsSecret{{
+			incoming: strings.TrimSpace(dto.APIKey),
+			set:      dto.KeySet,
+			stored:   current.APIKey,
+			slot:     &next.APIKey,
+		}}
+	},
+	badRequest: anySaveRefusalIsA400,
+}
+
 func (h *Handler) SettingsReadingGuideGet(c *gin.Context) {
-	cfg, err := h.appSettings.GetReadingGuide(c.Request.Context())
-	if err != nil {
-		writeServerError(c, "read guide settings", err)
-		return
-	}
-	c.JSON(http.StatusOK, readingGuideSettingsDTO{
-		Enabled: cfg.Enabled, BaseURL: cfg.BaseURL, Model: cfg.Model,
-		KeySet: cfg.APIKey != "", AuthStyle: cfg.AuthStyle, Language: cfg.Language,
-		TextCap: cfg.TextCap, RequestJSONMode: cfg.RequestJSONMode,
-	})
+	settingsGet(c, h, readingGuideSettings)
 }
 
 func (h *Handler) SettingsReadingGuideUpdate(c *gin.Context) {
-	var body readingGuideSettingsDTO
-	if !bindJSON(c, &body) {
-		return
-	}
-	ctx := c.Request.Context()
-	current, err := h.appSettings.GetReadingGuide(ctx)
-	if err != nil {
-		writeServerError(c, "read guide settings", err)
-		return
-	}
-
-	next := repo.ReadingGuideConfig{
-		Enabled:         body.Enabled,
-		BaseURL:         body.BaseURL,
-		Model:           body.Model,
-		APIKey:          resolveSecret(strings.TrimSpace(body.APIKey), body.KeySet, current.APIKey),
-		AuthStyle:       body.AuthStyle,
-		Language:        body.Language,
-		TextCap:         body.TextCap,
-		RequestJSONMode: body.RequestJSONMode,
-	}
-
-	if err := h.appSettings.SetReadingGuide(ctx, next); err != nil {
-		// Validation refuses enabling without an endpoint; that is the
-		// admin's mistake to see, not a 500.
-		writeError(c, http.StatusBadRequest, err.Error())
-		return
-	}
-	h.SettingsReadingGuideGet(c)
+	settingsPut(c, h, readingGuideSettings)
 }
 
 // SettingsReadingGuideEstimate sizes a bulk run before anything is spent.

--- a/internal/handler/settings_domain.go
+++ b/internal/handler/settings_domain.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package handler
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// settingsDomain declares one admin settings surface — the get/put pair
+// over a typed app_settings row — so the HTTP pipeline those endpoints
+// share is written once, in settingsGet and settingsPut, instead of once
+// per panel (#249).
+//
+// The split of responsibilities follows the row: repo.Setting already
+// owns normalize, validate, defaults and at-rest secret encryption, so a
+// declaration here carries only what the handler tier adds — the wire
+// shape, the keep-versus-clear secret slots, which save refusal is the
+// admin's 400, and the side effect a saved row triggers (hot-reload,
+// runtime publish, cache invalidation).
+//
+// Six surfaces are declared: email, reading guide, audiobook, forward
+// auth, converter, and OIDC (whose save is the transactional
+// service.OIDCSettingsService.Apply rather than a store write — the
+// pipeline around it is the same). The metadata surface stays outside
+// deliberately: it is a bare GetBool/SetBool, not a typed row, and has
+// none of the pipeline this collapses.
+type settingsDomain[Cfg, DTO any] struct {
+	// name tags log lines and server errors: "email settings save".
+	name string
+	// ready extends the nil-store 503 with a domain's extra dependency
+	// (OIDC needs the settings service). Optional.
+	ready func(*Handler) bool
+	// get loads the current config; put also uses it for the reload that
+	// builds the response, so a PUT answers what the row now holds.
+	get func(context.Context, *Handler) (Cfg, error)
+	// save persists the merged config. Usually the store's setter; OIDC
+	// applies through its service so five rows land in one transaction.
+	save func(context.Context, *Handler, Cfg) error
+	// toDTO builds the wire shape. Secrets never travel — a "set" flag
+	// does. The context is there for the one surface that derives a
+	// request-dependent field (OIDC's redirect URI).
+	toDTO func(*Handler, *gin.Context, Cfg) DTO
+	// merge lays the submission over the current config, non-secret
+	// fields only — secret slots are declared below and resolved by the
+	// adapter.
+	merge func(dto DTO, current Cfg) Cfg
+	// secrets enumerates the tri-state credential slots: what the wire
+	// carried, its "set" flag, what is stored, and where the resolved
+	// plaintext lands in the merged config. The adapter runs
+	// resolveSecret over them — the only place it runs — so a domain
+	// cannot restate the keep-versus-clear rule, only declare where it
+	// applies. Optional.
+	secrets func(dto *DTO, next, current *Cfg) []settingsSecret
+	// badRequest says which save refusal is the admin's mistake (400,
+	// message intact). Everything else is ours (500, message withheld).
+	// Optional; nil means every save failure is a 500.
+	badRequest func(error) bool
+	// afterSave runs the domain's post-persist side effect with the
+	// reloaded config. Returning false means it wrote the response
+	// (the row is saved either way — these hooks report, not roll back).
+	// Optional.
+	afterSave func(*Handler, *gin.Context, Cfg) bool
+	// noBody makes PUT answer 204 instead of the reloaded DTO.
+	noBody bool
+}
+
+// settingsSecret is one declared credential slot for the adapter's
+// resolveSecret loop.
+type settingsSecret struct {
+	incoming string  // what the wire carried
+	set      bool    // the DTO's "set" flag: blank+set keeps, blank+unset clears
+	stored   string  // the current row's plaintext
+	slot     *string // where the resolved value lands in the merged config
+}
+
+// anySaveRefusalIsA400 is the badRequest policy of the domains whose
+// store setter fails only on validation: the row's message is the
+// admin's to see. It knowingly sweeps up cipher and database failures —
+// the behavior these surfaces always had, kept rather than silently
+// reclassified.
+func anySaveRefusalIsA400(error) bool { return true }
+
+// settingsReady centralizes the 503 degrade every surface advertises
+// when the settings repo (or a domain's extra dependency) is not wired.
+func settingsReady[Cfg, DTO any](c *gin.Context, h *Handler, d settingsDomain[Cfg, DTO]) bool {
+	if h.appSettings == nil || (d.ready != nil && !d.ready(h)) {
+		writeError(c, http.StatusServiceUnavailable, "settings repo unavailable")
+		return false
+	}
+	return true
+}
+
+// settingsGet answers a domain's GET: load, project, 200.
+func settingsGet[Cfg, DTO any](c *gin.Context, h *Handler, d settingsDomain[Cfg, DTO]) {
+	if !settingsReady(c, h, d) {
+		return
+	}
+	cfg, err := d.get(c.Request.Context(), h)
+	if err != nil {
+		writeServerError(c, d.name+" get", err)
+		return
+	}
+	c.JSON(http.StatusOK, d.toDTO(h, c, cfg))
+}
+
+// settingsPut answers a domain's PUT: bind, load the current row, merge,
+// resolve declared secrets, save, reload, run the side effect, respond.
+func settingsPut[Cfg, DTO any](c *gin.Context, h *Handler, d settingsDomain[Cfg, DTO]) {
+	if !settingsReady(c, h, d) {
+		return
+	}
+	var body DTO
+	if !bindJSON(c, &body) {
+		return
+	}
+	ctx := c.Request.Context()
+
+	// Load first so a secret the admin did not retype can be kept.
+	// Submitting the form without retyping every credential has to be
+	// safe, or admins learn to paste keys into fields they can no longer
+	// read back.
+	current, err := d.get(ctx, h)
+	if err != nil {
+		writeServerError(c, d.name+" load", err)
+		return
+	}
+	next := d.merge(body, current)
+	if d.secrets != nil {
+		for _, s := range d.secrets(&body, &next, &current) {
+			*s.slot = resolveSecret(s.incoming, s.set, s.stored)
+		}
+	}
+
+	if err := d.save(ctx, h, next); err != nil {
+		if d.badRequest != nil && d.badRequest(err) {
+			writeError(c, http.StatusBadRequest, err.Error())
+			return
+		}
+		writeServerError(c, d.name+" save", err)
+		return
+	}
+
+	// Re-read so the response (and the side effect) sees what the row
+	// made of the submission — trimmed, defaults applied — rather than
+	// the submission itself.
+	saved, err := d.get(ctx, h)
+	if err != nil {
+		writeServerError(c, d.name+" reload", err)
+		return
+	}
+	if d.afterSave != nil && !d.afterSave(h, c, saved) {
+		return
+	}
+	if d.noBody {
+		c.Status(http.StatusNoContent)
+		return
+	}
+	c.JSON(http.StatusOK, d.toDTO(h, c, saved))
+}

--- a/internal/handler/settings_domain_test.go
+++ b/internal/handler/settings_domain_test.go
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// The adapter pipeline is pinned against a toy domain rather than any of
+// the six real ones, so each rule — the guards, the secret loop, the
+// error split, the response modes — is provable without dragging a
+// surface's own shape into the assertion. The real declarations are
+// covered by the per-surface tests that already existed.
+
+type toyConfig struct {
+	Name  string
+	Token string
+}
+
+type toyDTO struct {
+	Name     string `json:"name"`
+	Token    string `json:"token,omitempty"`
+	TokenSet bool   `json:"tokenSet"`
+}
+
+// toyState is the toy domain's "store": what get hands back, what save
+// receives, and the failures either is told to produce.
+type toyState struct {
+	stored   toyConfig
+	getErr   error
+	saveErr  error
+	saved    []toyConfig
+	reloaded bool
+}
+
+func toyDomain(st *toyState) settingsDomain[toyConfig, toyDTO] {
+	return settingsDomain[toyConfig, toyDTO]{
+		name: "toy settings",
+		get: func(context.Context, *Handler) (toyConfig, error) {
+			if st.getErr != nil {
+				return toyConfig{}, st.getErr
+			}
+			if len(st.saved) > 0 {
+				st.reloaded = true
+			}
+			return st.stored, nil
+		},
+		save: func(_ context.Context, _ *Handler, cfg toyConfig) error {
+			if st.saveErr != nil {
+				return st.saveErr
+			}
+			st.saved = append(st.saved, cfg)
+			st.stored = cfg
+			return nil
+		},
+		toDTO: func(_ *Handler, _ *gin.Context, cfg toyConfig) toyDTO {
+			return toyDTO{Name: cfg.Name, TokenSet: cfg.Token != ""}
+		},
+		merge: func(dto toyDTO, current toyConfig) toyConfig {
+			next := current
+			next.Name = dto.Name
+			return next
+		},
+		secrets: func(dto *toyDTO, next, current *toyConfig) []settingsSecret {
+			return []settingsSecret{{
+				incoming: dto.Token,
+				set:      dto.TokenSet,
+				stored:   current.Token,
+				slot:     &next.Token,
+			}}
+		},
+		badRequest: func(err error) bool { return errors.Is(err, errToyInvalid) },
+	}
+}
+
+var errToyInvalid = errors.New("toy: name required")
+
+func toyHandler() *Handler {
+	return &Handler{appSettings: &fakeAppSettings{}}
+}
+
+func TestSettingsDomainGuardsANilStore(t *testing.T) {
+	st := &toyState{}
+	h := &Handler{appSettings: newAppSettingsStore(nil)}
+
+	c, rec := settingsCtx(t, http.MethodGet, "/toy", "")
+	settingsGet(c, h, toyDomain(st))
+	if httpStatus(c, rec) != http.StatusServiceUnavailable {
+		t.Fatalf("get status = %d, want 503", rec.Code)
+	}
+
+	c, rec = settingsCtx(t, http.MethodPut, "/toy", `{}`)
+	settingsPut(c, h, toyDomain(st))
+	if httpStatus(c, rec) != http.StatusServiceUnavailable {
+		t.Fatalf("put status = %d, want 503", rec.Code)
+	}
+	if len(st.saved) != 0 {
+		t.Fatal("a save happened behind the 503")
+	}
+}
+
+func TestSettingsDomainReadyGuardExtendsThe503(t *testing.T) {
+	st := &toyState{}
+	d := toyDomain(st)
+	d.ready = func(*Handler) bool { return false }
+	h := toyHandler()
+
+	c, rec := settingsCtx(t, http.MethodGet, "/toy", "")
+	settingsGet(c, h, d)
+	if httpStatus(c, rec) != http.StatusServiceUnavailable {
+		t.Fatalf("get status = %d, want 503", rec.Code)
+	}
+
+	c, rec = settingsCtx(t, http.MethodPut, "/toy", `{}`)
+	settingsPut(c, h, d)
+	if httpStatus(c, rec) != http.StatusServiceUnavailable {
+		t.Fatalf("put status = %d, want 503", rec.Code)
+	}
+}
+
+func TestSettingsDomainGetHappyPath(t *testing.T) {
+	st := &toyState{stored: toyConfig{Name: "kokoro", Token: "sk-1"}}
+	c, rec := settingsCtx(t, http.MethodGet, "/toy", "")
+	settingsGet(c, toyHandler(), toyDomain(st))
+	if httpStatus(c, rec) != http.StatusOK {
+		t.Fatalf("status = %d (body %s)", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `"name":"kokoro"`) || !strings.Contains(body, `"tokenSet":true`) {
+		t.Errorf("body = %s", body)
+	}
+	if strings.Contains(body, "sk-1") {
+		t.Errorf("a stored secret leaked into the GET body: %s", body)
+	}
+}
+
+func TestSettingsDomainGetLoadFailureIsA500(t *testing.T) {
+	st := &toyState{getErr: errBoom}
+	c, rec := settingsCtx(t, http.MethodGet, "/toy", "")
+	settingsGet(c, toyHandler(), toyDomain(st))
+	if httpStatus(c, rec) != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+}
+
+func TestSettingsDomainPutRejectsBadJSON(t *testing.T) {
+	st := &toyState{}
+	c, rec := settingsCtx(t, http.MethodPut, "/toy", `{"name":`)
+	settingsPut(c, toyHandler(), toyDomain(st))
+	if httpStatus(c, rec) != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if len(st.saved) != 0 {
+		t.Fatal("a save happened despite the bind failure")
+	}
+}
+
+func TestSettingsDomainPutLoadFailureIsA500(t *testing.T) {
+	st := &toyState{getErr: errBoom}
+	c, rec := settingsCtx(t, http.MethodPut, "/toy", `{"name":"x"}`)
+	settingsPut(c, toyHandler(), toyDomain(st))
+	if httpStatus(c, rec) != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+}
+
+// TestSettingsDomainSecretLoop pins the one place resolveSecret now runs:
+// the adapter's loop over the domain's declared slots.
+func TestSettingsDomainSecretLoop(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"typed value replaces", `{"name":"n","token":"fresh","tokenSet":true}`, "fresh"},
+		{"blank plus set keeps the stored secret", `{"name":"n","token":"","tokenSet":true}`, "old"},
+		{"blank plus unset clears it", `{"name":"n","token":"","tokenSet":false}`, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			st := &toyState{stored: toyConfig{Name: "was", Token: "old"}}
+			c, rec := settingsCtx(t, http.MethodPut, "/toy", tc.body)
+			settingsPut(c, toyHandler(), toyDomain(st))
+			if httpStatus(c, rec) != http.StatusOK {
+				t.Fatalf("status = %d (body %s)", rec.Code, rec.Body.String())
+			}
+			if len(st.saved) != 1 {
+				t.Fatalf("saves = %d, want 1", len(st.saved))
+			}
+			if got := st.saved[0].Token; got != tc.want {
+				t.Errorf("saved token = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSettingsDomainSaveErrorSplit(t *testing.T) {
+	t.Run("a declared refusal is the admin's 400, message intact", func(t *testing.T) {
+		st := &toyState{saveErr: errToyInvalid}
+		c, rec := settingsCtx(t, http.MethodPut, "/toy", `{"name":""}`)
+		settingsPut(c, toyHandler(), toyDomain(st))
+		if httpStatus(c, rec) != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), errToyInvalid.Error()) {
+			t.Errorf("the refusal's own message was lost: %s", rec.Body.String())
+		}
+	})
+	t.Run("anything else is our 500, message withheld", func(t *testing.T) {
+		st := &toyState{saveErr: errBoom}
+		c, rec := settingsCtx(t, http.MethodPut, "/toy", `{"name":"x"}`)
+		settingsPut(c, toyHandler(), toyDomain(st))
+		if httpStatus(c, rec) != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500", rec.Code)
+		}
+		if strings.Contains(rec.Body.String(), "boom") {
+			t.Errorf("an internal error leaked: %s", rec.Body.String())
+		}
+	})
+}
+
+// TestSettingsDomainRespondsWithTheReloadedRow proves the PUT answer is
+// what the store now holds — normalized by the row — not the submission.
+func TestSettingsDomainRespondsWithTheReloadedRow(t *testing.T) {
+	st := &toyState{stored: toyConfig{Token: "old"}}
+	c, rec := settingsCtx(t, http.MethodPut, "/toy", `{"name":"next","token":"","tokenSet":true}`)
+	settingsPut(c, toyHandler(), toyDomain(st))
+	if httpStatus(c, rec) != http.StatusOK {
+		t.Fatalf("status = %d (body %s)", rec.Code, rec.Body.String())
+	}
+	if !st.reloaded {
+		t.Fatal("the response was built without re-reading the row")
+	}
+	if body := rec.Body.String(); !strings.Contains(body, `"name":"next"`) || !strings.Contains(body, `"tokenSet":true`) {
+		t.Errorf("body = %s", body)
+	}
+}
+
+func TestSettingsDomainNoBodyAnswers204(t *testing.T) {
+	st := &toyState{}
+	d := toyDomain(st)
+	d.noBody = true
+	c, rec := settingsCtx(t, http.MethodPut, "/toy", `{"name":"x"}`)
+	settingsPut(c, toyHandler(), d)
+	if httpStatus(c, rec) != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("204 carried a body: %s", rec.Body.String())
+	}
+}
+
+func TestSettingsDomainAfterSaveHook(t *testing.T) {
+	t.Run("runs with the reloaded config and can stop the response", func(t *testing.T) {
+		st := &toyState{}
+		d := toyDomain(st)
+		var hookCfg toyConfig
+		d.afterSave = func(_ *Handler, c *gin.Context, cfg toyConfig) bool {
+			hookCfg = cfg
+			writeErrorCode(c, http.StatusBadGateway, "TOY_RELOAD", "downstream said no")
+			return false
+		}
+		c, rec := settingsCtx(t, http.MethodPut, "/toy", `{"name":"hooked"}`)
+		settingsPut(c, toyHandler(), d)
+		if httpStatus(c, rec) != http.StatusBadGateway {
+			t.Fatalf("status = %d, want the hook's 502", rec.Code)
+		}
+		if hookCfg.Name != "hooked" {
+			t.Errorf("hook saw %+v, want the saved config", hookCfg)
+		}
+		if len(st.saved) != 1 {
+			t.Fatal("the row should already be persisted when the hook fails")
+		}
+	})
+	t.Run("a passing hook leaves the normal response", func(t *testing.T) {
+		st := &toyState{}
+		d := toyDomain(st)
+		d.afterSave = func(*Handler, *gin.Context, toyConfig) bool { return true }
+		c, rec := settingsCtx(t, http.MethodPut, "/toy", `{"name":"x"}`)
+		settingsPut(c, toyHandler(), d)
+		if httpStatus(c, rec) != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+	})
+}

--- a/internal/handler/settings_email.go
+++ b/internal/handler/settings_email.go
@@ -60,76 +60,71 @@ func toEmailSettingsDTO(cfg repo.EmailConfig) emailSettingsDTO {
 	}
 }
 
-// SettingsEmailGet returns the current EMAIL config with the
-// password elided. Admin-only — ADR-0010 keeps the password
-// AES-GCM-encrypted at rest, but reading "yes a password is set" is
-// useful for the UI even on instances without a KEK.
-func (h *Handler) SettingsEmailGet(c *gin.Context) {
-	cfg, err := h.appSettings.GetEmail(c.Request.Context())
-	if err != nil {
-		writeServerError(c, "email settings get", err)
-		return
-	}
-	c.JSON(http.StatusOK, toEmailSettingsDTO(cfg))
-}
-
-// SettingsEmailUpdate persists the EMAIL row. Trimming and validation
+// emailSettings declares the EMAIL surface. Trimming and validation
 // belong to the row, so a CLI or an importer is held to the same rules
-// as this endpoint. An empty password in the request means "keep the
-// existing one" so admins can edit other fields without retyping the
-// secret.
-func (h *Handler) SettingsEmailUpdate(c *gin.Context) {
-	var body emailSettingsDTO
-	if !bindJSON(c, &body) {
-		return
-	}
-
-	current, err := h.appSettings.GetEmail(c.Request.Context())
-	if err != nil {
-		writeServerError(c, "email settings load", err)
-		return
-	}
-	cfg := repo.EmailConfig{
-		Enabled: body.Enabled,
-		SMTP: repo.EmailSMTPConfig{
-			Host:     body.SMTP.Host,
-			Port:     body.SMTP.Port,
-			Username: body.SMTP.Username,
-			TLS:      body.SMTP.TLS,
-			Password: body.SMTP.Password,
-		},
-		From: repo.EmailFromConfig{
-			Address: body.From.Address,
-			Name:    body.From.Name,
-		},
-		PublicURL: body.PublicURL,
-	}
-	cfg.SMTP.Password = resolveSecret(body.SMTP.Password, body.PasswordSet, current.SMTP.Password)
-	if err := h.appSettings.SetEmail(c.Request.Context(), cfg); err != nil {
-		// The row trims and validates; a refusal is the admin's mistake
-		// to see, and it carries its own message. Anything else — a
-		// cipher or a database failure — is ours.
-		if errors.Is(err, repo.ErrEmailInvalid) {
-			writeError(c, http.StatusBadRequest, err.Error())
-			return
+// as these endpoints; the password is elided from every GET (ADR-0010)
+// and rides the tri-state secret slot on PUT. The 204 is historical —
+// the panel re-fetches rather than reading the PUT body.
+var emailSettings = settingsDomain[repo.EmailConfig, emailSettingsDTO]{
+	name: "email settings",
+	get: func(ctx context.Context, h *Handler) (repo.EmailConfig, error) {
+		return h.appSettings.GetEmail(ctx)
+	},
+	save: func(ctx context.Context, h *Handler, cfg repo.EmailConfig) error {
+		return h.appSettings.SetEmail(ctx, cfg)
+	},
+	toDTO: func(_ *Handler, _ *gin.Context, cfg repo.EmailConfig) emailSettingsDTO {
+		return toEmailSettingsDTO(cfg)
+	},
+	merge: func(dto emailSettingsDTO, _ repo.EmailConfig) repo.EmailConfig {
+		return repo.EmailConfig{
+			Enabled: dto.Enabled,
+			SMTP: repo.EmailSMTPConfig{
+				Host:     dto.SMTP.Host,
+				Port:     dto.SMTP.Port,
+				Username: dto.SMTP.Username,
+				TLS:      dto.SMTP.TLS,
+			},
+			From: repo.EmailFromConfig{
+				Address: dto.From.Address,
+				Name:    dto.From.Name,
+			},
+			PublicURL: dto.PublicURL,
 		}
-		writeServerError(c, "email settings save", err)
-		return
-	}
+	},
+	secrets: func(dto *emailSettingsDTO, next, current *repo.EmailConfig) []settingsSecret {
+		return []settingsSecret{{
+			incoming: dto.SMTP.Password,
+			set:      dto.PasswordSet,
+			stored:   current.SMTP.Password,
+			slot:     &next.SMTP.Password,
+		}}
+	},
+	// A row refusal is the admin's mistake to see, and it carries its
+	// own message. Anything else — a cipher or a database failure — is
+	// ours.
+	badRequest: func(err error) bool { return errors.Is(err, repo.ErrEmailInvalid) },
 	// Hot-reload so the new SMTP config takes effect without restart.
 	// Reload errors don't fail the save — the row is already persisted
 	// and Notifier holds a disabled state until the admin fixes the
 	// config — but they're returned so the UI can surface the SMTP
 	// construction error inline.
-	if h.notifier != nil {
+	afterSave: func(h *Handler, c *gin.Context, _ repo.EmailConfig) bool {
+		if h.notifier == nil {
+			return true
+		}
 		if err := h.notifier.Reload(c.Request.Context()); err != nil {
 			slog.Warn("email settings reload", "err", err)
 			writeErrorCode(c, http.StatusBadGateway, CodeEmailReloadFailed, err.Error())
-			return
+			return false
 		}
-	}
-	c.Status(http.StatusNoContent)
+		return true
+	},
+	noBody: true,
 }
+
+func (h *Handler) SettingsEmailGet(c *gin.Context)    { settingsGet(c, h, emailSettings) }
+func (h *Handler) SettingsEmailUpdate(c *gin.Context) { settingsPut(c, h, emailSettings) }
 
 type emailTestReq struct {
 	To string `json:"to"`

--- a/internal/handler/settings_forward_auth.go
+++ b/internal/handler/settings_forward_auth.go
@@ -3,8 +3,7 @@
 package handler
 
 import (
-	"errors"
-	"net/http"
+	"context"
 
 	"github.com/gin-gonic/gin"
 
@@ -24,80 +23,62 @@ type forwardAuthSettingsDTO struct {
 	HideLocalLogin    bool                    `json:"hideLocalLogin"`
 }
 
-// SettingsForwardAuthGet returns the persisted FORWARD_AUTH row.
-func (h *Handler) SettingsForwardAuthGet(c *gin.Context) {
-	if h.appSettings == nil {
-		writeError(c, http.StatusServiceUnavailable, "settings repo unavailable")
-		return
-	}
-	cfg, err := h.appSettings.GetForwardAuth(c.Request.Context())
-	if err != nil {
-		writeServerError(c, "forward_auth settings get", err)
-		return
-	}
-	c.JSON(http.StatusOK, forwardAuthSettingsDTO{
-		Enabled:           cfg.Enabled,
-		TrustedProxyCIDRs: cfg.TrustedProxyCIDRs,
-		Headers:           cfg.Headers,
-		LogoutURL:         cfg.LogoutURL,
-		HideLocalLogin:    cfg.HideLocalLogin,
-	})
-}
-
-// SettingsForwardAuthUpdate validates + persists the row, then hot-
-// swaps the runtime middleware config. Validation surfaces specific
-// 400s for the two failure modes admins are most likely to hit:
-// enabling without a CIDR, or pasting a malformed CIDR.
-func (h *Handler) SettingsForwardAuthUpdate(c *gin.Context) {
-	if h.appSettings == nil {
-		writeError(c, http.StatusServiceUnavailable, "settings repo unavailable")
-		return
-	}
-	var body forwardAuthSettingsDTO
-	if !bindJSON(c, &body) {
-		return
-	}
-	cfg := repo.ForwardAuthConfig{
-		Enabled:           body.Enabled,
-		TrustedProxyCIDRs: body.TrustedProxyCIDRs,
-		Headers:           body.Headers,
-		LogoutURL:         body.LogoutURL,
-		HideLocalLogin:    body.HideLocalLogin,
-	}
-	if err := h.appSettings.SetForwardAuth(c.Request.Context(), cfg); err != nil {
-		switch {
-		case errors.Is(err, repo.ErrForwardAuthEnabledWithoutCIDR):
-			writeError(c, http.StatusBadRequest, err.Error())
-		case errors.Is(err, repo.ErrForwardAuthInvalidCIDR),
-			errors.Is(err, repo.ErrForwardAuthInvalidHeader),
-			errors.Is(err, repo.ErrForwardAuthInvalidLogoutURL):
-			writeError(c, http.StatusBadRequest, err.Error())
-		default:
-			writeServerError(c, "forward_auth settings update", err)
+// forwardAuthSettings declares the FORWARD_AUTH surface. Validation
+// surfaces specific 400s for the failure modes admins are most likely
+// to hit: enabling without a CIDR, or pasting a malformed CIDR. After a
+// save the runtime middleware config is hot-swapped from the re-read
+// (normalized) row.
+var forwardAuthSettings = settingsDomain[repo.ForwardAuthConfig, forwardAuthSettingsDTO]{
+	name: "forward_auth settings",
+	get: func(ctx context.Context, h *Handler) (repo.ForwardAuthConfig, error) {
+		return h.appSettings.GetForwardAuth(ctx)
+	},
+	save: func(ctx context.Context, h *Handler, cfg repo.ForwardAuthConfig) error {
+		return h.appSettings.SetForwardAuth(ctx, cfg)
+	},
+	toDTO: func(_ *Handler, _ *gin.Context, cfg repo.ForwardAuthConfig) forwardAuthSettingsDTO {
+		return forwardAuthSettingsDTO{
+			Enabled:           cfg.Enabled,
+			TrustedProxyCIDRs: cfg.TrustedProxyCIDRs,
+			Headers:           cfg.Headers,
+			LogoutURL:         cfg.LogoutURL,
+			HideLocalLogin:    cfg.HideLocalLogin,
 		}
-		return
-	}
-
-	// Re-read to get the normalised values (trimmed, defaults
-	// applied) before publishing to the runtime holder.
-	saved, err := h.appSettings.GetForwardAuth(c.Request.Context())
-	if err != nil {
-		writeServerError(c, "forward_auth settings reload", err)
-		return
-	}
-	if h.fwdAuthHolder != nil {
-		runtime, rerr := service.NewForwardAuthRuntime(saved)
-		if rerr != nil {
-			writeServerError(c, "forward_auth runtime rebuild", rerr)
-			return
+	},
+	merge: func(dto forwardAuthSettingsDTO, _ repo.ForwardAuthConfig) repo.ForwardAuthConfig {
+		return repo.ForwardAuthConfig{
+			Enabled:           dto.Enabled,
+			TrustedProxyCIDRs: dto.TrustedProxyCIDRs,
+			Headers:           dto.Headers,
+			LogoutURL:         dto.LogoutURL,
+			HideLocalLogin:    dto.HideLocalLogin,
+		}
+	},
+	badRequest: func(err error) bool {
+		return errIsOneOf(err,
+			repo.ErrForwardAuthEnabledWithoutCIDR,
+			repo.ErrForwardAuthInvalidCIDR,
+			repo.ErrForwardAuthInvalidHeader,
+			repo.ErrForwardAuthInvalidLogoutURL)
+	},
+	afterSave: func(h *Handler, c *gin.Context, saved repo.ForwardAuthConfig) bool {
+		if h.fwdAuthHolder == nil {
+			return true
+		}
+		runtime, err := service.NewForwardAuthRuntime(saved)
+		if err != nil {
+			writeServerError(c, "forward_auth runtime rebuild", err)
+			return false
 		}
 		h.fwdAuthHolder.Set(runtime)
-	}
-	c.JSON(http.StatusOK, forwardAuthSettingsDTO{
-		Enabled:           saved.Enabled,
-		TrustedProxyCIDRs: saved.TrustedProxyCIDRs,
-		Headers:           saved.Headers,
-		LogoutURL:         saved.LogoutURL,
-		HideLocalLogin:    saved.HideLocalLogin,
-	})
+		return true
+	},
+}
+
+func (h *Handler) SettingsForwardAuthGet(c *gin.Context) {
+	settingsGet(c, h, forwardAuthSettings)
+}
+
+func (h *Handler) SettingsForwardAuthUpdate(c *gin.Context) {
+	settingsPut(c, h, forwardAuthSettings)
 }

--- a/internal/handler/settings_oidc.go
+++ b/internal/handler/settings_oidc.go
@@ -4,6 +4,8 @@ package handler
 
 import (
 	"context"
+	"errors"
+	"io"
 	"net/http"
 	"strings"
 
@@ -174,80 +176,26 @@ func (h *Handler) SettingsOIDCGet(c *gin.Context) { settingsGet(c, h, oidcSettin
 // row plus the shared flags.
 func (h *Handler) SettingsOIDCUpdate(c *gin.Context) { settingsPut(c, h, oidcSettings) }
 
-// SettingsOIDCTest runs TestConnection for one provider at a time. The
-// slug is supplied in the URL; the body carries an optional override
-// config (useful when testing before saving).
+// SettingsOIDCTest runs the connection diagnostic for one provider at a
+// time. The slug is supplied in the URL; the body carries an optional
+// override config (useful when testing before saving). The service owns
+// the provider registry, the override shapes, and the blank-submission
+// fallback, so this endpoint is a lookup plus one call (#258).
 func (h *Handler) SettingsOIDCTest(c *gin.Context) {
 	if h.oidc == nil {
 		writeError(c, http.StatusServiceUnavailable, "oidc service unavailable")
 		return
 	}
 	slug := c.Param("slug")
-	ctx := c.Request.Context()
-
-	switch slug {
-	case repo.ProviderSlugGoogle:
-		var body struct {
-			Google oauthPresetDTO `json:"google"`
-		}
-		_ = c.ShouldBindJSON(&body)
-		cfg := repo.OAuthPresetConfig{
-			ClientID:     body.Google.ClientID,
-			ClientSecret: body.Google.ClientSecret,
-		}
-		if cfg.ClientID == "" {
-			stored, err := h.appSettings.GetGoogle(ctx)
-			if err != nil {
-				writeServerError(c, "oidc test google", err)
-				return
-			}
-			cfg = stored
-		}
-		c.JSON(http.StatusOK, h.oidc.TestGoogle(ctx, cfg))
-
-	case repo.ProviderSlugGitHub:
-		var body struct {
-			GitHub oauthPresetDTO `json:"github"`
-		}
-		_ = c.ShouldBindJSON(&body)
-		cfg := repo.OAuthPresetConfig{
-			ClientID:     body.GitHub.ClientID,
-			ClientSecret: body.GitHub.ClientSecret,
-		}
-		if cfg.ClientID == "" {
-			stored, err := h.appSettings.GetGitHub(ctx)
-			if err != nil {
-				writeServerError(c, "oidc test github", err)
-				return
-			}
-			cfg = stored
-		}
-		c.JSON(http.StatusOK, h.oidc.TestGitHub(ctx, cfg))
-
-	case repo.ProviderSlugGeneric:
-		var body struct {
-			Generic genericOIDCDTO `json:"generic"`
-		}
-		_ = c.ShouldBindJSON(&body)
-		cfg := repo.GenericOIDCConfig{
-			ClientID:     body.Generic.ClientID,
-			ClientSecret: body.Generic.ClientSecret,
-			IssuerURI:    body.Generic.IssuerURI,
-			Scopes:       body.Generic.Scopes,
-			ClaimMapping: body.Generic.ClaimMapping,
-		}
-		if cfg.ClientID == "" || cfg.IssuerURI == "" {
-			stored, err := h.appSettings.GetGenericOIDC(ctx)
-			if err != nil {
-				writeServerError(c, "oidc test generic", err)
-				return
-			}
-			cfg = stored
-		}
-		c.JSON(http.StatusOK, h.oidc.TestGeneric(ctx, cfg))
-
-	default:
+	body, _ := io.ReadAll(c.Request.Body)
+	res, err := h.oidc.TestProvider(c.Request.Context(), slug, body)
+	switch {
+	case errors.Is(err, service.ErrOIDCUnknownProvider):
 		writeError(c, http.StatusNotFound, "unknown provider")
+	case err != nil:
+		writeServerError(c, "oidc test "+slug, err)
+	default:
+		c.JSON(http.StatusOK, res)
 	}
 }
 

--- a/internal/handler/settings_oidc.go
+++ b/internal/handler/settings_oidc.go
@@ -4,7 +4,6 @@ package handler
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"strings"
 
@@ -43,139 +42,137 @@ type genericOIDCDTO struct {
 	ClaimMapping    repo.ClaimMapping `json:"claimMapping"`
 }
 
-// SettingsOIDCGet returns everything the OIDC settings page needs.
-func (h *Handler) SettingsOIDCGet(c *gin.Context) {
-	if h.appSettings == nil {
-		writeError(c, http.StatusServiceUnavailable, "settings repo unavailable")
-		return
-	}
-	ctx := c.Request.Context()
-
-	force, err := h.appSettings.GetBool(ctx, repo.SettingOIDCForceOnlyMode)
-	if err != nil {
-		writeServerError(c, "oidc settings force", err)
-		return
-	}
-	auto, err := h.appSettings.GetOIDCAutoProvision(ctx)
-	if err != nil {
-		writeServerError(c, "oidc settings auto", err)
-		return
-	}
-	google, err := h.appSettings.GetGoogle(ctx)
-	if err != nil {
-		writeServerError(c, "oidc google", err)
-		return
-	}
-	github, err := h.appSettings.GetGitHub(ctx)
-	if err != nil {
-		writeServerError(c, "oidc github", err)
-		return
-	}
-	generic, err := h.appSettings.GetGenericOIDC(ctx)
-	if err != nil {
-		writeServerError(c, "oidc generic", err)
-		return
-	}
-
-	c.JSON(http.StatusOK, oidcSettingsDTO{
-		ForceOnly:     force,
-		AutoProvision: auto,
-		Google:        presetToDTO(google),
-		GitHub:        presetToDTO(github),
-		Generic:       genericToDTO(generic),
-		RedirectURI:   h.buildRedirectURI(c),
-	})
+// oidcSettingsRows is the OIDC surface's aggregate config: the five
+// rows one panel edits and one service call applies. It exists so the
+// surface fits the settingsDomain pipeline — get reads the rows, save
+// hands them to service.OIDCSettingsService.Apply as one transactional
+// decision (#195), and the tri-state client secrets ride the same
+// declared slots as every other panel's credentials (ADR-0010).
+type oidcSettingsRows struct {
+	ForceOnly bool
+	Auto      repo.OIDCAutoProvisionDetails
+	Google    repo.OAuthPresetConfig
+	GitHub    repo.OAuthPresetConfig
+	Generic   repo.GenericOIDCConfig
 }
+
+// oidcSettings declares the OIDC surface. The one shape the panel
+// round-trips covers three providers, so the declaration carries three
+// secret slots; ClientSecret is preserved when absent — an admin
+// editing the client ID shouldn't have to re-enter the secret.
+var oidcSettings = settingsDomain[oidcSettingsRows, oidcSettingsDTO]{
+	name: "oidc settings",
+	// Writes go through the settings service, so the whole surface —
+	// including its GET, which production never wires without the
+	// service — degrades together.
+	ready: func(h *Handler) bool { return h.oidcSettings != nil },
+	get: func(ctx context.Context, h *Handler) (oidcSettingsRows, error) {
+		var (
+			rows oidcSettingsRows
+			err  error
+		)
+		if rows.ForceOnly, err = h.appSettings.GetBool(ctx, repo.SettingOIDCForceOnlyMode); err != nil {
+			return rows, err
+		}
+		if rows.Auto, err = h.appSettings.GetOIDCAutoProvision(ctx); err != nil {
+			return rows, err
+		}
+		if rows.Google, err = h.appSettings.GetGoogle(ctx); err != nil {
+			return rows, err
+		}
+		if rows.GitHub, err = h.appSettings.GetGitHub(ctx); err != nil {
+			return rows, err
+		}
+		rows.Generic, err = h.appSettings.GetGenericOIDC(ctx)
+		return rows, err
+	},
+	save: func(ctx context.Context, h *Handler, rows oidcSettingsRows) error {
+		// What the service receives is already-resolved plaintext
+		// (ADR-0010); the adapter's secret loop ran before this.
+		if err := h.oidcSettings.Apply(ctx, service.OIDCSubmission{
+			Google:        rows.Google,
+			GitHub:        rows.GitHub,
+			Generic:       rows.Generic,
+			AutoProvision: rows.Auto,
+			ForceOnly:     rows.ForceOnly,
+		}); err != nil {
+			return err
+		}
+		// Invalidation belongs to the save, not the response: once the
+		// rows changed, the cached provider clients are stale even if
+		// the reload that builds the response fails.
+		if h.oidc != nil {
+			h.oidc.Invalidate()
+		}
+		return nil
+	},
+	toDTO: func(h *Handler, c *gin.Context, rows oidcSettingsRows) oidcSettingsDTO {
+		return oidcSettingsDTO{
+			ForceOnly:     rows.ForceOnly,
+			AutoProvision: rows.Auto,
+			Google:        presetToDTO(rows.Google),
+			GitHub:        presetToDTO(rows.GitHub),
+			Generic:       genericToDTO(rows.Generic),
+			RedirectURI:   h.buildRedirectURI(c),
+		}
+	},
+	merge: func(dto oidcSettingsDTO, _ oidcSettingsRows) oidcSettingsRows {
+		return oidcSettingsRows{
+			ForceOnly: dto.ForceOnly,
+			Auto:      dto.AutoProvision,
+			Google: repo.OAuthPresetConfig{
+				Enabled:  dto.Google.Enabled,
+				ClientID: strings.TrimSpace(dto.Google.ClientID),
+			},
+			GitHub: repo.OAuthPresetConfig{
+				Enabled:  dto.GitHub.Enabled,
+				ClientID: strings.TrimSpace(dto.GitHub.ClientID),
+			},
+			Generic: repo.GenericOIDCConfig{
+				Enabled:      dto.Generic.Enabled,
+				ProviderName: strings.TrimSpace(dto.Generic.ProviderName),
+				ClientID:     strings.TrimSpace(dto.Generic.ClientID),
+				IssuerURI:    strings.TrimSpace(dto.Generic.IssuerURI),
+				Scopes:       strings.TrimSpace(dto.Generic.Scopes),
+				// Defaults are the Setting declaration's, so a row written by
+				// anything other than this endpoint gets them too (#195).
+				ClaimMapping: dto.Generic.ClaimMapping,
+			},
+		}
+	},
+	secrets: func(dto *oidcSettingsDTO, next, current *oidcSettingsRows) []settingsSecret {
+		return []settingsSecret{
+			{
+				incoming: dto.Google.ClientSecret,
+				set:      dto.Google.ClientSecretSet,
+				stored:   current.Google.ClientSecret,
+				slot:     &next.Google.ClientSecret,
+			},
+			{
+				incoming: dto.GitHub.ClientSecret,
+				set:      dto.GitHub.ClientSecretSet,
+				stored:   current.GitHub.ClientSecret,
+				slot:     &next.GitHub.ClientSecret,
+			},
+			{
+				incoming: dto.Generic.ClientSecret,
+				set:      dto.Generic.ClientSecretSet,
+				stored:   current.Generic.ClientSecret,
+				slot:     &next.Generic.ClientSecret,
+			},
+		}
+	},
+	badRequest: func(err error) bool {
+		return errIsOneOf(err, service.ErrOIDCIncomplete, service.ErrOIDCForceOnlyBlocked)
+	},
+}
+
+// SettingsOIDCGet returns everything the OIDC settings page needs.
+func (h *Handler) SettingsOIDCGet(c *gin.Context) { settingsGet(c, h, oidcSettings) }
 
 // SettingsOIDCUpdate accepts the full DTO and saves each provider's
-// row plus the shared flags. ClientSecret is preserved when absent —
-// an admin editing the client ID shouldn't have to re-enter the secret.
-func (h *Handler) SettingsOIDCUpdate(c *gin.Context) {
-	if h.appSettings == nil || h.oidcSettings == nil {
-		writeError(c, http.StatusServiceUnavailable, "settings repo unavailable")
-		return
-	}
-	var body oidcSettingsDTO
-	if !bindJSON(c, &body) {
-		return
-	}
-	ctx := c.Request.Context()
-
-	// The keep-versus-clear contract for secrets stays here, with the
-	// wire shape that expresses it: a blank field with its "set" flag
-	// still true means "keep what is stored". What the service receives
-	// is already-resolved plaintext (ADR-0010).
-	sub, err := h.resolveOIDCSubmission(ctx, body)
-	if err != nil {
-		writeServerError(c, "oidc existing rows", err)
-		return
-	}
-
-	if err := h.oidcSettings.Apply(ctx, sub); err != nil {
-		switch {
-		case errors.Is(err, service.ErrOIDCIncomplete),
-			errors.Is(err, service.ErrOIDCForceOnlyBlocked):
-			writeError(c, http.StatusBadRequest, err.Error())
-		default:
-			writeServerError(c, "oidc settings apply", err)
-		}
-		return
-	}
-
-	if h.oidc != nil {
-		h.oidc.Invalidate()
-	}
-	h.SettingsOIDCGet(c)
-}
-
-// resolveOIDCSubmission turns the wire shape into the submission the
-// service applies, reading the stored rows only to resolve secrets the
-// client asked to keep.
-func (h *Handler) resolveOIDCSubmission(
-	ctx context.Context,
-	body oidcSettingsDTO,
-) (service.OIDCSubmission, error) {
-	var zero service.OIDCSubmission
-
-	existingGoogle, err := h.appSettings.GetGoogle(ctx)
-	if err != nil {
-		return zero, err
-	}
-	existingGitHub, err := h.appSettings.GetGitHub(ctx)
-	if err != nil {
-		return zero, err
-	}
-	existingGeneric, err := h.appSettings.GetGenericOIDC(ctx)
-	if err != nil {
-		return zero, err
-	}
-
-	return service.OIDCSubmission{
-		Google: repo.OAuthPresetConfig{
-			Enabled:      body.Google.Enabled,
-			ClientID:     strings.TrimSpace(body.Google.ClientID),
-			ClientSecret: resolveSecret(body.Google.ClientSecret, body.Google.ClientSecretSet, existingGoogle.ClientSecret),
-		},
-		GitHub: repo.OAuthPresetConfig{
-			Enabled:      body.GitHub.Enabled,
-			ClientID:     strings.TrimSpace(body.GitHub.ClientID),
-			ClientSecret: resolveSecret(body.GitHub.ClientSecret, body.GitHub.ClientSecretSet, existingGitHub.ClientSecret),
-		},
-		Generic: repo.GenericOIDCConfig{
-			Enabled:      body.Generic.Enabled,
-			ProviderName: strings.TrimSpace(body.Generic.ProviderName),
-			ClientID:     strings.TrimSpace(body.Generic.ClientID),
-			ClientSecret: resolveSecret(body.Generic.ClientSecret, body.Generic.ClientSecretSet, existingGeneric.ClientSecret),
-			IssuerURI:    strings.TrimSpace(body.Generic.IssuerURI),
-			Scopes:       strings.TrimSpace(body.Generic.Scopes),
-			// Defaults are the Setting declaration's, so a row written by
-			// anything other than this endpoint gets them too (#195).
-			ClaimMapping: body.Generic.ClaimMapping,
-		},
-		AutoProvision: body.AutoProvision,
-		ForceOnly:     body.ForceOnly,
-	}, nil
-}
+// row plus the shared flags.
+func (h *Handler) SettingsOIDCUpdate(c *gin.Context) { settingsPut(c, h, oidcSettings) }
 
 // SettingsOIDCTest runs TestConnection for one provider at a time. The
 // slug is supplied in the URL; the body carries an optional override

--- a/internal/handler/settings_oidc_test.go
+++ b/internal/handler/settings_oidc_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gin-gonic/gin"
+
 	"github.com/blackforge/embookshelf/internal/config"
 	"github.com/blackforge/embookshelf/internal/repo"
 	"github.com/blackforge/embookshelf/internal/service"
@@ -220,4 +222,29 @@ func TestBuildRedirectURIEdges(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSettingsOIDCTestIsARegistryLookup pins the endpoint's shape after
+// #258: no per-slug switch, so an unknown slug is the service's refusal
+// mapped to 404, and a missing service is a 503 before any dispatch.
+func TestSettingsOIDCTestIsARegistryLookup(t *testing.T) {
+	t.Run("unknown slug is a 404", func(t *testing.T) {
+		h := &Handler{oidc: service.NewOIDCService(nil, nil, nil, nil, "")}
+		c, rec := settingsCtx(t, http.MethodPost, "/api/v1/settings/oidc/test/myspace", "{}")
+		c.Params = gin.Params{{Key: "slug", Value: "myspace"}}
+		h.SettingsOIDCTest(c)
+		if got := httpStatus(c, rec); got != http.StatusNotFound {
+			t.Errorf("status = %d, want 404", got)
+		}
+	})
+
+	t.Run("no service is a 503", func(t *testing.T) {
+		h := &Handler{}
+		c, rec := settingsCtx(t, http.MethodPost, "/api/v1/settings/oidc/test/google", "{}")
+		c.Params = gin.Params{{Key: "slug", Value: "google"}}
+		h.SettingsOIDCTest(c)
+		if got := httpStatus(c, rec); got != http.StatusServiceUnavailable {
+			t.Errorf("status = %d, want 503", got)
+		}
+	})
 }

--- a/internal/service/oidc.go
+++ b/internal/service/oidc.go
@@ -68,20 +68,6 @@ const (
 	githubIssuer = "https://github.com"
 )
 
-// oidcProvider is one login provider's two operations. Both the
-// authorize-URL builder and the callback exchange dispatch on the same
-// slug, so they are declared together and looked up once rather than
-// switched on in two places that must stay in step.
-//
-// Shaped as a struct of funcs rather than an interface for the same
-// reason queue/registry.go is: the per-provider work already lives as
-// methods, so a registration is a pair of method values and no bodies
-// have to move. Adding a provider is one entry in newProviderRegistry.
-type oidcProvider struct {
-	authURL  func(ctx context.Context, redirect, intent, linkUserID string) (string, error)
-	callback func(ctx context.Context, code string, entry stateEntry, redirect string) (resolvedClaims, string, error)
-}
-
 // OIDCService is the multi-provider OIDC/OAuth login service.
 // Google, GitHub, and a custom OIDC provider each have their own
 // settings row and can be enabled in parallel.
@@ -141,9 +127,10 @@ type OIDCService struct {
 
 	states *stateStore
 
-	// providers is the slug → operations registry. Built once at
-	// construction; the two dispatch sites are map lookups.
-	providers map[string]oidcProvider
+	// providers is the ordered provider registry (oidc_providers.go).
+	// Built once at construction; every dispatch site — auth URL,
+	// callback, public listing, connection test — resolves against it.
+	providers []registeredProvider
 
 	// Discovery cache for the generic OIDC provider only. Google runs
 	// through the same path but its issuer is fixed so we'd still hit
@@ -175,25 +162,6 @@ func NewOIDCService(settings oidcSettingsStore, users oidcUserProfileStore, sess
 	}
 	svc.providers = svc.newProviderRegistry()
 	return svc
-}
-
-// newProviderRegistry declares every login provider this binary supports.
-// One entry per slug; nothing else in the file switches on a slug.
-func (s *OIDCService) newProviderRegistry() map[string]oidcProvider {
-	return map[string]oidcProvider{
-		repo.ProviderSlugGoogle: {
-			authURL:  s.authURLGoogleWithIntent,
-			callback: s.callbackGoogle,
-		},
-		repo.ProviderSlugGitHub: {
-			authURL:  s.authURLGitHubWithIntent,
-			callback: s.callbackGitHub,
-		},
-		repo.ProviderSlugGeneric: {
-			authURL:  s.authURLGenericWithIntent,
-			callback: s.callbackGeneric,
-		},
-	}
 }
 
 // -----------------------------------------------------------------------------
@@ -241,47 +209,21 @@ func (s *OIDCService) Enabled(ctx context.Context) (bool, error) {
 	return len(ps) > 0, nil
 }
 
+// publicProviders walks the registry in order; each adapter's public()
+// is both the usable gate and the listing entry, so what the login page
+// offers is exactly what the registry declares.
 func (s *OIDCService) publicProviders(ctx context.Context) ([]PublicProvider, error) {
 	var out []PublicProvider
-	if g, err := s.settings.GetGoogle(ctx); err != nil {
-		return nil, err
-	} else if googleUsable(g) {
-		out = append(out, PublicProvider{
-			Slug: repo.ProviderSlugGoogle, Name: "Google", Kind: "google",
-			LoginURL: "/api/v1/auth/oidc/" + repo.ProviderSlugGoogle,
-		})
-	}
-	if g, err := s.settings.GetGitHub(ctx); err != nil {
-		return nil, err
-	} else if githubUsable(g) {
-		out = append(out, PublicProvider{
-			Slug: repo.ProviderSlugGitHub, Name: "GitHub", Kind: "github",
-			LoginURL: "/api/v1/auth/oidc/" + repo.ProviderSlugGitHub,
-		})
-	}
-	if g, err := s.settings.GetGenericOIDC(ctx); err != nil {
-		return nil, err
-	} else if genericUsable(g) {
-		name := g.ProviderName
-		if name == "" {
-			name = "SSO"
+	for _, e := range s.providers {
+		p, ok, err := e.public(ctx)
+		if err != nil {
+			return nil, err
 		}
-		out = append(out, PublicProvider{
-			Slug: repo.ProviderSlugGeneric, Name: name, Kind: "oidc",
-			LoginURL: "/api/v1/auth/oidc/" + repo.ProviderSlugGeneric,
-		})
+		if ok {
+			out = append(out, p)
+		}
 	}
 	return out, nil
-}
-
-func googleUsable(c repo.OAuthPresetConfig) bool {
-	return c.Enabled && c.ClientID != "" && c.ClientSecret != ""
-}
-func githubUsable(c repo.OAuthPresetConfig) bool {
-	return c.Enabled && c.ClientID != "" && c.ClientSecret != ""
-}
-func genericUsable(c repo.GenericOIDCConfig) bool {
-	return c.Enabled && c.ClientID != "" && c.IssuerURI != ""
 }
 
 // ValidateForceOnlyTransition refuses to enable force-only mode when no
@@ -472,53 +414,11 @@ func refuseLogin(res ProvisionResult) (ExchangeOutcome, error) {
 // resolveCallback runs the provider-specific OAuth/OIDC token exchange
 // and returns the resolved claims + canonical issuer for the request.
 func (s *OIDCService) resolveCallback(ctx context.Context, code string, entry stateEntry, redirect string) (resolvedClaims, string, error) {
-	p, ok := s.providers[entry.ProviderSlug]
+	p, ok := s.provider(entry.ProviderSlug)
 	if !ok {
 		return resolvedClaims{}, "", ErrOIDCUnknownProvider
 	}
 	return p.callback(ctx, code, entry, redirect)
-}
-
-// callbackGoogle exchanges the code against Google's OIDC endpoints.
-func (s *OIDCService) callbackGoogle(ctx context.Context, code string, entry stateEntry, redirect string) (resolvedClaims, string, error) {
-	cfg, err := s.settings.GetGoogle(ctx)
-	if err != nil {
-		return resolvedClaims{}, "", err
-	}
-	if !googleUsable(cfg) {
-		return resolvedClaims{}, "", ErrOIDCDisabled
-	}
-	return s.oidcCallback(ctx, code, entry, googleOIDCConfig(cfg), redirect)
-}
-
-// callbackGitHub exchanges the code against GitHub's REST API. GitHub is
-// not an OIDC provider — no discovery document, no ID token — so the
-// issuer is a constant rather than something discovery reports.
-func (s *OIDCService) callbackGitHub(ctx context.Context, code string, entry stateEntry, redirect string) (resolvedClaims, string, error) {
-	cfg, err := s.settings.GetGitHub(ctx)
-	if err != nil {
-		return resolvedClaims{}, "", err
-	}
-	if !githubUsable(cfg) {
-		return resolvedClaims{}, "", ErrOIDCDisabled
-	}
-	claims, err := s.githubCallback(ctx, code, entry, cfg, redirect)
-	if err != nil {
-		return resolvedClaims{}, "", err
-	}
-	return claims, githubIssuer, nil
-}
-
-// callbackGeneric exchanges the code against the admin-configured issuer.
-func (s *OIDCService) callbackGeneric(ctx context.Context, code string, entry stateEntry, redirect string) (resolvedClaims, string, error) {
-	cfg, err := s.settings.GetGenericOIDC(ctx)
-	if err != nil {
-		return resolvedClaims{}, "", err
-	}
-	if !genericUsable(cfg) {
-		return resolvedClaims{}, "", ErrOIDCDisabled
-	}
-	return s.oidcCallback(ctx, code, entry, cfg, redirect)
 }
 
 // AuthURLForLink builds an authorize URL whose state carries
@@ -539,7 +439,7 @@ func (s *OIDCService) AuthURLForLink(ctx context.Context, slug, baseURL, userID 
 // authURLForSlug is the shared dispatch used by both AuthURL and
 // AuthURLForLink — same builders, same state minting, same redirect.
 func (s *OIDCService) authURLForSlug(ctx context.Context, slug, redirect, intent, linkUserID string) (string, error) {
-	p, ok := s.providers[slug]
+	p, ok := s.provider(slug)
 	if !ok {
 		return "", ErrOIDCUnknownProvider
 	}
@@ -549,28 +449,6 @@ func (s *OIDCService) authURLForSlug(ctx context.Context, slug, redirect, intent
 // -----------------------------------------------------------------------------
 // AuthURL builders
 // -----------------------------------------------------------------------------
-
-func (s *OIDCService) authURLGoogleWithIntent(ctx context.Context, redirect, intent, linkUserID string) (string, error) {
-	cfg, err := s.settings.GetGoogle(ctx)
-	if err != nil {
-		return "", err
-	}
-	if !googleUsable(cfg) {
-		return "", ErrOIDCDisabled
-	}
-	return s.authURLOIDC(ctx, repo.ProviderSlugGoogle, googleOIDCConfig(cfg), redirect, intent, linkUserID)
-}
-
-func (s *OIDCService) authURLGenericWithIntent(ctx context.Context, redirect, intent, linkUserID string) (string, error) {
-	cfg, err := s.settings.GetGenericOIDC(ctx)
-	if err != nil {
-		return "", err
-	}
-	if !genericUsable(cfg) {
-		return "", ErrOIDCDisabled
-	}
-	return s.authURLOIDC(ctx, repo.ProviderSlugGeneric, cfg, redirect, intent, linkUserID)
-}
 
 func (s *OIDCService) authURLOIDC(ctx context.Context, slug string, cfg repo.GenericOIDCConfig, redirect, intent, linkUserID string) (string, error) {
 	disc, err := s.getDiscovery(ctx, cfg)
@@ -591,14 +469,9 @@ func (s *OIDCService) authURLOIDC(ctx context.Context, slug string, cfg repo.Gen
 	return u, nil
 }
 
-func (s *OIDCService) authURLGitHubWithIntent(ctx context.Context, redirect, intent, linkUserID string) (string, error) {
-	cfg, err := s.settings.GetGitHub(ctx)
-	if err != nil {
-		return "", err
-	}
-	if !githubUsable(cfg) {
-		return "", ErrOIDCDisabled
-	}
+// authURLGitHub hand-builds GitHub's authorize URL — no discovery
+// document exists to derive it from. The usable gate ran in the adapter.
+func (s *OIDCService) authURLGitHub(cfg repo.OAuthPresetConfig, redirect, intent, linkUserID string) (string, error) {
 	state, _, verifier, err := s.issueStateWithIntent(repo.ProviderSlugGitHub, redirect, intent, linkUserID)
 	if err != nil {
 		return "", err
@@ -883,25 +756,6 @@ func oidcOAuthConfig(cfg repo.GenericOIDCConfig, provider *oidc.Provider, redire
 		RedirectURL:  redirect,
 		Endpoint:     provider.Endpoint(),
 		Scopes:       splitScopes(cfg.Scopes),
-	}
-}
-
-// googleOIDCConfig widens Google's tiny preset config into the generic
-// OIDC shape the discovery path consumes. Issuer + scopes + claim
-// mapping are all baked in — admins only supply credentials.
-func googleOIDCConfig(c repo.OAuthPresetConfig) repo.GenericOIDCConfig {
-	return repo.GenericOIDCConfig{
-		Enabled:      c.Enabled,
-		ProviderName: "Google",
-		ClientID:     c.ClientID,
-		ClientSecret: c.ClientSecret,
-		IssuerURI:    "https://accounts.google.com",
-		Scopes:       "openid profile email",
-		ClaimMapping: repo.ClaimMapping{
-			Username: "email",
-			Email:    "email",
-			Name:     "name",
-		},
 	}
 }
 

--- a/internal/service/oidc_diagnostics.go
+++ b/internal/service/oidc_diagnostics.go
@@ -53,18 +53,31 @@ func (t *TestResult) add(name string, status CheckStatus, msg string) {
 	t.Checks = append(t.Checks, TestCheck{Name: name, Status: status, Message: msg})
 }
 
-// TestGeneric runs the discovery-based checks.
-func (s *OIDCService) TestGeneric(ctx context.Context, cfg repo.GenericOIDCConfig) TestResult {
+// TestProvider runs one provider's connection diagnostic. The slug
+// resolves against the same registry as the login flow, and the raw
+// request body is handed to the adapter, which owns its override shape
+// and the blank-submission fallback (#258). This is the whole test
+// endpoint: a lookup plus one call.
+func (s *OIDCService) TestProvider(ctx context.Context, slug string, body []byte) (TestResult, error) {
+	p, ok := s.provider(slug)
+	if !ok {
+		return TestResult{}, ErrOIDCUnknownProvider
+	}
+	return p.test(ctx, body)
+}
+
+// testGeneric runs the discovery-based checks.
+func testGeneric(ctx context.Context, cfg repo.GenericOIDCConfig) TestResult {
 	return testOIDCIssuer(ctx, cfg.IssuerURI, cfg.ClientID)
 }
 
-// TestGoogle reuses the generic path after filling in Google's issuer.
-func (s *OIDCService) TestGoogle(ctx context.Context, cfg repo.OAuthPresetConfig) TestResult {
+// testGoogle reuses the generic path after filling in Google's issuer.
+func testGoogle(ctx context.Context, cfg repo.OAuthPresetConfig) TestResult {
 	return testOIDCIssuer(ctx, "https://accounts.google.com", cfg.ClientID)
 }
 
-// TestGitHub pings the fixed GitHub endpoints (no discovery doc).
-func (s *OIDCService) TestGitHub(ctx context.Context, cfg repo.OAuthPresetConfig) TestResult {
+// testGitHub pings the fixed GitHub endpoints (no discovery doc).
+func testGitHub(ctx context.Context, cfg repo.OAuthPresetConfig) TestResult {
 	out := TestResult{}
 	if cfg.ClientID == "" {
 		out.add("Client ID", CheckFail, "client id is empty")

--- a/internal/service/oidc_exchange_test.go
+++ b/internal/service/oidc_exchange_test.go
@@ -126,16 +126,38 @@ func newExchangeFixture(t *testing.T, provision repo.OIDCAutoProvisionDetails) *
 	// Stub the one operation that would otherwise talk to an IdP. The
 	// registry is the service's only dispatch point, so registering a
 	// slug here exercises Exchange exactly as a real provider would.
-	f.svc.providers[testIdPSlug] = oidcProvider{
-		callback: func(context.Context, string, stateEntry, string) (resolvedClaims, string, error) {
+	f.svc.providers = append(f.svc.providers, registeredProvider{testIdPSlug, stubOIDCProvider{
+		callbackFn: func(context.Context, string, stateEntry, string) (resolvedClaims, string, error) {
 			f.callbacks++
 			if f.callbackErr != nil {
 				return resolvedClaims{}, "", f.callbackErr
 			}
 			return f.claims, testIssuer, nil
 		},
-	}
+	}})
 	return f
+}
+
+// stubOIDCProvider is a registrable fake: only the callback matters to
+// Exchange, the rest of the interface answers with zero values.
+type stubOIDCProvider struct {
+	callbackFn func(context.Context, string, stateEntry, string) (resolvedClaims, string, error)
+}
+
+func (p stubOIDCProvider) public(context.Context) (PublicProvider, bool, error) {
+	return PublicProvider{}, false, nil
+}
+
+func (p stubOIDCProvider) authURL(context.Context, string, string, string) (string, error) {
+	return "", nil
+}
+
+func (p stubOIDCProvider) callback(ctx context.Context, code string, entry stateEntry, redirect string) (resolvedClaims, string, error) {
+	return p.callbackFn(ctx, code, entry, redirect)
+}
+
+func (p stubOIDCProvider) test(context.Context, []byte) (TestResult, error) {
+	return TestResult{}, nil
 }
 
 // seedState mints a state as an authorize redirect would have, and

--- a/internal/service/oidc_providers.go
+++ b/internal/service/oidc_providers.go
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/blackforge/embookshelf/internal/repo"
+)
+
+// One login provider, whole (#258). Before this file a provider existed
+// five times — its usable gate, its auth-URL builder, its callback, its
+// public listing, and a hand-written slug switch in the handler for the
+// connection test. Each of those sites dispatched on the same slug and
+// had to stay in step. Now a provider is one adapter satisfying this
+// interface, and adding one is a single entry in newProviderRegistry:
+// the login page, the dispatch, and the test endpoint all derive from
+// the registry.
+//
+// The adapters hold *OIDCService because the mechanics they share —
+// discovery cache, state minting, the OAuth exchanges — live there; the
+// adapter is the provider-shaped face over that machinery, not a second
+// home for it.
+type oidcProvider interface {
+	// public is the usable gate and the login-page entry in one: a
+	// provider that is enabled and fully configured returns its listing
+	// and true, anything else returns false. Merged deliberately —
+	// "usable" exists so the login page doesn't offer a button that
+	// 500s, so the gate and the listing are one decision.
+	public(ctx context.Context) (PublicProvider, bool, error)
+
+	// authURL builds the authorize URL for a login or link flow,
+	// minting the state that ties the redirect to the callback.
+	authURL(ctx context.Context, redirect, intent, linkUserID string) (string, error)
+
+	// callback runs the provider's token exchange and returns the
+	// resolved claims plus the canonical issuer for the identity row.
+	callback(ctx context.Context, code string, entry stateEntry, redirect string) (resolvedClaims, string, error)
+
+	// test runs the admin panel's connection diagnostic. body is the
+	// raw request payload — each provider owns its override shape, and
+	// a blank submission falls back to the stored row (the one rule,
+	// stated once, in testWithStoredFallback).
+	test(ctx context.Context, body []byte) (TestResult, error)
+}
+
+// registeredProvider pairs a slug with its adapter. The registry is an
+// ordered slice rather than a map so the login page lists providers in
+// a stable order and the enumeration test can walk it.
+type registeredProvider struct {
+	slug string
+	oidcProvider
+}
+
+// newProviderRegistry declares every login provider this binary
+// supports. One entry per provider; nothing else switches on a slug.
+func (s *OIDCService) newProviderRegistry() []registeredProvider {
+	return []registeredProvider{
+		{repo.ProviderSlugGoogle, googleProvider{s}},
+		{repo.ProviderSlugGitHub, githubProvider{s}},
+		{repo.ProviderSlugGeneric, genericProvider{s}},
+	}
+}
+
+// provider resolves a slug against the registry. Linear over three
+// entries; the slice is the single source of truth, so there is no map
+// to fall out of step with.
+func (s *OIDCService) provider(slug string) (oidcProvider, bool) {
+	for _, e := range s.providers {
+		if e.slug == slug {
+			return e.oidcProvider, true
+		}
+	}
+	return nil, false
+}
+
+// oidcLoginURL is the path the login page's button hits for a slug.
+func oidcLoginURL(slug string) string {
+	return "/api/v1/auth/oidc/" + slug
+}
+
+// presetUsable gates the two preset providers (Google, GitHub): enabled
+// with both credentials present. genericUsable differs because public
+// clients are legitimate there — it needs an issuer, not a secret.
+func presetUsable(c repo.OAuthPresetConfig) bool {
+	return c.Enabled && c.ClientID != "" && c.ClientSecret != ""
+}
+
+func genericUsable(c repo.GenericOIDCConfig) bool {
+	return c.Enabled && c.ClientID != "" && c.IssuerURI != ""
+}
+
+// testWithStoredFallback is the blank-submission rule, stated once: the
+// panel tests what is on screen, and a submission missing its required
+// fields means "test what is stored instead". A failure to read that
+// row is a store error, not a diagnostic verdict.
+func testWithStoredFallback[C any](
+	ctx context.Context,
+	override C,
+	blank func(C) bool,
+	stored func(context.Context) (C, error),
+	run func(context.Context, C) TestResult,
+) (TestResult, error) {
+	cfg := override
+	if blank(cfg) {
+		var err error
+		if cfg, err = stored(ctx); err != nil {
+			return TestResult{}, err
+		}
+	}
+	return run(ctx, cfg), nil
+}
+
+// oauthPresetOverride is the wire shape both preset providers' test
+// submissions carry. Bind errors are deliberately ignored, matching the
+// old handler: an unreadable body is a blank submission, which the
+// fallback rule already answers.
+type oauthPresetOverride struct {
+	ClientID     string `json:"clientId"`
+	ClientSecret string `json:"clientSecret"`
+}
+
+func (o oauthPresetOverride) config() repo.OAuthPresetConfig {
+	return repo.OAuthPresetConfig{ClientID: o.ClientID, ClientSecret: o.ClientSecret}
+}
+
+func presetBlank(c repo.OAuthPresetConfig) bool { return c.ClientID == "" }
+
+// -----------------------------------------------------------------------------
+// Google
+// -----------------------------------------------------------------------------
+
+type googleProvider struct{ s *OIDCService }
+
+func (p googleProvider) public(ctx context.Context) (PublicProvider, bool, error) {
+	cfg, err := p.s.settings.GetGoogle(ctx)
+	if err != nil || !presetUsable(cfg) {
+		return PublicProvider{}, false, err
+	}
+	return PublicProvider{
+		Slug: repo.ProviderSlugGoogle, Name: "Google", Kind: "google",
+		LoginURL: oidcLoginURL(repo.ProviderSlugGoogle),
+	}, true, nil
+}
+
+func (p googleProvider) authURL(ctx context.Context, redirect, intent, linkUserID string) (string, error) {
+	cfg, err := p.s.settings.GetGoogle(ctx)
+	if err != nil {
+		return "", err
+	}
+	if !presetUsable(cfg) {
+		return "", ErrOIDCDisabled
+	}
+	return p.s.authURLOIDC(ctx, repo.ProviderSlugGoogle, googleOIDCConfig(cfg), redirect, intent, linkUserID)
+}
+
+func (p googleProvider) callback(ctx context.Context, code string, entry stateEntry, redirect string) (resolvedClaims, string, error) {
+	cfg, err := p.s.settings.GetGoogle(ctx)
+	if err != nil {
+		return resolvedClaims{}, "", err
+	}
+	if !presetUsable(cfg) {
+		return resolvedClaims{}, "", ErrOIDCDisabled
+	}
+	return p.s.oidcCallback(ctx, code, entry, googleOIDCConfig(cfg), redirect)
+}
+
+func (p googleProvider) test(ctx context.Context, body []byte) (TestResult, error) {
+	var b struct {
+		Google oauthPresetOverride `json:"google"`
+	}
+	_ = json.Unmarshal(body, &b)
+	return testWithStoredFallback(ctx, b.Google.config(), presetBlank, p.s.settings.GetGoogle, testGoogle)
+}
+
+// googleOIDCConfig widens Google's tiny preset config into the generic
+// OIDC shape the discovery path consumes. Issuer + scopes + claim
+// mapping are all baked in — admins only supply credentials.
+func googleOIDCConfig(c repo.OAuthPresetConfig) repo.GenericOIDCConfig {
+	return repo.GenericOIDCConfig{
+		Enabled:      c.Enabled,
+		ProviderName: "Google",
+		ClientID:     c.ClientID,
+		ClientSecret: c.ClientSecret,
+		IssuerURI:    "https://accounts.google.com",
+		Scopes:       "openid profile email",
+		ClaimMapping: repo.ClaimMapping{
+			Username: "email",
+			Email:    "email",
+			Name:     "name",
+		},
+	}
+}
+
+// -----------------------------------------------------------------------------
+// GitHub
+// -----------------------------------------------------------------------------
+
+type githubProvider struct{ s *OIDCService }
+
+func (p githubProvider) public(ctx context.Context) (PublicProvider, bool, error) {
+	cfg, err := p.s.settings.GetGitHub(ctx)
+	if err != nil || !presetUsable(cfg) {
+		return PublicProvider{}, false, err
+	}
+	return PublicProvider{
+		Slug: repo.ProviderSlugGitHub, Name: "GitHub", Kind: "github",
+		LoginURL: oidcLoginURL(repo.ProviderSlugGitHub),
+	}, true, nil
+}
+
+func (p githubProvider) authURL(ctx context.Context, redirect, intent, linkUserID string) (string, error) {
+	cfg, err := p.s.settings.GetGitHub(ctx)
+	if err != nil {
+		return "", err
+	}
+	if !presetUsable(cfg) {
+		return "", ErrOIDCDisabled
+	}
+	return p.s.authURLGitHub(cfg, redirect, intent, linkUserID)
+}
+
+func (p githubProvider) callback(ctx context.Context, code string, entry stateEntry, redirect string) (resolvedClaims, string, error) {
+	cfg, err := p.s.settings.GetGitHub(ctx)
+	if err != nil {
+		return resolvedClaims{}, "", err
+	}
+	if !presetUsable(cfg) {
+		return resolvedClaims{}, "", ErrOIDCDisabled
+	}
+	claims, err := p.s.githubCallback(ctx, code, entry, cfg, redirect)
+	if err != nil {
+		return resolvedClaims{}, "", err
+	}
+	return claims, githubIssuer, nil
+}
+
+func (p githubProvider) test(ctx context.Context, body []byte) (TestResult, error) {
+	var b struct {
+		GitHub oauthPresetOverride `json:"github"`
+	}
+	_ = json.Unmarshal(body, &b)
+	return testWithStoredFallback(ctx, b.GitHub.config(), presetBlank, p.s.settings.GetGitHub, testGitHub)
+}
+
+// -----------------------------------------------------------------------------
+// Generic OIDC
+// -----------------------------------------------------------------------------
+
+type genericProvider struct{ s *OIDCService }
+
+func (p genericProvider) public(ctx context.Context) (PublicProvider, bool, error) {
+	cfg, err := p.s.settings.GetGenericOIDC(ctx)
+	if err != nil || !genericUsable(cfg) {
+		return PublicProvider{}, false, err
+	}
+	name := cfg.ProviderName
+	if name == "" {
+		name = "SSO"
+	}
+	return PublicProvider{
+		Slug: repo.ProviderSlugGeneric, Name: name, Kind: "oidc",
+		LoginURL: oidcLoginURL(repo.ProviderSlugGeneric),
+	}, true, nil
+}
+
+func (p genericProvider) authURL(ctx context.Context, redirect, intent, linkUserID string) (string, error) {
+	cfg, err := p.s.settings.GetGenericOIDC(ctx)
+	if err != nil {
+		return "", err
+	}
+	if !genericUsable(cfg) {
+		return "", ErrOIDCDisabled
+	}
+	return p.s.authURLOIDC(ctx, repo.ProviderSlugGeneric, cfg, redirect, intent, linkUserID)
+}
+
+func (p genericProvider) callback(ctx context.Context, code string, entry stateEntry, redirect string) (resolvedClaims, string, error) {
+	cfg, err := p.s.settings.GetGenericOIDC(ctx)
+	if err != nil {
+		return resolvedClaims{}, "", err
+	}
+	if !genericUsable(cfg) {
+		return resolvedClaims{}, "", ErrOIDCDisabled
+	}
+	return p.s.oidcCallback(ctx, code, entry, cfg, redirect)
+}
+
+func (p genericProvider) test(ctx context.Context, body []byte) (TestResult, error) {
+	var b struct {
+		Generic struct {
+			ClientID     string            `json:"clientId"`
+			ClientSecret string            `json:"clientSecret"`
+			IssuerURI    string            `json:"issuerUri"`
+			Scopes       string            `json:"scopes"`
+			ClaimMapping repo.ClaimMapping `json:"claimMapping"`
+		} `json:"generic"`
+	}
+	_ = json.Unmarshal(body, &b)
+	override := repo.GenericOIDCConfig{
+		ClientID:     b.Generic.ClientID,
+		ClientSecret: b.Generic.ClientSecret,
+		IssuerURI:    b.Generic.IssuerURI,
+		Scopes:       b.Generic.Scopes,
+		ClaimMapping: b.Generic.ClaimMapping,
+	}
+	return testWithStoredFallback(ctx, override,
+		func(c repo.GenericOIDCConfig) bool { return c.ClientID == "" || c.IssuerURI == "" },
+		p.s.settings.GetGenericOIDC, testGeneric)
+}

--- a/internal/service/oidc_providers.go
+++ b/internal/service/oidc_providers.go
@@ -5,6 +5,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 
 	"github.com/blackforge/embookshelf/internal/repo"
 )
@@ -91,6 +92,15 @@ func genericUsable(c repo.GenericOIDCConfig) bool {
 	return c.Enabled && c.ClientID != "" && c.IssuerURI != ""
 }
 
+// ignoreDisabled maps ErrOIDCDisabled to nil for public(): a disabled
+// provider is simply not listed, while a store failure still surfaces.
+func ignoreDisabled(err error) error {
+	if errors.Is(err, ErrOIDCDisabled) {
+		return nil
+	}
+	return err
+}
+
 // testWithStoredFallback is the blank-submission rule, stated once: the
 // panel tests what is on screen, and a submission missing its required
 // fields means "test what is stored instead". A failure to read that
@@ -133,10 +143,22 @@ func presetBlank(c repo.OAuthPresetConfig) bool { return c.ClientID == "" }
 
 type googleProvider struct{ s *OIDCService }
 
-func (p googleProvider) public(ctx context.Context) (PublicProvider, bool, error) {
+// usableConfig is Google's usable gate, stated once: the stored row,
+// or ErrOIDCDisabled when it isn't fit to serve a login.
+func (p googleProvider) usableConfig(ctx context.Context) (repo.OAuthPresetConfig, error) {
 	cfg, err := p.s.settings.GetGoogle(ctx)
-	if err != nil || !presetUsable(cfg) {
-		return PublicProvider{}, false, err
+	if err != nil {
+		return cfg, err
+	}
+	if !presetUsable(cfg) {
+		return cfg, ErrOIDCDisabled
+	}
+	return cfg, nil
+}
+
+func (p googleProvider) public(ctx context.Context) (PublicProvider, bool, error) {
+	if _, err := p.usableConfig(ctx); err != nil {
+		return PublicProvider{}, false, ignoreDisabled(err)
 	}
 	return PublicProvider{
 		Slug: repo.ProviderSlugGoogle, Name: "Google", Kind: "google",
@@ -145,23 +167,17 @@ func (p googleProvider) public(ctx context.Context) (PublicProvider, bool, error
 }
 
 func (p googleProvider) authURL(ctx context.Context, redirect, intent, linkUserID string) (string, error) {
-	cfg, err := p.s.settings.GetGoogle(ctx)
+	cfg, err := p.usableConfig(ctx)
 	if err != nil {
 		return "", err
-	}
-	if !presetUsable(cfg) {
-		return "", ErrOIDCDisabled
 	}
 	return p.s.authURLOIDC(ctx, repo.ProviderSlugGoogle, googleOIDCConfig(cfg), redirect, intent, linkUserID)
 }
 
 func (p googleProvider) callback(ctx context.Context, code string, entry stateEntry, redirect string) (resolvedClaims, string, error) {
-	cfg, err := p.s.settings.GetGoogle(ctx)
+	cfg, err := p.usableConfig(ctx)
 	if err != nil {
 		return resolvedClaims{}, "", err
-	}
-	if !presetUsable(cfg) {
-		return resolvedClaims{}, "", ErrOIDCDisabled
 	}
 	return p.s.oidcCallback(ctx, code, entry, googleOIDCConfig(cfg), redirect)
 }
@@ -199,10 +215,22 @@ func googleOIDCConfig(c repo.OAuthPresetConfig) repo.GenericOIDCConfig {
 
 type githubProvider struct{ s *OIDCService }
 
-func (p githubProvider) public(ctx context.Context) (PublicProvider, bool, error) {
+// usableConfig is GitHub's usable gate, stated once — same preset rule
+// as Google's.
+func (p githubProvider) usableConfig(ctx context.Context) (repo.OAuthPresetConfig, error) {
 	cfg, err := p.s.settings.GetGitHub(ctx)
-	if err != nil || !presetUsable(cfg) {
-		return PublicProvider{}, false, err
+	if err != nil {
+		return cfg, err
+	}
+	if !presetUsable(cfg) {
+		return cfg, ErrOIDCDisabled
+	}
+	return cfg, nil
+}
+
+func (p githubProvider) public(ctx context.Context) (PublicProvider, bool, error) {
+	if _, err := p.usableConfig(ctx); err != nil {
+		return PublicProvider{}, false, ignoreDisabled(err)
 	}
 	return PublicProvider{
 		Slug: repo.ProviderSlugGitHub, Name: "GitHub", Kind: "github",
@@ -211,23 +239,17 @@ func (p githubProvider) public(ctx context.Context) (PublicProvider, bool, error
 }
 
 func (p githubProvider) authURL(ctx context.Context, redirect, intent, linkUserID string) (string, error) {
-	cfg, err := p.s.settings.GetGitHub(ctx)
+	cfg, err := p.usableConfig(ctx)
 	if err != nil {
 		return "", err
-	}
-	if !presetUsable(cfg) {
-		return "", ErrOIDCDisabled
 	}
 	return p.s.authURLGitHub(cfg, redirect, intent, linkUserID)
 }
 
 func (p githubProvider) callback(ctx context.Context, code string, entry stateEntry, redirect string) (resolvedClaims, string, error) {
-	cfg, err := p.s.settings.GetGitHub(ctx)
+	cfg, err := p.usableConfig(ctx)
 	if err != nil {
 		return resolvedClaims{}, "", err
-	}
-	if !presetUsable(cfg) {
-		return resolvedClaims{}, "", ErrOIDCDisabled
 	}
 	claims, err := p.s.githubCallback(ctx, code, entry, cfg, redirect)
 	if err != nil {
@@ -250,10 +272,23 @@ func (p githubProvider) test(ctx context.Context, body []byte) (TestResult, erro
 
 type genericProvider struct{ s *OIDCService }
 
-func (p genericProvider) public(ctx context.Context) (PublicProvider, bool, error) {
+// usableConfig is the generic provider's usable gate, stated once —
+// issuer instead of secret, because public clients are legitimate.
+func (p genericProvider) usableConfig(ctx context.Context) (repo.GenericOIDCConfig, error) {
 	cfg, err := p.s.settings.GetGenericOIDC(ctx)
-	if err != nil || !genericUsable(cfg) {
-		return PublicProvider{}, false, err
+	if err != nil {
+		return cfg, err
+	}
+	if !genericUsable(cfg) {
+		return cfg, ErrOIDCDisabled
+	}
+	return cfg, nil
+}
+
+func (p genericProvider) public(ctx context.Context) (PublicProvider, bool, error) {
+	cfg, err := p.usableConfig(ctx)
+	if err != nil {
+		return PublicProvider{}, false, ignoreDisabled(err)
 	}
 	name := cfg.ProviderName
 	if name == "" {
@@ -266,23 +301,17 @@ func (p genericProvider) public(ctx context.Context) (PublicProvider, bool, erro
 }
 
 func (p genericProvider) authURL(ctx context.Context, redirect, intent, linkUserID string) (string, error) {
-	cfg, err := p.s.settings.GetGenericOIDC(ctx)
+	cfg, err := p.usableConfig(ctx)
 	if err != nil {
 		return "", err
-	}
-	if !genericUsable(cfg) {
-		return "", ErrOIDCDisabled
 	}
 	return p.s.authURLOIDC(ctx, repo.ProviderSlugGeneric, cfg, redirect, intent, linkUserID)
 }
 
 func (p genericProvider) callback(ctx context.Context, code string, entry stateEntry, redirect string) (resolvedClaims, string, error) {
-	cfg, err := p.s.settings.GetGenericOIDC(ctx)
+	cfg, err := p.usableConfig(ctx)
 	if err != nil {
 		return resolvedClaims{}, "", err
-	}
-	if !genericUsable(cfg) {
-		return resolvedClaims{}, "", ErrOIDCDisabled
 	}
 	return p.s.oidcCallback(ctx, code, entry, cfg, redirect)
 }

--- a/internal/service/oidc_providers_test.go
+++ b/internal/service/oidc_providers_test.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/blackforge/embookshelf/internal/repo"
+)
+
+// The registry is the one place a provider exists (#258): its slug, its
+// login-page entry, its dispatch, and its connection test all come from
+// the same entry. These tests enumerate the registry rather than naming
+// slugs one by one, so a fourth provider is covered the moment its entry
+// is added.
+
+// Every registered provider, once its config is usable, appears on the
+// login page — in registry order, with a login URL derived from its slug.
+// The listing is compared against the registry itself, not a hand-kept
+// list, which is what pins "adding a provider is one entry".
+func TestPublicListingDerivesFromTheRegistry(t *testing.T) {
+	t.Parallel()
+
+	svc := oidcForTest(t, &fakeOIDCSettings{
+		google:  repo.OAuthPresetConfig{Enabled: true, ClientID: "g", ClientSecret: "s"},
+		github:  repo.OAuthPresetConfig{Enabled: true, ClientID: "h", ClientSecret: "s"},
+		generic: repo.GenericOIDCConfig{Enabled: true, ClientID: "c", IssuerURI: "https://idp.test", ProviderName: "Corp"},
+	})
+
+	got, err := svc.publicProviders(context.Background())
+	if err != nil {
+		t.Fatalf("publicProviders: %v", err)
+	}
+
+	if len(got) != len(svc.providers) {
+		t.Fatalf("listed %d providers, registry has %d — the listing is not registry-derived", len(got), len(svc.providers))
+	}
+	for i, entry := range svc.providers {
+		p := got[i]
+		if p.Slug != entry.slug {
+			t.Errorf("listing[%d].Slug = %q, want registry slug %q", i, p.Slug, entry.slug)
+		}
+		if p.LoginURL != "/api/v1/auth/oidc/"+entry.slug {
+			t.Errorf("listing[%d].LoginURL = %q, want it derived from the slug", i, p.LoginURL)
+		}
+		if p.Name == "" || p.Kind == "" {
+			t.Errorf("listing[%d] = %+v, want a name and a kind", i, p)
+		}
+	}
+}
+
+// A generic provider with no display name still needs a button label.
+func TestPublicListingDefaultsGenericNameToSSO(t *testing.T) {
+	t.Parallel()
+
+	svc := oidcForTest(t, &fakeOIDCSettings{
+		generic: repo.GenericOIDCConfig{Enabled: true, ClientID: "c", IssuerURI: "https://idp.test"},
+	})
+
+	got, err := svc.publicProviders(context.Background())
+	if err != nil {
+		t.Fatalf("publicProviders: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "SSO" {
+		t.Fatalf("listing = %+v, want a single provider named SSO", got)
+	}
+}
+
+// The connection test dispatches through the same registry as the login
+// flow, so an unknown slug is the same refusal everywhere.
+func TestTestProviderRejectsUnknownSlug(t *testing.T) {
+	t.Parallel()
+
+	svc := oidcForTest(t, &fakeOIDCSettings{})
+	_, err := svc.TestProvider(context.Background(), "myspace", nil)
+	if !errors.Is(err, ErrOIDCUnknownProvider) {
+		t.Errorf("err = %v, want ErrOIDCUnknownProvider", err)
+	}
+}
+
+// The blank-submission rule, stated once: an override that is missing its
+// required fields falls back to the stored row, and a failure to read
+// that row is the caller's error, not a diagnostic verdict.
+func TestBlankSubmissionFallsBackToStoredRow(t *testing.T) {
+	t.Parallel()
+
+	stored := repo.OAuthPresetConfig{ClientID: "stored-id"}
+	blank := func(c repo.OAuthPresetConfig) bool { return c.ClientID == "" }
+	run := func(_ context.Context, c repo.OAuthPresetConfig) TestResult {
+		return TestResult{Checks: []TestCheck{{Name: c.ClientID}}}
+	}
+
+	t.Run("a filled override wins", func(t *testing.T) {
+		t.Parallel()
+		res, err := testWithStoredFallback(context.Background(),
+			repo.OAuthPresetConfig{ClientID: "typed-id"}, blank,
+			func(context.Context) (repo.OAuthPresetConfig, error) {
+				t.Fatal("stored row read for a non-blank submission")
+				return repo.OAuthPresetConfig{}, nil
+			}, run)
+		if err != nil {
+			t.Fatalf("err = %v", err)
+		}
+		if res.Checks[0].Name != "typed-id" {
+			t.Errorf("ran against %q, want the typed override", res.Checks[0].Name)
+		}
+	})
+
+	t.Run("a blank override falls back", func(t *testing.T) {
+		t.Parallel()
+		res, err := testWithStoredFallback(context.Background(),
+			repo.OAuthPresetConfig{}, blank,
+			func(context.Context) (repo.OAuthPresetConfig, error) { return stored, nil }, run)
+		if err != nil {
+			t.Fatalf("err = %v", err)
+		}
+		if res.Checks[0].Name != "stored-id" {
+			t.Errorf("ran against %q, want the stored row", res.Checks[0].Name)
+		}
+	})
+
+	t.Run("a stored-row failure surfaces", func(t *testing.T) {
+		t.Parallel()
+		wantErr := errors.New("boom")
+		_, err := testWithStoredFallback(context.Background(),
+			repo.OAuthPresetConfig{}, blank,
+			func(context.Context) (repo.OAuthPresetConfig, error) { return repo.OAuthPresetConfig{}, wantErr }, run)
+		if !errors.Is(err, wantErr) {
+			t.Errorf("err = %v, want the store failure", err)
+		}
+	})
+}
+
+// conformingIssuer serves a minimal well-formed discovery document, so a
+// diagnostic run against it passes every critical check.
+func conformingIssuer(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                   srv.URL,
+			"authorization_endpoint":   srv.URL + "/authorize",
+			"token_endpoint":           srv.URL + "/token",
+			"jwks_uri":                 srv.URL + "/jwks",
+			"scopes_supported":         []string{"openid", "profile", "email"},
+			"response_types_supported": []string{"code"},
+		})
+	})
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"keys":[{"kty":"RSA","kid":"k1"}]}`))
+	})
+	return srv
+}
+
+// A submission carrying a config runs against that config; one without
+// runs against the stored row. This is the end-to-end shape the panel's
+// "test before saving" relies on, pinned against a stub issuer.
+func TestGenericConnectionTestPrefersTheSubmission(t *testing.T) {
+	t.Parallel()
+
+	srv := conformingIssuer(t)
+	svc := oidcForTest(t, &fakeOIDCSettings{
+		generic: repo.GenericOIDCConfig{Enabled: true, ClientID: "stored", IssuerURI: srv.URL},
+	})
+
+	// Blank body → stored row → the stub issuer answers.
+	res, err := svc.TestProvider(context.Background(), repo.ProviderSlugGeneric, []byte(`{}`))
+	if err != nil {
+		t.Fatalf("TestProvider: %v", err)
+	}
+	if !res.Success {
+		t.Fatalf("stored-row fallback failed against a conforming issuer: %+v", res.Checks)
+	}
+
+	// A typed submission wins over the stored row: an unreachable issuer
+	// in the body must fail even though the stored one would pass.
+	dead := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	deadURL := dead.URL
+	dead.Close()
+
+	body, _ := json.Marshal(map[string]any{
+		"generic": map[string]any{"clientId": "typed", "issuerUri": deadURL},
+	})
+	res, err = svc.TestProvider(context.Background(), repo.ProviderSlugGeneric, body)
+	if err != nil {
+		t.Fatalf("TestProvider: %v", err)
+	}
+	if res.Success {
+		t.Fatal("a typed submission naming a dead issuer passed — the stored row was tested instead")
+	}
+}

--- a/internal/service/oidc_test.go
+++ b/internal/service/oidc_test.go
@@ -257,12 +257,10 @@ func TestProviderUsableGates(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			if got := googleUsable(tc.cfg); got != tc.want {
-				t.Errorf("googleUsable = %v, want %v", got, tc.want)
-			}
-			// GitHub takes the same shape and the same rule.
-			if got := githubUsable(tc.cfg); got != tc.want {
-				t.Errorf("githubUsable = %v, want %v", got, tc.want)
+			// One gate for both preset providers — Google and GitHub
+			// take the same shape and the same rule.
+			if got := presetUsable(tc.cfg); got != tc.want {
+				t.Errorf("presetUsable = %v, want %v", got, tc.want)
 			}
 		})
 	}
@@ -483,8 +481,7 @@ func TestDiagnosticsPassAgainstAConformingIssuer(t *testing.T) {
 		_, _ = w.Write([]byte(`{"keys":[{"kty":"RSA","kid":"k1"}]}`))
 	})
 
-	svc := oidcForTest(t, &fakeOIDCSettings{})
-	res := svc.TestGeneric(context.Background(), repo.GenericOIDCConfig{IssuerURI: srv.URL, ClientID: "cid"})
+	res := testGeneric(context.Background(), repo.GenericOIDCConfig{IssuerURI: srv.URL, ClientID: "cid"})
 
 	if !res.Success {
 		t.Fatalf("a conforming issuer failed: %+v", res.Checks)
@@ -526,8 +523,7 @@ func TestDiagnosticsGradeMissingCapabilities(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	svc := oidcForTest(t, &fakeOIDCSettings{})
-	res := svc.TestGeneric(context.Background(), repo.GenericOIDCConfig{IssuerURI: srv.URL, ClientID: "cid"})
+	res := testGeneric(context.Background(), repo.GenericOIDCConfig{IssuerURI: srv.URL, ClientID: "cid"})
 
 	if res.Success {
 		t.Fatal("an issuer without the authorization-code flow was reported as usable")
@@ -556,8 +552,7 @@ func TestDiagnosticsReportUnreachableIssuer(t *testing.T) {
 	url := srv.URL
 	srv.Close() // nothing is listening now
 
-	svc := oidcForTest(t, &fakeOIDCSettings{})
-	res := svc.TestGeneric(context.Background(), repo.GenericOIDCConfig{IssuerURI: url, ClientID: "cid"})
+	res := testGeneric(context.Background(), repo.GenericOIDCConfig{IssuerURI: url, ClientID: "cid"})
 
 	if res.Success || len(res.Checks) != 1 || res.Checks[0].Status != CheckFail {
 		t.Fatalf("checks = %+v, want a single FAIL on discovery", res.Checks)
@@ -569,18 +564,16 @@ func TestDiagnosticsReportUnreachableIssuer(t *testing.T) {
 func TestDiagnosticsRefuseEmptyConfig(t *testing.T) {
 	t.Parallel()
 
-	svc := oidcForTest(t, &fakeOIDCSettings{})
-
-	if res := svc.TestGeneric(context.Background(), repo.GenericOIDCConfig{ClientID: "cid"}); res.Success ||
+	if res := testGeneric(context.Background(), repo.GenericOIDCConfig{ClientID: "cid"}); res.Success ||
 		len(res.Checks) != 1 || res.Checks[0].Name != "Issuer URI" {
 		t.Errorf("empty issuer: checks = %+v, want a single Issuer URI failure", res.Checks)
 	}
-	if res := svc.TestGeneric(context.Background(), repo.GenericOIDCConfig{IssuerURI: "https://idp.test"}); res.Success ||
+	if res := testGeneric(context.Background(), repo.GenericOIDCConfig{IssuerURI: "https://idp.test"}); res.Success ||
 		len(res.Checks) != 1 || res.Checks[0].Name != "Client ID" {
 		t.Errorf("empty client id: checks = %+v, want a single Client ID failure", res.Checks)
 	}
 	// GitHub has no discovery document, so its guard is its own.
-	if res := svc.TestGitHub(context.Background(), repo.OAuthPresetConfig{}); res.Success ||
+	if res := testGitHub(context.Background(), repo.OAuthPresetConfig{}); res.Success ||
 		len(res.Checks) != 1 || res.Checks[0].Name != "Client ID" {
 		t.Errorf("github: checks = %+v, want a single Client ID failure", res.Checks)
 	}


### PR DESCRIPTION
Closes #258.

Each login provider is now a single adapter satisfying the `oidcProvider` interface — usable gate + public listing (one `public()` call), auth URL, callback, connection test — and the ordered registry in `newProviderRegistry` is the only place a provider exists.

- The login-page listing walks the registry instead of an unrolled three-branch chain, pinned by a test that enumerates the registry (`TestPublicListingDerivesFromTheRegistry`).
- The handler's seventy-line slug switch for the connection test collapses to `TestProvider`: a registry lookup plus one call. Wire contract unchanged — the panel still posts `{"google"|"github"|"generic": {...}}`, and bind errors still read as blank submissions.
- The blank-submission fallback ("a blank submission tests the stored row") is stated once, in `testWithStoredFallback`; each adapter supplies only its blank predicate and stored row.
- The two identical preset usable gates merge into `presetUsable`; each adapter states its gate once in `usableConfig`.
- `#230`'s exchange tests pin that login and link flows behave identically — only the stub-registration mechanics changed.
- Docs: CONTEXT.md registry + #249 entries updated; architecture.md records the one deliberate DTO exception (connection-test override shapes live with their adapters).

Two-axis review ran (Standards + Spec): all six acceptance criteria confirmed, behavior preservation verified against main, review findings addressed in the follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pcyxag7xV1QMorRDqFNU3K