### PR TITLE
refactor(fileproc): one FormatSpecs table behind every format dispatch

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -531,6 +531,10 @@ Lived in its own `internal/extractor/` package until it had one caller and no se
 
 `fileproc.DispatchFormat(format) Processor`; the slug-keyed twin of `Dispatch`, which keys off a file extension. Both live in `fileproc` because format dispatch is that package's job. When a caller has both, the key wins: the key is what the bytes actually are, the slug is what a row claims they are.
 
+### Ingest axis
+
+`model.FormatSpec.IngestExts` + `.Audio`, and `fileproc.processors` (#308); the format vocabulary's ingest side, previously seven hand-kept switches across two packages with no parity test — which had already diverged: `.cbr` was admitted by Intake, stamped `CBZ`, then refused by `Dispatch` with the generic unsupported message. Now the table declares which extensions intake admits and what format each stamps (aliases live on their format's row: `.m4a` → M4B, the comic aliases → CBZ), plus the audio flag; `SupportedExts`, `IsSupported`, `FormatForExt`, `Dispatch`, `DispatchFormat` and `IsAudioFormat` are all derivations, held to the table by `dispatch_parity_test.go` — the fileproc sibling of the model↔UI format parity test. The one fact the table cannot hold without inverting the import stays in `fileproc`: the extension → extractor map. An **admitted extension with no processor** (`.cbr`/`.cb7` until #310, `.mobi`/`.azw3` until #311, `.fb2` until #312) fails ingest with `NoProcessorError` — a per-format "recognised but cannot be ingested" message that lands on the bookdrop row verbatim — which unwraps to `ErrUnsupportedFormat` so the worker's terminal-failure branch still refuses to retry it. The pinned no-processor set in the parity test is the work-list those three issues shrink. `IsAudioFormat` stays deliberately case-sensitive (`books.format` stores upper-case; lower-case reaching it is a bug to surface). The reMarkable device-push EPUB/PDF switch stays local on purpose — it is the device's rule, not a format property (#194).
+
 ---
 
 ## Metadata enrichment (ADRs 0008–0013)

--- a/internal/fileproc/dispatch_parity_test.go
+++ b/internal/fileproc/dispatch_parity_test.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package fileproc
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/blackforge/embookshelf/internal/model"
+)
+
+// The sibling of model's format_parity_test.go, for the fileproc tier:
+// every dispatcher here derives from model.FormatSpecs, and this file is
+// what stops the two packages re-growing hand-kept switches that
+// disagree — the state this replaced admitted .cbr at intake, stamped it
+// CBZ, then refused it at dispatch with a message calling it unsupported.
+
+// TestSupportedExtsDeriveFromTheTable — the watcher's admit set is the
+// table's ingest set, verbatim.
+func TestSupportedExtsDeriveFromTheTable(t *testing.T) {
+	if !reflect.DeepEqual(SupportedExts, model.IngestExtensions()) {
+		t.Fatalf("SupportedExts = %v\nmodel.IngestExtensions() = %v", SupportedExts, model.IngestExtensions())
+	}
+}
+
+// TestFormatForExtAgreesWithModel — one folding, not two.
+func TestFormatForExtAgreesWithModel(t *testing.T) {
+	for _, ext := range SupportedExts {
+		if got, want := FormatForExt(ext), model.IngestFormatForExt(ext); got != want || got == "" {
+			t.Errorf("FormatForExt(%q) = %q, model says %q", ext, got, want)
+		}
+	}
+	// The historical no-dot call shape keeps working.
+	if got := FormatForExt("cbr"); got != "CBZ" {
+		t.Errorf(`FormatForExt("cbr") = %q, want CBZ`, got)
+	}
+}
+
+// TestDispatchCoversEveryProcessorExt — an extension with a processor
+// dispatches to it and stamps the table's format.
+func TestDispatchCoversEveryProcessorExt(t *testing.T) {
+	cases := map[string]string{
+		".epub": "EPUB", ".pdf": "PDF", ".cbz": "CBZ",
+		".mp3": "MP3", ".m4a": "M4B", ".m4b": "M4B",
+	}
+	for ext, wantFormat := range cases {
+		p, format, err := Dispatch("x" + ext)
+		if err != nil || p == nil {
+			t.Errorf("Dispatch(%q): p=%v err=%v", ext, p, err)
+			continue
+		}
+		if format != wantFormat {
+			t.Errorf("Dispatch(%q) format = %q, want %q", ext, format, wantFormat)
+		}
+	}
+}
+
+// TestDispatchNoProcessorIsPerFormatAndPermanent — an admitted
+// extension with no processor fails with a message naming the format,
+// not the generic unsupported answer, and still reads as
+// ErrUnsupportedFormat so the ingest worker's terminal-failure branch
+// keeps firing (no retry for a file that will refuse identically in
+// thirty seconds).
+//
+// This set is the interim ADR-0033-style loud state; #310 (.cbr/.cb7),
+// #311 (.mobi/.azw3) and #312 (.fb2) each shrink it by wiring a
+// processor, at which point the entry moves to the covers-every-ext
+// test above.
+func TestDispatchNoProcessorIsPerFormatAndPermanent(t *testing.T) {
+	noProcessor := map[string]string{
+		".cbr":  "CBZ",
+		".cb7":  "CBZ",
+		".mobi": "MOBI",
+		".azw3": "AZW3",
+		".fb2":  "FB2",
+	}
+	for ext, format := range noProcessor {
+		_, _, err := Dispatch("x" + ext)
+		if err == nil {
+			t.Errorf("Dispatch(%q) succeeded — a processor exists; move %q to the covered table", ext, ext)
+			continue
+		}
+		if !errors.Is(err, ErrUnsupportedFormat) {
+			t.Errorf("Dispatch(%q) err = %v, want it to read as ErrUnsupportedFormat for the terminal-failure branch", ext, err)
+		}
+		if !strings.Contains(err.Error(), "no processor") || !strings.Contains(err.Error(), format) {
+			t.Errorf("Dispatch(%q) err = %q, want a per-format no-processor message naming %s", ext, err, format)
+		}
+	}
+
+	// Exhaustiveness: admitted extensions are exactly covered + no-processor.
+	covered := map[string]bool{
+		".epub": true, ".pdf": true, ".cbz": true,
+		".mp3": true, ".m4a": true, ".m4b": true,
+	}
+	for _, ext := range SupportedExts {
+		if _, ok := noProcessor[ext]; ok == covered[ext] {
+			t.Errorf("extension %q is in neither or both of the covered/no-processor sets", ext)
+		}
+	}
+}
+
+// TestDispatchUnknownExtensionStaysGeneric — an extension the table does
+// not know keeps the old answer.
+func TestDispatchUnknownExtensionStaysGeneric(t *testing.T) {
+	_, format, err := Dispatch("x.xyz")
+	if !errors.Is(err, ErrUnsupportedFormat) {
+		t.Fatalf("err = %v, want ErrUnsupportedFormat", err)
+	}
+	if strings.Contains(err.Error(), "no processor") {
+		t.Fatalf("err = %q — the per-format message is for recognised formats only", err)
+	}
+	if format != "XYZ" {
+		t.Fatalf("format tag = %q, want the historical upper-cased extension", format)
+	}
+}
+
+// TestDispatchFormatAgreesWithDispatch — the slug-keyed twin answers
+// with the same processor type as the extension entry point.
+func TestDispatchFormatAgreesWithDispatch(t *testing.T) {
+	for _, format := range []string{"EPUB", "PDF", "CBZ", "MP3", "M4B"} {
+		byFormat, err := DispatchFormat(format)
+		if err != nil {
+			t.Errorf("DispatchFormat(%q): %v", format, err)
+			continue
+		}
+		spec, _ := model.LookupFormat(format)
+		byExt, _, err := Dispatch("x" + spec.Ext)
+		if err != nil {
+			t.Errorf("Dispatch for %q's ext: %v", format, err)
+			continue
+		}
+		if fmt.Sprintf("%T", byFormat) != fmt.Sprintf("%T", byExt) {
+			t.Errorf("DispatchFormat(%q) = %T, Dispatch = %T", format, byFormat, byExt)
+		}
+	}
+	if _, err := DispatchFormat("MOBI"); !errors.Is(err, ErrUnsupportedFormat) {
+		t.Errorf("DispatchFormat(MOBI) err = %v, want ErrUnsupportedFormat while no processor exists", err)
+	}
+}
+
+// TestIsAudioFormatDerivesFromTheTable — the predicate is the table's
+// Audio column, exactly, and stays case-sensitive: books.format stores
+// the upper-case form, and a lower-case value reaching this predicate
+// is a bug to surface, not to absorb.
+func TestIsAudioFormatDerivesFromTheTable(t *testing.T) {
+	for _, s := range model.FormatSpecs {
+		if got := IsAudioFormat(s.Format); got != s.Audio {
+			t.Errorf("IsAudioFormat(%q) = %v, table says %v", s.Format, got, s.Audio)
+		}
+	}
+	if IsAudioFormat("mp3") {
+		t.Error(`IsAudioFormat("mp3") = true, want the case-sensitive refusal`)
+	}
+}

--- a/internal/fileproc/extract.go
+++ b/internal/fileproc/extract.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/blackforge/embookshelf/internal/model"
 	"github.com/blackforge/embookshelf/internal/sidecar"
 	"github.com/blackforge/embookshelf/internal/storage"
 )
@@ -42,17 +43,18 @@ type ExtractResult struct {
 // ("x.epub") to feed the extension dispatcher — a module converting its
 // own input backwards to satisfy the interface it wrapped.
 func DispatchFormat(format string) (Processor, error) {
-	switch strings.ToUpper(strings.TrimSpace(format)) {
-	case "EPUB":
-		return &EPUBProcessor{}, nil
-	case "PDF":
-		return &PDFProcessor{}, nil
-	case "CBZ":
-		return &CBZProcessor{}, nil
-	case "MP3", "M4B":
-		return &AudioProcessor{}, nil
+	spec, ok := model.LookupFormat(format)
+	if !ok {
+		return nil, ErrUnsupportedFormat
 	}
-	return nil, ErrUnsupportedFormat
+	// The format's canonical extension carries its processor entry; a
+	// format whose extractor is still unwired (#310–#312) answers the
+	// same refusal the extension entry point gives.
+	p, ok := processors[spec.Ext]
+	if !ok {
+		return nil, &NoProcessorError{Format: spec.Format, Ext: spec.Ext}
+	}
+	return p(), nil
 }
 
 // ExtractBook runs the format-specific Processor against an open Source,

--- a/internal/fileproc/processor.go
+++ b/internal/fileproc/processor.go
@@ -8,9 +8,11 @@ package fileproc
 import (
 	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
 
+	"github.com/blackforge/embookshelf/internal/model"
 	"github.com/blackforge/embookshelf/internal/storage"
 )
 
@@ -56,68 +58,68 @@ type Processor interface {
 // ErrUnsupportedFormat is returned by Dispatch when the extension is unknown.
 var ErrUnsupportedFormat = errors.New("unsupported file format")
 
+// processors is the one fact model.FormatSpecs cannot hold without
+// inverting the import: which extension has an extractor. Everything
+// else — which extensions are admitted, what format they stamp, which
+// formats are audio — derives from the table (#308). Keyed by extension
+// rather than format because the alias and the canonical form need not
+// share an implementation: .cbr is stamped CBZ but is a RAR archive the
+// zip processor cannot open, so it has no entry until #310 wires one.
+var processors = map[string]func() Processor{
+	".epub": func() Processor { return &EPUBProcessor{} },
+	".pdf":  func() Processor { return &PDFProcessor{} },
+	".cbz":  func() Processor { return &CBZProcessor{} },
+	".mp3":  func() Processor { return &AudioProcessor{} },
+	".m4a":  func() Processor { return &AudioProcessor{} },
+	".m4b":  func() Processor { return &AudioProcessor{} },
+}
+
+// NoProcessorError is Dispatch's answer for an extension the table
+// admits but nothing extracts yet — a recognised format, refused with
+// its own name instead of the generic unsupported message that used to
+// make an admitted .cbr read like a typo'd extension. Reads as
+// ErrUnsupportedFormat so the ingest worker's terminal-failure branch
+// keeps firing: the same bytes refuse identically in thirty seconds.
+type NoProcessorError struct {
+	Format string
+	Ext    string
+}
+
+func (e *NoProcessorError) Error() string {
+	return fmt.Sprintf("no processor for %s (%s) yet — the format is recognised but cannot be ingested", e.Format, e.Ext)
+}
+
+func (e *NoProcessorError) Unwrap() error { return ErrUnsupportedFormat }
+
 // Dispatch picks the right processor based on the file's extension.
 func Dispatch(path string) (Processor, string, error) {
 	ext := strings.ToLower(filepath.Ext(path))
-	switch ext {
-	case ".epub":
-		return &EPUBProcessor{}, "EPUB", nil
-	case ".pdf":
-		return &PDFProcessor{}, "PDF", nil
-	case ".cbz":
-		return &CBZProcessor{}, "CBZ", nil
-	case ".mp3":
-		return &AudioProcessor{}, "MP3", nil
-	case ".m4a", ".m4b":
-		return &AudioProcessor{}, "M4B", nil
-	// TODO: cbr, azw3, mobi, fb2
-	default:
+	format := model.IngestFormatForExt(ext)
+	if format == "" {
 		return nil, strings.ToUpper(strings.TrimPrefix(ext, ".")), ErrUnsupportedFormat
 	}
+	p, ok := processors[ext]
+	if !ok {
+		return nil, format, &NoProcessorError{Format: format, Ext: ext}
+	}
+	return p(), format, nil
 }
 
 // FormatForExt returns the canonical format tag for a given extension, or
-// an empty string for unknown/unsupported extensions.
+// an empty string for unknown/unsupported extensions. A derivation of
+// the model table — the folding (.cbr → CBZ, .m4a → M4B) lives on the
+// rows there.
 func FormatForExt(ext string) string {
-	ext = strings.ToLower(strings.TrimPrefix(ext, "."))
-	switch ext {
-	case "epub":
-		return "EPUB"
-	case "pdf":
-		return "PDF"
-	case "cbz", "cbr", "cb7":
-		return "CBZ"
-	case "mp3":
-		return "MP3"
-	case "m4a", "m4b":
-		return "M4B"
-	case "mobi":
-		return "MOBI"
-	case "azw3":
-		return "AZW3"
-	case "fb2":
-		return "FB2"
-	}
-	return ""
+	return model.IngestFormatForExt(ext)
 }
 
-// SupportedExts is the set of file extensions the watcher should consider.
-var SupportedExts = []string{
-	".epub", ".pdf",
-	".cbz", ".cbr", ".cb7",
-	".mp3", ".m4a", ".m4b",
-	".mobi", ".azw3", ".fb2",
-}
+// SupportedExts is the set of file extensions the watcher should
+// consider — the table's ingest axis, derived once at init.
+var SupportedExts = model.IngestExtensions()
 
 // IsSupported reports whether the file's extension is in SupportedExts.
 func IsSupported(path string) bool {
-	ext := strings.ToLower(filepath.Ext(path))
-	for _, e := range SupportedExts {
-		if e == ext {
-			return true
-		}
-	}
-	return false
+	return model.IngestFormatForExt(filepath.Ext(path)) != ""
 }
 
 // IsAudioFormat reports whether a books.format value denotes an
@@ -125,14 +127,10 @@ func IsSupported(path string) bool {
 // narrator come from tag metadata rather than a text extractor — so
 // several packages need to ask this question.
 //
-// It lives here because format dispatch is this package's job, and
-// because the answer was previously copied verbatim into three packages,
-// which meant adding a format was three edits that nothing forced to
-// agree.
+// A derivation of the table's Audio column, kept case-sensitive on
+// purpose: books.format stores the upper-case form, and a lower-case
+// value reaching this predicate is a bug to surface, not absorb.
 func IsAudioFormat(format string) bool {
-	switch format {
-	case "MP3", "M4B":
-		return true
-	}
-	return false
+	s, ok := model.LookupFormat(format)
+	return ok && s.Audio && format == s.Format
 }

--- a/internal/model/format.go
+++ b/internal/model/format.go
@@ -68,6 +68,20 @@ type FormatSpec struct {
 	// extraction serves it with no sidecar (gap-filler routing, ADR-0033
 	// §2) — and MOBI/AZW3/FB2 are outside anydoc's set.
 	Convertible bool
+	// IngestExts are the file extensions intake admits and stamps with
+	// this Format — the ingest axis fileproc's dispatchers derive from
+	// (#308). Distinct from Ext (the one download extension): a format
+	// can be reached from several extensions (.m4a and .m4b are the same
+	// container; the comic aliases fold into CBZ), and a legacy tag (CBR,
+	// TXT) declares none because no ingest path produces it. An extension
+	// may appear on exactly one row.
+	IngestExts []string
+	// Audio is whether a file of this format is an audiobook at ingest:
+	// duration and narrator come from tag metadata rather than a text
+	// extractor. The ingest-side fact behind fileproc.IsAudioFormat —
+	// says nothing about origin (a generated narration's book stays
+	// EPUB, see CONTEXT.md, Audio format).
+	Audio bool
 }
 
 // FormatSpecs is every format the library can hold. The client keeps one
@@ -80,26 +94,68 @@ var FormatSpecs = []FormatSpec{
 	{
 		Format: "EPUB", Ext: ".epub", MIME: "application/epub+zip", Reader: ReaderText,
 		Narratable: true, KindleEligible: true,
+		IngestExts: []string{".epub"},
 	},
 	{
 		Format: "PDF", Ext: ".pdf", MIME: "application/pdf", Reader: ReaderText,
 		KindleEligible: true, Convertible: true,
+		IngestExts: []string{".pdf"},
 	},
-	{Format: "CBZ", Ext: ".cbz", MIME: "application/vnd.comicbook+zip", Reader: ReaderComic},
-	{Format: "MP3", Ext: ".mp3", MIME: "audio/mpeg", Reader: ReaderAudio},
+	// The comic aliases fold into CBZ at ingest, the folding FormatForExt
+	// always did; giving CBR its own ingest life is the RAR-processor
+	// issue's decision (#310), not this table's.
+	{
+		Format: "CBZ", Ext: ".cbz", MIME: "application/vnd.comicbook+zip", Reader: ReaderComic,
+		IngestExts: []string{".cbz", ".cbr", ".cb7"},
+	},
+	{
+		Format: "MP3", Ext: ".mp3", MIME: "audio/mpeg", Reader: ReaderAudio,
+		IngestExts: []string{".mp3"}, Audio: true,
+	},
 	// Apple uses audio/mp4; the m4b container is identical to m4a.
-	{Format: "M4B", Ext: ".m4b", MIME: "audio/mp4", Reader: ReaderAudio},
-	// Ingested and downloadable, but nothing reads them in-app: there is
-	// no extractor and no reader, so they carry an extension and no MIME.
-	{Format: "MOBI", Ext: ".mobi"},
-	{Format: "AZW3", Ext: ".azw3"},
-	{Format: "FB2", Ext: ".fb2"},
-	// Tags no ingest path produces any more — fileproc.FormatForExt folds
-	// .cbr into CBZ and never returns TXT — but which the download path
-	// met on rows written by older releases, and named correctly. Listed
-	// so it still does.
+	{
+		Format: "M4B", Ext: ".m4b", MIME: "audio/mp4", Reader: ReaderAudio,
+		IngestExts: []string{".m4b", ".m4a"}, Audio: true,
+	},
+	// Admitted and downloadable, but nothing reads them in-app: no
+	// reader, so an extension and no MIME. Their processors are #311 and
+	// #312; until then dispatch refuses them with the per-format
+	// no-processor answer.
+	{Format: "MOBI", Ext: ".mobi", IngestExts: []string{".mobi"}},
+	{Format: "AZW3", Ext: ".azw3", IngestExts: []string{".azw3"}},
+	{Format: "FB2", Ext: ".fb2", IngestExts: []string{".fb2"}},
+	// Legacy tags no ingest path produces — .cbr stamps CBZ above, and
+	// nothing stamps TXT — but which the download path met on rows
+	// written by older releases, and named correctly. No IngestExts:
+	// the extension belongs to the row that stamps it.
 	{Format: "CBR", Ext: ".cbr"},
 	{Format: "TXT", Ext: ".txt"},
+}
+
+// IngestFormatForExt folds a file extension onto the format intake
+// stamps it with, or "" for one no ingest path admits. Case and the
+// leading dot are normalised — the value arrives from filenames in the
+// wild.
+func IngestFormatForExt(ext string) string {
+	want := "." + strings.TrimPrefix(strings.ToLower(strings.TrimSpace(ext)), ".")
+	for _, s := range FormatSpecs {
+		for _, e := range s.IngestExts {
+			if e == want {
+				return s.Format
+			}
+		}
+	}
+	return ""
+}
+
+// IngestExtensions lists every admitted extension in table order — the
+// watcher's admit set, derived rather than hand-kept beside the table.
+func IngestExtensions() []string {
+	var out []string
+	for _, s := range FormatSpecs {
+		out = append(out, s.IngestExts...)
+	}
+	return out
 }
 
 // LookupFormat finds a format's spec. The lookup is case-insensitive and

--- a/internal/model/format_ingest_test.go
+++ b/internal/model/format_ingest_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package model
+
+import "testing"
+
+// TestIngestFormatForExt — the extension→format folding, previously a
+// hand-kept switch in fileproc that had already diverged from this
+// table (.cbr was admitted, stamped CBZ, then refused by Dispatch).
+// One declaration: an alias lives on its format's row.
+func TestIngestFormatForExt(t *testing.T) {
+	cases := map[string]string{
+		".epub": "EPUB",
+		".pdf":  "PDF",
+		".cbz":  "CBZ",
+		// The comic aliases fold into CBZ, preserving the ingest-side
+		// behavior fileproc always had; giving CBR its own ingest life is
+		// the processor issue's decision (#310), not this table's.
+		".cbr": "CBZ",
+		".cb7": "CBZ",
+		".mp3": "MP3",
+		".m4b": "M4B",
+		// Apple's m4a is the same container as m4b.
+		".m4a":  "M4B",
+		".mobi": "MOBI",
+		".azw3": "AZW3",
+		".fb2":  "FB2",
+		// Case and the leading dot are normalised; the value arrives from
+		// filenames in the wild.
+		".EPUB": "EPUB",
+		"pdf":   "PDF",
+		// Unknown and legacy-tag-only extensions produce no format: .txt
+		// rows exist in old libraries, but no ingest path produces them.
+		".txt": "",
+		".xyz": "",
+		"":     "",
+	}
+	for ext, want := range cases {
+		if got := IngestFormatForExt(ext); got != want {
+			t.Errorf("IngestFormatForExt(%q) = %q, want %q", ext, got, want)
+		}
+	}
+}
+
+// TestIngestExtensionsAreUniqueAndOrdered — every admitted extension is
+// declared exactly once (an extension on two rows would stamp two
+// formats depending on iteration order), and the derived list is stable
+// table order so the watcher's set does not shuffle between builds.
+func TestIngestExtensionsAreUniqueAndOrdered(t *testing.T) {
+	seen := map[string]string{}
+	for _, s := range FormatSpecs {
+		for _, ext := range s.IngestExts {
+			if prev, dup := seen[ext]; dup {
+				t.Errorf("extension %q declared by both %s and %s", ext, prev, s.Format)
+			}
+			seen[ext] = s.Format
+		}
+	}
+	want := []string{
+		".epub", ".pdf",
+		".cbz", ".cbr", ".cb7",
+		".mp3", ".m4b", ".m4a",
+		".mobi", ".azw3", ".fb2",
+	}
+	got := IngestExtensions()
+	if len(got) != len(want) {
+		t.Fatalf("IngestExtensions() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("IngestExtensions()[%d] = %q, want %q (full: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+// TestAudioAxis — the ingest-side "is this file audio" fact joins the
+// table; MP3 and M4B alone, matching the fileproc predicate this
+// derives.
+func TestAudioAxis(t *testing.T) {
+	for _, s := range FormatSpecs {
+		want := s.Format == "MP3" || s.Format == "M4B"
+		if s.Audio != want {
+			t.Errorf("%s.Audio = %v, want %v", s.Format, s.Audio, want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #308.

## What changed

- `model.FormatSpec` gains the ingest axis: `IngestExts` (which extensions intake admits and what format each stamps — aliases on their format's row, so `.m4a` → M4B and `.cbr`/`.cb7` → CBZ keep the folding `FormatForExt` always did) and `Audio`.
- Every fileproc dispatcher derives from the table: `SupportedExts`, `IsSupported`, `FormatForExt`, `Dispatch`, `DispatchFormat`, `IsAudioFormat`. The only fileproc-owned fact left is the extension → extractor map (model can't hold it without inverting the import).
- The live `.cbr` divergence (admitted → stamped CBZ → refused with the generic "unsupported file format") becomes an honest interim state: `NoProcessorError` — *"no processor for CBZ (.cbr) yet — the format is recognised but cannot be ingested"* — lands on the bookdrop row verbatim, and unwraps to `ErrUnsupportedFormat` so the ingest worker's terminal-failure branch keeps refusing to retry it.
- `dispatch_parity_test.go` is the fileproc sibling of the model↔UI format parity test: SupportedExts ≡ table, FormatForExt ≡ table, every admitted extension is exactly either covered or in the pinned no-processor set (`.cbr .cb7 .mobi .azw3 .fb2`) — the work-list #310/#311/#312 shrink, one entry moving per wired processor.
- Deliberately unchanged: `IsAudioFormat` stays case-sensitive (`books.format` stores upper-case; a lower-case value is a bug to surface — pinned by the existing test); the reMarkable EPUB/PDF switch stays local per its own in-code #194 note (device rule, not a format property); CBR/TXT remain legacy download tags with no ingest extensions.
- CONTEXT.md gains an "Ingest axis" glossary entry.

## Behavior deltas (wire-visible)

- A `.cbr`/`.cb7`/`.mobi`/`.azw3`/`.fb2` upload still fails ingest, but the row now names the format and the reason instead of the generic message.
- `Dispatch`'s format tag on the no-processor arm is now the stamped format (`CBZ` for `.cbr`) instead of the upper-cased extension; callers only read the tag on success.

## Tests

- New: `model/format_ingest_test.go` (alias folding, uniqueness+order, audio axis) and `fileproc/dispatch_parity_test.go` (eight parity/behavior tests incl. the pinned no-processor set). Written first, watched fail.
- `go test ./...` green against local Postgres; `golangci-lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)