### PR TITLE
refactor(bookops): RecordDerived — one finalize tail for every derived artifact

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -837,7 +837,11 @@ The markdown produced from a book's file by the [[Converter extension]] — a de
 
 ### Book operations
 
-`service.BookOps`; the deep module over [[LibraryStore]] holding the library-touching steps every derived-artifact job shares — `Open` (the book's bytes), `PrimaryHash` (provenance, via [[Primary hash]]), `OpenMarkdown`, `PlaceDerived`. The job registry consumes it and declares job wiring instead of restating library plumbing per job; the resolve-library-fails arm is testable through its interface instead of being buried in inline closures.
+`service.BookOps`; the deep module over [[LibraryStore]] holding the library-touching steps every derived-artifact job shares — `Open` (the book's bytes), `PrimaryHash` (provenance, via [[Primary hash]]), `OpenMarkdown`, and `RecordDerived` (the finalize tail, below). The job registry consumes it and declares job wiring instead of restating library plumbing per job; the resolve-library-fails arm is testable through its interface instead of being buried in inline closures.
+
+### Derived record
+
+`BookOps.RecordDerived(book, srcPath, kind)` → `DerivedRecord{FileID, Hash, Location, Size, Mtime}`; the one finalize tail every derived-artifact job ends with (#307): hash the staged bytes, place them via [[Derived artifact placement]], and land the `files` row — updating the row a previous generation left at the same location rather than violating `UNIQUE(library_id, location)` on regeneration. The ordering is the module's, not the callers': hash strictly before placement (placement consumes the staged file, and `content_hash` is what the [[Relocate by hash]] safety net keys on), and a files-row lookup failure that is not "no row" is an error — falling through to Insert is exactly the constraint violation the lookup exists to prevent, which is the drift the previous two hand-written copies (generated EPUB vs narration finalize) had already grown. Markdown is the one kind that records no `files` row (ADR-0033 §4 — machine feed, not a library artifact); that exception lives here, so `FileID` is empty for it and no worker restates the rule. Workers take it as a per-kind closure via `Recorder(kind)`, the record-side shape `FinalizeDeps`/`EpubRenderDeps`/`MarkdownRenditionDeps` share.
 
 ### Primary hash
 

--- a/internal/queue/registry.go
+++ b/internal/queue/registry.go
@@ -104,7 +104,7 @@ func registry(deps Deps) []registration {
 	// shares (#299): open the book, read its provenance hash, open its
 	// markdown, place a derived file. The registry declares which job
 	// gets which operation; the library plumbing lives in the module.
-	bookOps := service.NewBookOps(deps.LibStore)
+	bookOps := service.NewBookOps(deps.LibStore, deps.FileRepo)
 
 	// Settings is read per job so an admin can change model, language or
 	// cap without a restart. Registered unconditionally, like the email
@@ -161,7 +161,7 @@ func registry(deps Deps) []registration {
 		Open:       bookOps.Open,
 		SourceHash: bookOps.PrimaryHash,
 		Convert:    (&service.ConverterClient{}).Convert,
-		Place:      bookOps.Placer(service.DerivedMarkdown),
+		Record:     bookOps.Recorder(service.DerivedMarkdown),
 	}
 
 	// Generated EPUBs (ADR-0034): the second converter stage, chained
@@ -173,8 +173,7 @@ func registry(deps Deps) []registration {
 		Markdown:   markdownFeed,
 		SourceHash: bookOps.PrimaryHash,
 		Render:     (&service.ConverterClient{}).RenderEPUB,
-		Place:      bookOps.Placer(service.DerivedEPUB),
-		Files:      deps.FileRepo,
+		Record:     bookOps.Recorder(service.DerivedEPUB),
 	}
 
 	// publishAudiobook is the SSE side of every audiobook state change —
@@ -203,13 +202,12 @@ func registry(deps Deps) []registration {
 		Report:  deps.AudiobookSvc,
 		Fail:    deps.AudiobookSvc.FailRun,
 		Books:   deps.Books,
-		Files:   deps.FileRepo,
 		Staging: deps.Staging,
-		// Deliberately the derived placement rather than the generic
+		// Deliberately the derived recording rather than the generic
 		// Placer: the book's folder already exists, and Placer would
 		// answer that with a "Title (2)" sibling — a second leaf that
 		// scan reads as a second book.
-		Place: bookOps.Placer(service.DerivedNarration),
+		Record: bookOps.Recorder(service.DerivedNarration),
 	}
 	if deps.Covers != nil {
 		finalize.Cover = deps.Covers.Open

--- a/internal/service/book_ops.go
+++ b/internal/service/book_ops.go
@@ -4,13 +4,18 @@ package service
 
 import (
 	"context"
+	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
+	"os"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/blackforge/embookshelf/internal/layout"
 	"github.com/blackforge/embookshelf/internal/model"
+	"github.com/blackforge/embookshelf/internal/repo"
 )
 
 // DerivedKind names a derived artifact a book can grow: the machine or
@@ -91,11 +96,21 @@ func (h *LibraryHandle) PlaceDerived(
 // inline closures (#299).
 type BookOps struct {
 	store LibraryStore
+	files DerivedFiles
 	hash  func(context.Context, model.Book) []byte
 }
 
-func NewBookOps(store LibraryStore) *BookOps {
-	return &BookOps{store: store, hash: NewPrimaryHash(store)}
+// DerivedFiles is the files-table slice RecordDerived needs to land a
+// derived artifact's row, reusing the row a previous generation left at
+// the same location.
+type DerivedFiles interface {
+	GetByLocation(ctx context.Context, libraryID, location string) (model.File, error)
+	SetContentHash(ctx context.Context, fileID string, hash []byte, size int64, mtime time.Time) error
+	Insert(ctx context.Context, f model.File) (model.File, error)
+}
+
+func NewBookOps(store LibraryStore, files DerivedFiles) *BookOps {
+	return &BookOps{store: store, files: files, hash: NewPrimaryHash(store)}
 }
 
 // Open yields the book's bytes as a stream — the converter POST body's
@@ -134,20 +149,103 @@ func (o *BookOps) OpenMarkdown(ctx context.Context, book model.Book, location st
 	}{io.NewSectionReader(src, 0, src.Size()), src}, nil
 }
 
-// PlaceDerived places one derived artifact into the book's own folder.
-func (o *BookOps) PlaceDerived(
-	ctx context.Context, book model.Book, srcPath string, kind DerivedKind,
-) (PlaceResult, error) {
-	handle, err := o.store.For(ctx, book.LibraryID)
-	if err != nil {
-		return PlaceResult{}, fmt.Errorf("resolve library: %w", err)
-	}
-	return handle.PlaceDerived(ctx, book, srcPath, kind)
+// DerivedRecord is what recording a derived artifact established: where
+// the bytes landed and, for kinds the catalog tracks, the files row
+// holding them. FileID is empty for markdown — machine feed, no files
+// row (ADR-0033 §4).
+type DerivedRecord struct {
+	FileID   string
+	Hash     []byte
+	Location string
+	Size     int64
+	Mtime    time.Time
 }
 
-// Placer binds PlaceDerived to one kind, in the shape worker deps take.
-func (o *BookOps) Placer(kind DerivedKind) func(context.Context, model.Book, string) (PlaceResult, error) {
-	return func(ctx context.Context, book model.Book, srcPath string) (PlaceResult, error) {
-		return o.PlaceDerived(ctx, book, srcPath, kind)
+// RecordDerived is the finalize tail every derived-artifact job shares:
+// hash the staged bytes, place them in the book's own folder, and land
+// the files row — updating the row a previous generation left at the
+// same location rather than violating UNIQUE(library_id, location) on
+// regeneration (#307).
+//
+// The order is the module's to own, not the callers': the hash comes
+// first because placement consumes the staged file, and content_hash is
+// the identity the library scan's rename safety net keys on. A lookup
+// failure that is not "no row" is an error — falling through to Insert
+// is exactly the constraint violation the lookup exists to prevent.
+func (o *BookOps) RecordDerived(
+	ctx context.Context, book model.Book, srcPath string, kind DerivedKind,
+) (DerivedRecord, error) {
+	handle, err := o.store.For(ctx, book.LibraryID)
+	if err != nil {
+		return DerivedRecord{}, fmt.Errorf("resolve library: %w", err)
 	}
+
+	var hash []byte
+	if kind != DerivedMarkdown {
+		if hash, err = hashStaged(srcPath); err != nil {
+			return DerivedRecord{}, fmt.Errorf("hash %s: %w", kind, err)
+		}
+	}
+
+	placed, err := handle.PlaceDerived(ctx, book, srcPath, kind)
+	if err != nil {
+		return DerivedRecord{}, fmt.Errorf("place %s: %w", kind, err)
+	}
+	rec := DerivedRecord{
+		Hash:     hash,
+		Location: placed.Location,
+		Size:     placed.Size,
+		Mtime:    placed.Mtime,
+	}
+	if kind == DerivedMarkdown {
+		return rec, nil
+	}
+
+	existing, err := o.files.GetByLocation(ctx, book.LibraryID, placed.Location)
+	switch {
+	case err == nil:
+		if err := o.files.SetContentHash(ctx, existing.ID, hash, placed.Size, placed.Mtime); err != nil {
+			return DerivedRecord{}, fmt.Errorf("refresh files row %s: %w", existing.ID, err)
+		}
+		rec.FileID = existing.ID
+	case errors.Is(err, repo.ErrNotFound):
+		inserted, err := o.files.Insert(ctx, model.File{
+			LibraryID:   book.LibraryID,
+			BookID:      book.ID,
+			Location:    placed.Location,
+			Size:        placed.Size,
+			Mtime:       placed.Mtime,
+			ContentHash: hash,
+			Format:      derivedSpecs[kind].format,
+		})
+		if err != nil {
+			return DerivedRecord{}, fmt.Errorf("insert files row at %s: %w", placed.Location, err)
+		}
+		rec.FileID = inserted.ID
+	default:
+		return DerivedRecord{}, fmt.Errorf("look up files row at %s: %w", placed.Location, err)
+	}
+	return rec, nil
+}
+
+// Recorder binds RecordDerived to one kind, in the shape worker deps
+// take — the record-side twin of Placer.
+func (o *BookOps) Recorder(kind DerivedKind) func(context.Context, model.Book, string) (DerivedRecord, error) {
+	return func(ctx context.Context, book model.Book, srcPath string) (DerivedRecord, error) {
+		return o.RecordDerived(ctx, book, srcPath, kind)
+	}
+}
+
+// hashStaged streams a staged artifact through sha256.
+func hashStaged(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return nil, err
+	}
+	return h.Sum(nil), nil
 }

--- a/internal/service/book_ops_test.go
+++ b/internal/service/book_ops_test.go
@@ -48,7 +48,7 @@ func TestDerivedKeyTable(t *testing.T) {
 // untestable there (#299): every operation surfaces the failure through
 // the module's own interface instead of a nil dereference downstream.
 func TestBookOpsResolveLibraryFailure(t *testing.T) {
-	ops := service.NewBookOps(unresolvableStore{err: errors.New("backend down")})
+	ops := service.NewBookOps(unresolvableStore{err: errors.New("backend down")}, nil)
 	ctx := context.Background()
 	book := model.Book{ID: "b1", LibraryID: "l1", Title: "T", Author: "A"}
 
@@ -57,9 +57,6 @@ func TestBookOpsResolveLibraryFailure(t *testing.T) {
 	}
 	if _, err := ops.OpenMarkdown(ctx, book, "A/T/T.md"); err == nil || !strings.Contains(err.Error(), "resolve library") {
 		t.Errorf("OpenMarkdown: err = %v, want a resolve-library failure", err)
-	}
-	if _, err := ops.PlaceDerived(ctx, book, "/tmp/x", service.DerivedMarkdown); err == nil || !strings.Contains(err.Error(), "resolve library") {
-		t.Errorf("PlaceDerived: err = %v, want a resolve-library failure", err)
 	}
 	// PrimaryHash is the warn-and-degrade seam (#297): no hash, no error.
 	if got := ops.PrimaryHash(ctx, book); got != nil {

--- a/internal/service/record_derived_test.go
+++ b/internal/service/record_derived_test.go
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/blackforge/embookshelf/internal/model"
+	"github.com/blackforge/embookshelf/internal/repo"
+	"github.com/blackforge/embookshelf/internal/storage/local"
+)
+
+// recordingDerivedFiles is a DerivedFiles fake whose lookup answer is
+// programmable, recording what the record path did to the files table.
+type recordingDerivedFiles struct {
+	lookupFile model.File
+	lookupErr  error
+
+	setID    string
+	setHash  []byte
+	setSize  int64
+	inserted *model.File
+}
+
+func (f *recordingDerivedFiles) GetByLocation(_ context.Context, _, _ string) (model.File, error) {
+	return f.lookupFile, f.lookupErr
+}
+
+func (f *recordingDerivedFiles) SetContentHash(_ context.Context, fileID string, hash []byte, size int64, _ time.Time) error {
+	f.setID, f.setHash, f.setSize = fileID, hash, size
+	return nil
+}
+
+func (f *recordingDerivedFiles) Insert(_ context.Context, file model.File) (model.File, error) {
+	file.ID = "inserted-file"
+	f.inserted = &file
+	return file, nil
+}
+
+// derivedFixture stands up a real local library in a temp dir, a staged
+// artifact holding content, and a BookOps over both.
+func derivedFixture(t *testing.T, files *recordingDerivedFiles, content string) (*BookOps, model.Book, string) {
+	t.Helper()
+	root := t.TempDir()
+	fs, err := local.New("/")
+	if err != nil {
+		t.Fatalf("local.New: %v", err)
+	}
+	handle := &LibraryHandle{
+		Library: model.Library{ID: "l1", Path: root},
+		Storage: fs,
+	}
+	ops := NewBookOps(&fakeLibStore{handle: handle}, files)
+
+	src := filepath.Join(t.TempDir(), "staged.bin")
+	if err := os.WriteFile(src, []byte(content), 0o644); err != nil {
+		t.Fatalf("write staged file: %v", err)
+	}
+	book := model.Book{ID: "b1", LibraryID: "l1", Title: "Dune", Author: "Frank Herbert"}
+	return ops, book, src
+}
+
+// TestRecordDerivedTransientLookupErrorIsAnError — the drift #307 exists
+// to close: a lookup failure that is not "no row" must surface as an
+// error, never fall through to an Insert that violates
+// UNIQUE(library_id, location) on regeneration.
+func TestRecordDerivedTransientLookupErrorIsAnError(t *testing.T) {
+	files := &recordingDerivedFiles{lookupErr: errors.New("connection reset")}
+	ops, book, src := derivedFixture(t, files, "epub bytes")
+
+	_, err := ops.RecordDerived(context.Background(), book, src, DerivedEPUB)
+	if err == nil || !strings.Contains(err.Error(), "connection reset") {
+		t.Fatalf("err = %v, want the transient lookup failure surfaced", err)
+	}
+	if files.inserted != nil {
+		t.Fatalf("Insert ran on a transient lookup error: %+v", *files.inserted)
+	}
+}
+
+// TestRecordDerivedUpdatesExistingRow — regeneration lands on the same
+// key, so the previous rendition's row is updated, not duplicated.
+func TestRecordDerivedUpdatesExistingRow(t *testing.T) {
+	files := &recordingDerivedFiles{lookupFile: model.File{ID: "f-old"}}
+	ops, book, src := derivedFixture(t, files, "epub bytes")
+
+	rec, err := ops.RecordDerived(context.Background(), book, src, DerivedEPUB)
+	if err != nil {
+		t.Fatalf("RecordDerived: %v", err)
+	}
+	if rec.FileID != "f-old" {
+		t.Errorf("FileID = %q, want the existing row's id", rec.FileID)
+	}
+	if files.setID != "f-old" || files.setSize != int64(len("epub bytes")) {
+		t.Errorf("SetContentHash(%q, size %d), want the existing row refreshed with the new size", files.setID, files.setSize)
+	}
+	if files.inserted != nil {
+		t.Errorf("Insert ran although the location already had a row")
+	}
+}
+
+// TestRecordDerivedInsertsWhenNotFound — a first generation inserts the
+// row, format per kind, hash of the staged bytes computed before
+// placement consumed the file.
+func TestRecordDerivedInsertsWhenNotFound(t *testing.T) {
+	kinds := map[DerivedKind]string{
+		DerivedEPUB:      "EPUB",
+		DerivedNarration: "MP3",
+	}
+	for kind, format := range kinds {
+		t.Run(string(kind), func(t *testing.T) {
+			files := &recordingDerivedFiles{lookupErr: repo.ErrNotFound}
+			ops, book, src := derivedFixture(t, files, "artifact bytes")
+
+			rec, err := ops.RecordDerived(context.Background(), book, src, kind)
+			if err != nil {
+				t.Fatalf("RecordDerived: %v", err)
+			}
+			if rec.FileID != "inserted-file" {
+				t.Errorf("FileID = %q, want the inserted row's id", rec.FileID)
+			}
+			if files.inserted == nil {
+				t.Fatal("no files row inserted")
+			}
+			if files.inserted.Format != format {
+				t.Errorf("Format = %q, want %q", files.inserted.Format, format)
+			}
+			if files.inserted.BookID != "b1" || files.inserted.LibraryID != "l1" {
+				t.Errorf("row book/library = %q/%q, want b1/l1", files.inserted.BookID, files.inserted.LibraryID)
+			}
+			want := sha256.Sum256([]byte("artifact bytes"))
+			if !bytes.Equal(files.inserted.ContentHash, want[:]) {
+				t.Errorf("ContentHash = %x, want sha256 of the staged bytes", files.inserted.ContentHash)
+			}
+			if !bytes.Equal(rec.Hash, want[:]) {
+				t.Errorf("rec.Hash = %x, want sha256 of the staged bytes", rec.Hash)
+			}
+			// Placement consumed the staged file — which is why the hash
+			// has to be taken first; a post-place hash has nothing to read.
+			if _, err := os.Stat(src); !os.IsNotExist(err) {
+				t.Errorf("staged file still present: placement did not consume it")
+			}
+		})
+	}
+}
+
+// TestRecordDerivedMarkdownRecordsNoFilesRow — ADR-0033 §4: markdown is
+// machine feed, not a library artifact; the catalog never sees it.
+func TestRecordDerivedMarkdownRecordsNoFilesRow(t *testing.T) {
+	files := &recordingDerivedFiles{lookupErr: errors.New("must not be asked")}
+	ops, book, src := derivedFixture(t, files, "# markdown")
+
+	rec, err := ops.RecordDerived(context.Background(), book, src, DerivedMarkdown)
+	if err != nil {
+		t.Fatalf("RecordDerived: %v", err)
+	}
+	if files.inserted != nil || files.setID != "" {
+		t.Errorf("markdown touched the files table: inserted=%v set=%q", files.inserted, files.setID)
+	}
+	if rec.FileID != "" {
+		t.Errorf("FileID = %q, want empty for markdown", rec.FileID)
+	}
+	if rec.Location == "" || rec.Size != int64(len("# markdown")) {
+		t.Errorf("record = %+v, want the placement's location and size", rec)
+	}
+}
+
+// failingLibStore refuses every resolve, the in-package twin of
+// service_test's unresolvableStore.
+type failingLibStore struct{ err error }
+
+func (s failingLibStore) For(context.Context, string) (*LibraryHandle, error) {
+	return nil, s.err
+}
+
+// TestRecordDerivedResolveLibraryFailure — the resolve arm surfaces
+// through the module's interface, like every other BookOps operation.
+func TestRecordDerivedResolveLibraryFailure(t *testing.T) {
+	ops := NewBookOps(failingLibStore{err: errors.New("backend down")}, &recordingDerivedFiles{})
+	book := model.Book{ID: "b1", LibraryID: "l1", Title: "T", Author: "A"}
+
+	src := filepath.Join(t.TempDir(), "staged.bin")
+	if err := os.WriteFile(src, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write staged file: %v", err)
+	}
+	if _, err := ops.RecordDerived(context.Background(), book, src, DerivedEPUB); err == nil || !strings.Contains(err.Error(), "resolve library") {
+		t.Errorf("err = %v, want a resolve-library failure", err)
+	}
+}

--- a/internal/task/audiobook_finalize.go
+++ b/internal/task/audiobook_finalize.go
@@ -10,12 +10,10 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"time"
 
 	"github.com/blackforge/embookshelf/internal/audio"
 	"github.com/blackforge/embookshelf/internal/jobs"
 	"github.com/blackforge/embookshelf/internal/model"
-	"github.com/blackforge/embookshelf/internal/repo"
 	"github.com/blackforge/embookshelf/internal/service"
 )
 
@@ -46,27 +44,20 @@ type bookAudioWriter interface {
 	UpdateAudio(ctx context.Context, id string, durationSeconds *int, narrator string, chapters []model.Chapter) error
 }
 
-// narrationFiles is the files-table slice finalize needs to record the
-// placed audio, reusing the row a previous rendition left behind.
-type narrationFiles interface {
-	GetByLocation(ctx context.Context, libraryID, location string) (model.File, error)
-	SetContentHash(ctx context.Context, fileID string, hash []byte, size int64, mtime time.Time) error
-	Insert(ctx context.Context, f model.File) (model.File, error)
-}
-
 // FinalizeDeps groups the seams the finalize worker needs.
 type FinalizeDeps struct {
 	Runs   finalizeStore
 	Report narrationReporter
 	Books  bookAudioWriter
-	Files  narrationFiles
-	// Place moves the assembled file into the book's own folder.
+	// Record is the shared finalize tail (#307): hash the assembled
+	// file, place it into the book's own folder, and land the files row
+	// — reusing the row a previous rendition left at the same location.
 	// Narrower than a LibraryStore on purpose: handing over the whole
-	// store would let a later edit reach more than placing one file
+	// store would let a later edit reach more than recording one file
 	// needs. Why the wiring behind this field must use the derived
 	// placement rather than the generic Placer is that wiring's
 	// decision to explain, not this worker's — see the registry.
-	Place func(ctx context.Context, book model.Book, srcPath string) (service.PlaceResult, error)
+	Record func(ctx context.Context, book model.Book, srcPath string) (service.DerivedRecord, error)
 	// Cover supplies the art embedded in the finished file. Nil-able and
 	// best effort: a narration without embedded art is still a good
 	// narration.
@@ -137,28 +128,13 @@ func AudiobookFinalize(ctx context.Context, a jobs.AudiobookFinalizeArgs, deps F
 	}
 	defer func() { _ = os.Remove(assembled) }()
 
-	// Hashed before placement, because placement consumes the file:
-	// content_hash is the authoritative identity of every other files row
-	// (CONTEXT, Content hash) and a narration with a NULL one is invisible
-	// to the rename safety net a library scan runs on.
-	hash, err := hashFile(ctx, assembled)
+	// Hash, placement and the files row are one call: the tail is shared
+	// with every other derived artifact (#307), and its ordering — hash
+	// before placement consumes the file, update-don't-duplicate on
+	// regeneration — lives there, not here.
+	rec, err := deps.Record(ctx, book, assembled)
 	if err != nil {
-		return fail(ctx, deps, a.BookID, fmt.Errorf("hash narration: %w", err))
-	}
-
-	placed, err := deps.Place(ctx, book, assembled)
-	if err != nil {
-		return fail(ctx, deps, a.BookID, fmt.Errorf("place narration: %w", err))
-	}
-
-	// Regeneration lands on the same key, so the previous rendition's row
-	// is updated rather than duplicated. Inserting unconditionally would
-	// violate files' UNIQUE(library_id, location) on the second run, and
-	// on a backend it would leave the old row pointing at bytes the new
-	// upload has already overwritten.
-	fileRow, err := upsertNarrationFile(ctx, deps, book, placed, hash)
-	if err != nil {
-		return fail(ctx, deps, a.BookID, fmt.Errorf("record narration file: %w", err))
+		return fail(ctx, deps, a.BookID, fmt.Errorf("record narration: %w", err))
 	}
 
 	// books.chapters and duration_seconds are what the existing audio
@@ -174,42 +150,11 @@ func AudiobookFinalize(ctx context.Context, a jobs.AudiobookFinalizeArgs, deps F
 	// publish here: a run the user cancelled while this was assembling
 	// does not move, and telling open pages otherwise would contradict
 	// the cancel they just watched land.
-	if err := deps.Report.NarrationAssembled(ctx, a.BookID, fileRow.ID, totalMS); err != nil {
+	if err := deps.Report.NarrationAssembled(ctx, a.BookID, rec.FileID, totalMS); err != nil {
 		return fmt.Errorf("mark ready: %w", err)
 	}
 	deps.Staging.Clean(a.BookID)
 	return nil
-}
-
-// upsertNarrationFile records the placed audio, reusing the row a
-// previous rendition left at the same location.
-func upsertNarrationFile(
-	ctx context.Context,
-	deps FinalizeDeps,
-	book model.Book,
-	placed service.PlaceResult,
-	hash []byte,
-) (model.File, error) {
-	existing, err := deps.Files.GetByLocation(ctx, book.LibraryID, placed.Location)
-	if err == nil {
-		if serr := deps.Files.SetContentHash(ctx, existing.ID, hash, placed.Size, placed.Mtime); serr != nil {
-			return model.File{}, serr
-		}
-		existing.ContentHash, existing.Size, existing.Mtime = hash, placed.Size, placed.Mtime
-		return existing, nil
-	}
-	if !errors.Is(err, repo.ErrNotFound) {
-		return model.File{}, err
-	}
-	return deps.Files.Insert(ctx, model.File{
-		LibraryID:   book.LibraryID,
-		BookID:      book.ID,
-		Location:    placed.Location,
-		Size:        placed.Size,
-		Mtime:       placed.Mtime,
-		ContentHash: hash,
-		Format:      "MP3",
-	})
 }
 
 // assemble concatenates the staged segments, writes the ID3 tag, and

--- a/internal/task/audiobook_finalize_test.go
+++ b/internal/task/audiobook_finalize_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/blackforge/embookshelf/internal/audio/audiotest"
 	"github.com/blackforge/embookshelf/internal/jobs"
 	"github.com/blackforge/embookshelf/internal/model"
-	"github.com/blackforge/embookshelf/internal/repo"
 	"github.com/blackforge/embookshelf/internal/service"
 	"github.com/blackforge/embookshelf/internal/task"
 )
@@ -73,37 +72,6 @@ func (f *fakeFinalizeRuns) NarrationAssembled(_ context.Context, _, fileID strin
 	return nil
 }
 
-type fakeFiles struct {
-	existing  *model.File
-	inserted  []model.File
-	hashSets  int
-	nextID    string
-	lookupErr error
-}
-
-func (f *fakeFiles) GetByLocation(context.Context, string, string) (model.File, error) {
-	if f.existing != nil {
-		return *f.existing, nil
-	}
-	if f.lookupErr != nil {
-		return model.File{}, f.lookupErr
-	}
-	return model.File{}, repo.ErrNotFound
-}
-
-func (f *fakeFiles) SetContentHash(context.Context, string, []byte, int64, time.Time) error {
-	f.hashSets++
-	return nil
-}
-
-func (f *fakeFiles) Insert(_ context.Context, file model.File) (model.File, error) {
-	if f.nextID != "" {
-		file.ID = f.nextID
-	}
-	f.inserted = append(f.inserted, file)
-	return file, nil
-}
-
 // ---------------------------------------------------------------------------
 // Harness
 // ---------------------------------------------------------------------------
@@ -112,11 +80,10 @@ type finalizeHarness struct {
 	deps      task.FinalizeDeps
 	runs      *fakeFinalizeRuns
 	books     *fakeBooks
-	files     *fakeFiles
 	staging   task.Staging
 	published int
-	placed    int
-	placeErr  error
+	recorded  int
+	recordErr error
 }
 
 // newFinalizeHarness stages two done segments on disk, which is the
@@ -131,7 +98,6 @@ func newFinalizeHarness(t *testing.T) *finalizeHarness {
 			ID: "b1", LibraryID: "lib1", Title: "Dune", Author: "Frank Herbert", Format: "EPUB",
 			Narrator: "Ada Lovelace",
 		}},
-		files:   &fakeFiles{nextID: "file-1"},
 		staging: tempStaging(t),
 	}
 
@@ -153,18 +119,16 @@ func newFinalizeHarness(t *testing.T) *finalizeHarness {
 	h.deps = task.FinalizeDeps{
 		Runs:  h.runs,
 		Books: h.books,
-		Files: h.files,
-		Place: func(_ context.Context, _ model.Book, srcPath string) (service.PlaceResult, error) {
-			h.placed++
-			if h.placeErr != nil {
-				return service.PlaceResult{}, h.placeErr
+		Record: func(_ context.Context, _ model.Book, srcPath string) (service.DerivedRecord, error) {
+			h.recorded++
+			if h.recordErr != nil {
+				return service.DerivedRecord{}, h.recordErr
 			}
-			// Placement consumes the source file in production; the fake
-			// mirrors that so a regression that hashes after placement
-			// fails here instead of passing by accident.
+			// Recording consumes the source file in production (placement
+			// is inside it); the fake mirrors that.
 			_ = os.Remove(srcPath)
-			return service.PlaceResult{
-				Location: "Dune/Dune.mp3", Size: 1234, Mtime: time.Unix(0, 0).UTC(),
+			return service.DerivedRecord{
+				FileID: "file-1", Location: "Dune/Dune.mp3", Size: 1234, Mtime: time.Unix(0, 0).UTC(),
 			}, nil
 		},
 		// The one module that marks a run failed also publishes, so the
@@ -213,8 +177,8 @@ func TestFinalizeSweepsACanceledRunWithoutPublishing(t *testing.T) {
 	if h.published != 0 {
 		t.Errorf("published %d times for a canceled run", h.published)
 	}
-	if len(h.files.inserted) != 0 {
-		t.Errorf("inserted %d files rows for a canceled run", len(h.files.inserted))
+	if h.recorded != 0 {
+		t.Errorf("recorded %d files for a canceled run", h.recorded)
 	}
 }
 
@@ -225,8 +189,8 @@ func TestFinalizeIsANoOpForAReadyRun(t *testing.T) {
 	if err := h.run(); err != nil {
 		t.Fatalf("AudiobookFinalize: %v", err)
 	}
-	if h.placed != 0 || h.published != 0 {
-		t.Errorf("placed=%d published=%d, want neither on a finished run", h.placed, h.published)
+	if h.recorded != 0 || h.published != 0 {
+		t.Errorf("recorded=%d published=%d, want neither on a finished run", h.recorded, h.published)
 	}
 }
 
@@ -239,8 +203,8 @@ func TestFinalizeDefersWhileASegmentIsOutstanding(t *testing.T) {
 	if err := h.run(); err != nil {
 		t.Fatalf("AudiobookFinalize: %v", err)
 	}
-	if h.placed != 0 {
-		t.Errorf("placed %d times with a segment still outstanding", h.placed)
+	if h.recorded != 0 {
+		t.Errorf("recorded %d times with a segment still outstanding", h.recorded)
 	}
 	if h.published != 0 {
 		t.Errorf("published %d times before the run finished", h.published)
@@ -267,10 +231,12 @@ func TestFinalizeFailsARunWithNoSegments(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // Retry re-enqueues only the segments that never finished, so every
-// paid-for segment has to survive a failed finalize.
-func TestFinalizeRetainsStagingWhenPlacementFails(t *testing.T) {
+// paid-for segment has to survive a failed finalize. The refusal can be
+// the placement or the files row — both are inside Record now, and both
+// fail the run the same way, naming the step.
+func TestFinalizeRetainsStagingWhenRecordingFails(t *testing.T) {
 	h := newFinalizeHarness(t)
-	h.placeErr = errors.New("backend refused the upload")
+	h.recordErr = errors.New("backend refused the upload")
 
 	if err := h.run(); err != nil {
 		t.Fatalf("AudiobookFinalize returned %v, want nil so River stops", err)
@@ -278,11 +244,14 @@ func TestFinalizeRetainsStagingWhenPlacementFails(t *testing.T) {
 	if len(h.runs.states) != 1 || h.runs.states[0].State != model.AudiobookFailed {
 		t.Fatalf("states = %+v, want one failed write", h.runs.states)
 	}
+	if !strings.Contains(h.runs.states[0].Msg, "record narration") {
+		t.Errorf("failure message = %q, want it to name the failing step", h.runs.states[0].Msg)
+	}
 	if !h.stagingExists() {
 		t.Error("a failed finalize reclaimed the staging — Retry would have to buy it again")
 	}
-	if h.placed != 1 {
-		t.Errorf("placed %d times, want exactly one placement attempt before the failure", h.placed)
+	if h.recorded != 1 {
+		t.Errorf("recorded %d times, want exactly one attempt before the failure", h.recorded)
 	}
 	if h.published != 1 {
 		t.Errorf("published %d times, want exactly one terminal event", h.published)
@@ -303,21 +272,18 @@ func TestFinalizeReportsTheNarrationAndSweeps(t *testing.T) {
 	if err := h.run(); err != nil {
 		t.Fatalf("AudiobookFinalize: %v", err)
 	}
-	if len(h.files.inserted) != 1 {
-		t.Fatalf("inserted %d files rows, want 1", len(h.files.inserted))
-	}
-	got := h.files.inserted[0]
-	if got.Format != "MP3" {
-		t.Errorf("format = %q, want MP3", got.Format)
-	}
-	if len(got.ContentHash) == 0 {
-		t.Error("content_hash is empty — the rename safety net a library scan runs is blind to it")
+	// The files row's shape — format, content hash, update-don't-duplicate
+	// — is RecordDerived's, pinned by the service tests (#307). What is
+	// this worker's: one record of the assembled file, and the run marked
+	// ready with the id it answered.
+	if h.recorded != 1 {
+		t.Fatalf("recorded %d times, want 1", h.recorded)
 	}
 	if h.runs.ready == nil {
 		t.Fatal("the run was never marked ready")
 	}
 	if h.runs.ready.FileID != "file-1" {
-		t.Errorf("file id = %q, want the inserted row's", h.runs.ready.FileID)
+		t.Errorf("file id = %q, want the recorded row's", h.runs.ready.FileID)
 	}
 	_, perSegMS, err := audio.Payload(audiotest.Frames(4))
 	if err != nil {
@@ -353,27 +319,6 @@ func TestFinalizeReportsTheNarrationAndSweeps(t *testing.T) {
 	}
 }
 
-// Regeneration lands on the same key. Inserting unconditionally would
-// violate files' UNIQUE(library_id, location), and on a backend it would
-// leave the old row pointing at bytes the new upload overwrote.
-func TestFinalizeUpdatesTheRowAPreviousRenditionLeft(t *testing.T) {
-	h := newFinalizeHarness(t)
-	h.files.existing = &model.File{ID: "old-file", LibraryID: "lib1", BookID: "b1", Location: "Dune/Dune.mp3"}
-
-	if err := h.run(); err != nil {
-		t.Fatalf("AudiobookFinalize: %v", err)
-	}
-	if len(h.files.inserted) != 0 {
-		t.Errorf("inserted %d rows, want the existing one reused", len(h.files.inserted))
-	}
-	if h.files.hashSets != 1 {
-		t.Errorf("set the hash %d times, want 1", h.files.hashSets)
-	}
-	if h.runs.ready == nil || h.runs.ready.FileID != "old-file" {
-		t.Errorf("ready points at %+v, want the reused row", h.runs.ready)
-	}
-}
-
 // A narration without embedded art is still a good narration.
 func TestFinalizeSucceedsWithNoCoverSource(t *testing.T) {
 	h := newFinalizeHarness(t)
@@ -401,16 +346,16 @@ func TestFinalizeEmbedsTheSuppliedCover(t *testing.T) {
 	}
 
 	var tag []byte
-	h.deps.Place = func(_ context.Context, _ model.Book, srcPath string) (service.PlaceResult, error) {
-		h.placed++
+	h.deps.Record = func(_ context.Context, _ model.Book, srcPath string) (service.DerivedRecord, error) {
+		h.recorded++
 		b, err := os.ReadFile(srcPath)
 		if err != nil {
 			t.Fatalf("read assembled file: %v", err)
 		}
 		tag = b
 		_ = os.Remove(srcPath)
-		return service.PlaceResult{
-			Location: "Dune/Dune.mp3", Size: 1234, Mtime: time.Unix(0, 0).UTC(),
+		return service.DerivedRecord{
+			FileID: "file-1", Location: "Dune/Dune.mp3", Size: 1234, Mtime: time.Unix(0, 0).UTC(),
 		}, nil
 	}
 
@@ -419,24 +364,5 @@ func TestFinalizeEmbedsTheSuppliedCover(t *testing.T) {
 	}
 	if !bytes.Contains(tag, []byte("APIC")) || !bytes.Contains(tag, []byte(coverBytes)) {
 		t.Error("the cover never reached the finished file's ID3 tag")
-	}
-}
-
-// A files lookup failure that is not "row doesn't exist" has to fail the
-// run rather than fall through to Insert, which would collide with
-// files' UNIQUE(library_id, location) once the row it should have found
-// turns out to exist after all.
-func TestFinalizeFailsWhenTheFilesLookupErrors(t *testing.T) {
-	h := newFinalizeHarness(t)
-	h.files.lookupErr = errors.New("db unavailable")
-
-	if err := h.run(); err != nil {
-		t.Fatalf("AudiobookFinalize returned %v, want nil so River stops", err)
-	}
-	if len(h.runs.states) != 1 || h.runs.states[0].State != model.AudiobookFailed {
-		t.Fatalf("states = %+v, want one failed write", h.runs.states)
-	}
-	if !strings.Contains(h.runs.states[0].Msg, "record narration file") {
-		t.Errorf("failure message = %q, want it to name the failing step", h.runs.states[0].Msg)
 	}
 }

--- a/internal/task/epub_render.go
+++ b/internal/task/epub_render.go
@@ -22,12 +22,6 @@ type epubRenditionStore interface {
 	MarkFailed(ctx context.Context, bookID, msg string) error
 }
 
-// epubFiles is the narrow files-repo slice the finalize step needs —
-// the narrationFiles trio, for the same regeneration reason: the
-// location is stable, so a second render must update the row that
-// exists rather than violate UNIQUE(library_id, location).
-type epubFiles = narrationFiles
-
 // epubTextCap bounds how much markdown feeds the render. Deliberately
 // enormous — the EPUB wants the whole book, unlike the guide's cost
 // dial — while still refusing a pathological rendition.
@@ -45,8 +39,11 @@ type EpubRenderDeps struct {
 	// is answered against, not the markdown.
 	SourceHash func(context.Context, model.Book) []byte
 	Render     func(ctx context.Context, baseURL string, req service.EpubRenderRequest) (service.ConvertResult, error)
-	Place      func(context.Context, model.Book, string) (service.PlaceResult, error)
-	Files      epubFiles
+	// Record is the shared finalize tail (#307): hash the staged EPUB,
+	// place it in the book's folder, and land the files row — updating
+	// the row a previous render left rather than violating
+	// UNIQUE(library_id, location) on regeneration.
+	Record func(context.Context, model.Book, string) (service.DerivedRecord, error)
 }
 
 // EpubRender renders one book's generated EPUB and records the outcome
@@ -141,54 +138,19 @@ func EpubRender(ctx context.Context, a jobs.EpubRenderArgs, deps EpubRenderDeps)
 			return "", false, nil
 		},
 		func(ctx context.Context) (string, bool, error) {
-			// Hash before placing — placement consumes the staged file, and
-			// the files row's content_hash is the identity scan's rename
-			// safety net keys on (same order as audiobook finalize).
-			epubHash, err := hashFile(ctx, result.Path)
-			if err != nil {
-				return "hash epub: " + err.Error(), false, fmt.Errorf("hash epub for %s: %w", a.BookID, err)
-			}
+			// The source hash (the PDF's) is read before Record consumes
+			// the staged file; the artifact's own hash is Record's job.
 			sourceHash := deps.SourceHash(ctx, book)
 
-			placed, err := deps.Place(ctx, book, result.Path)
+			rec, err := deps.Record(ctx, book, result.Path)
 			if err != nil {
-				return "place epub: " + err.Error(), false, fmt.Errorf("place epub for %s: %w", a.BookID, err)
+				return "record epub: " + err.Error(), false, fmt.Errorf("record epub for %s: %w", a.BookID, err)
 			}
 
-			fileID, err := upsertEpubFile(ctx, deps.Files, book, placed, epubHash)
-			if err != nil {
-				return "record files row: " + err.Error(), false, fmt.Errorf("record files row for %s: %w", a.BookID, err)
-			}
-
-			if err := deps.Renditions.MarkReady(ctx, a.BookID, fileID, sourceHash, result.Version); err != nil {
+			if err := deps.Renditions.MarkReady(ctx, a.BookID, rec.FileID, sourceHash, result.Version); err != nil {
 				return "", false, fmt.Errorf("mark ready: %w", err)
 			}
 			return "", false, nil
 		},
 	)
-}
-
-// upsertEpubFile lands the generated EPUB in files without violating
-// UNIQUE(library_id, location) on regeneration — update the existing
-// row's hash if the location is already recorded, insert otherwise.
-func upsertEpubFile(ctx context.Context, files epubFiles, book model.Book, placed service.PlaceResult, hash []byte) (string, error) {
-	if existing, err := files.GetByLocation(ctx, book.LibraryID, placed.Location); err == nil {
-		if err := files.SetContentHash(ctx, existing.ID, hash, placed.Size, placed.Mtime); err != nil {
-			return "", err
-		}
-		return existing.ID, nil
-	}
-	inserted, err := files.Insert(ctx, model.File{
-		LibraryID:   book.LibraryID,
-		BookID:      book.ID,
-		Location:    placed.Location,
-		Size:        placed.Size,
-		Mtime:       placed.Mtime,
-		ContentHash: hash,
-		Format:      "EPUB",
-	})
-	if err != nil {
-		return "", err
-	}
-	return inserted.ID, nil
 }

--- a/internal/task/epub_render_test.go
+++ b/internal/task/epub_render_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/blackforge/embookshelf/internal/jobs"
 	"github.com/blackforge/embookshelf/internal/model"
@@ -38,30 +37,6 @@ func (f *fakeEpubStore) MarkFailed(_ context.Context, _, msg string) error {
 	return nil
 }
 
-type fakeEpubFiles struct {
-	byLocation map[string]model.File
-	inserted   []model.File
-	rehashee   string
-}
-
-func (f *fakeEpubFiles) GetByLocation(_ context.Context, _, location string) (model.File, error) {
-	if row, ok := f.byLocation[location]; ok {
-		return row, nil
-	}
-	return model.File{}, repo.ErrNotFound
-}
-
-func (f *fakeEpubFiles) SetContentHash(_ context.Context, id string, _ []byte, _ int64, _ time.Time) error {
-	f.rehashee = id
-	return nil
-}
-
-func (f *fakeEpubFiles) Insert(_ context.Context, row model.File) (model.File, error) {
-	row.ID = "file-new"
-	f.inserted = append(f.inserted, row)
-	return row, nil
-}
-
 func readyFeed(text string) *service.MarkdownFeed {
 	return &service.MarkdownFeed{
 		Renditions: renditionRowFake{row: model.MarkdownRendition{
@@ -79,7 +54,30 @@ func (f renditionRowFake) GetByBookID(context.Context, string) (model.MarkdownRe
 	return f.row, nil
 }
 
-func epubDeps(store *fakeEpubStore, files *fakeEpubFiles) EpubRenderDeps {
+// epubRecorder counts Record calls and mirrors production's consuming of
+// the staged file; the files-row shape itself is RecordDerived's,
+// pinned by the service tests (#307).
+type epubRecorder struct {
+	calls int
+	err   error
+}
+
+func (r *epubRecorder) record(_ context.Context, _ model.Book, src string) (service.DerivedRecord, error) {
+	r.calls++
+	if r.err != nil {
+		return service.DerivedRecord{}, r.err
+	}
+	info, err := os.Stat(src)
+	if err != nil {
+		return service.DerivedRecord{}, err
+	}
+	_ = os.Remove(src)
+	return service.DerivedRecord{
+		FileID: "file-new", Location: "A/Sample/Sample.epub", Size: info.Size(),
+	}, nil
+}
+
+func epubDeps(store *fakeEpubStore, rec *epubRecorder) EpubRenderDeps {
 	return EpubRenderDeps{
 		Config: func(context.Context) (repo.ConverterConfig, error) {
 			return repo.ConverterConfig{Enabled: true, BaseURL: "http://c"}, nil
@@ -97,21 +95,14 @@ func epubDeps(store *fakeEpubStore, files *fakeEpubFiles) EpubRenderDeps {
 			_ = f.Close()
 			return service.ConvertResult{Path: f.Name(), Version: "0.2.0"}, nil
 		},
-		Place: func(_ context.Context, _ model.Book, src string) (service.PlaceResult, error) {
-			info, err := os.Stat(src)
-			if err != nil {
-				return service.PlaceResult{}, err
-			}
-			return service.PlaceResult{Location: "A/Sample/Sample.epub", Size: info.Size()}, nil
-		},
-		Files: files,
+		Record: rec.record,
 	}
 }
 
-func TestEpubRenderHappyPathInsertsAFilesRow(t *testing.T) {
+func TestEpubRenderHappyPathRecordsTheArtifact(t *testing.T) {
 	store := &fakeEpubStore{}
-	files := &fakeEpubFiles{}
-	deps := epubDeps(store, files)
+	rec := &epubRecorder{}
+	deps := epubDeps(store, rec)
 
 	if err := EpubRender(context.Background(), jobs.EpubRenderArgs{BookID: "b1"}, deps); err != nil {
 		t.Fatalf("EpubRender: %v", err)
@@ -119,35 +110,29 @@ func TestEpubRenderHappyPathInsertsAFilesRow(t *testing.T) {
 	if !store.ready || store.fileID != "file-new" || store.version != "0.2.0" {
 		t.Fatalf("store = %+v", store)
 	}
-	if len(files.inserted) != 1 || files.inserted[0].Format != "EPUB" {
-		t.Fatalf("inserted = %+v", files.inserted)
-	}
-	if len(files.inserted[0].ContentHash) == 0 {
-		t.Fatal("files row has no content hash — scan's rename safety net keys on it")
+	if rec.calls != 1 {
+		t.Fatalf("recorded %d times, want 1", rec.calls)
 	}
 	if len(store.hash) == 0 || store.hash[0] != 0xcd {
 		t.Fatalf("source hash = %x, want the PDF's", store.hash)
 	}
 }
 
-// TestEpubRenderRegenerationReusesTheFilesRow — the location is stable,
-// so a second render updates the existing row instead of violating
-// UNIQUE(library_id, location).
-func TestEpubRenderRegenerationReusesTheFilesRow(t *testing.T) {
+// TestEpubRenderRecordFailureIsLoudAndRetryable — the recording arm
+// (hash, place, files row — all inside Record now) lands on the row and
+// stays retryable; the update-vs-insert split itself is RecordDerived's,
+// pinned by the service tests (#307).
+func TestEpubRenderRecordFailureIsLoudAndRetryable(t *testing.T) {
 	store := &fakeEpubStore{}
-	files := &fakeEpubFiles{byLocation: map[string]model.File{
-		"A/Sample/Sample.epub": {ID: "file-old"},
-	}}
-	deps := epubDeps(store, files)
+	rec := &epubRecorder{err: errors.New("backend refused the upload")}
+	deps := epubDeps(store, rec)
 
-	if err := EpubRender(context.Background(), jobs.EpubRenderArgs{BookID: "b1"}, deps); err != nil {
-		t.Fatalf("EpubRender: %v", err)
+	err := EpubRender(context.Background(), jobs.EpubRenderArgs{BookID: "b1"}, deps)
+	if err == nil || errors.Is(err, jobs.ErrDoNotRetry) {
+		t.Fatalf("err = %v, want a retryable failure", err)
 	}
-	if store.fileID != "file-old" || files.rehashee != "file-old" {
-		t.Fatalf("store.fileID = %q, rehashee = %q, want the existing row reused", store.fileID, files.rehashee)
-	}
-	if len(files.inserted) != 0 {
-		t.Fatalf("inserted a duplicate row: %+v", files.inserted)
+	if !strings.Contains(store.failed, "record epub") {
+		t.Fatalf("row error = %q, want it to name the failing step", store.failed)
 	}
 }
 
@@ -155,7 +140,7 @@ func TestEpubRenderRegenerationReusesTheFilesRow(t *testing.T) {
 // is loud on the row but transient for the queue.
 func TestEpubRenderWaitsForTheMarkdownRendition(t *testing.T) {
 	store := &fakeEpubStore{}
-	deps := epubDeps(store, &fakeEpubFiles{})
+	deps := epubDeps(store, &epubRecorder{})
 	requested := 0
 	deps.Markdown = &service.MarkdownFeed{
 		Renditions: renditionRowFake{row: model.MarkdownRendition{
@@ -180,7 +165,7 @@ func TestEpubRenderWaitsForTheMarkdownRendition(t *testing.T) {
 // message is the row's message (ADR-0034 §5).
 func TestEpubRenderPropagatesMarkdownFailureVerbatim(t *testing.T) {
 	store := &fakeEpubStore{}
-	deps := epubDeps(store, &fakeEpubFiles{})
+	deps := epubDeps(store, &epubRecorder{})
 	deps.Markdown = &service.MarkdownFeed{
 		Renditions: renditionRowFake{row: model.MarkdownRendition{
 			State: model.RenditionFailed,
@@ -201,4 +186,5 @@ func TestEpubRenderPropagatesMarkdownFailureVerbatim(t *testing.T) {
 // non-convertible) are TestMarkdownRenditionFailureArms' table plus the
 // renditionRun choreography test — what stays here is the EPUB
 // worker's own: the markdown chain (wait + verbatim propagation above)
-// and the files-row upsert.
+// and the record arm. The files-row shape lives with RecordDerived's
+// service tests (#307).

--- a/internal/task/markdown_rendition.go
+++ b/internal/task/markdown_rendition.go
@@ -42,8 +42,11 @@ type MarkdownRenditionDeps struct {
 	// Convert speaks the sidecar's wire contract and stages the answer
 	// in a temp file.
 	Convert func(ctx context.Context, baseURL string, body io.Reader) (service.ConvertResult, error)
-	// Place moves the staged markdown into the book's folder.
-	Place func(context.Context, model.Book, string) (service.PlaceResult, error)
+	// Record is the shared finalize tail (#307): places the staged
+	// markdown into the book's folder. Markdown records no files row —
+	// that exception is RecordDerived's to own (ADR-0033 §4), not this
+	// worker's to restate.
+	Record func(context.Context, model.Book, string) (service.DerivedRecord, error)
 }
 
 // ErrConverterNotConfigured is the loud "extension not configured"
@@ -120,15 +123,15 @@ func MarkdownRendition(ctx context.Context, a jobs.MarkdownRenditionArgs, deps M
 			return "", false, nil
 		},
 		func(ctx context.Context) (string, bool, error) {
-			// Hash before placing: placement consumes the staged file, and
-			// the hash is what answers "is this rendition still current".
+			// The source hash is read before Record consumes the staged
+			// file — it is what answers "is this rendition still current".
 			sourceHash := deps.SourceHash(ctx, book)
 
-			placed, err := deps.Place(ctx, book, result.Path)
+			rec, err := deps.Record(ctx, book, result.Path)
 			if err != nil {
 				return "place markdown: " + err.Error(), false, fmt.Errorf("place markdown for %s: %w", a.BookID, err)
 			}
-			if err := deps.Renditions.MarkReady(ctx, a.BookID, placed.Location, placed.Size, sourceHash, result.Version); err != nil {
+			if err := deps.Renditions.MarkReady(ctx, a.BookID, rec.Location, rec.Size, sourceHash, result.Version); err != nil {
 				return "", false, fmt.Errorf("mark ready: %w", err)
 			}
 			return "", false, nil

--- a/internal/task/markdown_rendition_test.go
+++ b/internal/task/markdown_rendition_test.go
@@ -70,12 +70,12 @@ func renditionDeps(store *fakeRenditionStore, cfg repo.ConverterConfig) Markdown
 			_ = f.Close()
 			return service.ConvertResult{Path: f.Name(), Version: "0.1.0"}, nil
 		},
-		Place: func(_ context.Context, _ model.Book, src string) (service.PlaceResult, error) {
+		Record: func(_ context.Context, _ model.Book, src string) (service.DerivedRecord, error) {
 			info, err := os.Stat(src)
 			if err != nil {
-				return service.PlaceResult{}, err
+				return service.DerivedRecord{}, err
 			}
-			return service.PlaceResult{Location: "A/Sample/Sample.md", Size: info.Size()}, nil
+			return service.DerivedRecord{Location: "A/Sample/Sample.md", Size: info.Size()}, nil
 		},
 	}
 }


### PR DESCRIPTION
Closes #307.

## What changed

- `BookOps.RecordDerived(book, srcPath, kind)` is the shared finalize tail: hash the staged bytes, place via the derived placement, land the files row. `Recorder(kind)` binds it into the shape worker deps take.
- The ordering is unrepresentable-wrong for callers: hash runs strictly before placement (placement consumes the staged file), and a files-row lookup failure that is not `ErrNotFound` is an error — the EPUB copy's fall-through-to-Insert drift (a UNIQUE(library_id, location) violation waiting on any transient lookup error) is gone.
- Markdown's no-files-row exception (ADR-0033 §4) lives in the module; `FileID` is empty for it.
- The three workers (markdown rendition, generated EPUB, narration finalize) consume `Record`; `upsertEpubFile`, `upsertNarrationFile`, the `epubFiles = narrationFiles` alias, and the now caller-less `BookOps.Placer`/`BookOps.PlaceDerived` are deleted.
- Files-row shape (format per kind, hash of staged bytes, update-don't-duplicate, transient-error refusal) is pinned by DB-free service tests; worker tests keep their choreography assertions.
- CONTEXT.md gains a "Derived record" glossary entry.

## Tests

- New: `internal/service/record_derived_test.go` — transient-lookup refusal, update-vs-insert, per-kind format, hash-before-place (asserted via the consumed staged file), markdown exception, resolve-library arm. Written first, watched fail.
- `go test ./...` green against local Postgres; `golangci-lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)